### PR TITLE
refactor: flatten Config struct by removing sub-structs

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -1,13 +1,9 @@
 //! Configuration for the MCP server.
 //!
-//! Configuration is organized into logical sub-groups:
-//! - [`McpConfig`] — MCP server behavior (read-only mode, pool size)
-//! - [`NetworkConfig`] — CORS allowed origins and hosts
-//! - [`LogConfig`] — logging level, file path, rotation
-//!
-//! Database connection (including SSL/TLS) is configured via a DSN URL
-//! string (e.g. `mysql://root@localhost/mydb?ssl-mode=required`) passed
-//! through `--database-url`, following the sqlx convention.
+//! All configuration fields live directly on [`Config`] as a flat struct —
+//! no sub-structs. Database connection (including SSL/TLS) is configured
+//! via a DSN URL string (e.g. `mysql://root@localhost/mydb?ssl-mode=required`)
+//! passed through `--database-url`, following the sqlx convention.
 //!
 //! All values are provided exclusively via CLI flags parsed by [`clap`].
 //!
@@ -16,96 +12,10 @@
 //! [`Config`] implements [`Debug`] manually to redact the database URL
 //! (which may contain credentials).
 
-// ---------------------------------------------------------------------------
-// McpConfig
-// ---------------------------------------------------------------------------
-
-/// MCP server behavior settings.
-#[derive(Clone, Debug)]
-pub struct McpConfig {
-    /// Whether the server runs in read-only mode.
-    pub read_only: bool,
-
-    /// Maximum database connection pool size.
-    pub max_pool_size: u32,
-}
-
-impl Default for McpConfig {
-    fn default() -> Self {
-        Self {
-            read_only: true,
-            max_pool_size: 10,
-        }
-    }
-}
-
-// ---------------------------------------------------------------------------
-// NetworkConfig
-// ---------------------------------------------------------------------------
-
-/// Network and CORS settings.
-#[derive(Clone, Debug)]
-pub struct NetworkConfig {
-    /// Allowed CORS origins.
-    pub allowed_origins: Vec<String>,
-
-    /// Allowed host names.
-    pub allowed_hosts: Vec<String>,
-}
-
-impl Default for NetworkConfig {
-    fn default() -> Self {
-        Self {
-            allowed_origins: vec![
-                "http://localhost".into(),
-                "http://127.0.0.1".into(),
-                "https://localhost".into(),
-                "https://127.0.0.1".into(),
-            ],
-            allowed_hosts: vec!["localhost".into(), "127.0.0.1".into()],
-        }
-    }
-}
-
-// ---------------------------------------------------------------------------
-// LogConfig
-// ---------------------------------------------------------------------------
-
-/// Logging settings.
-#[derive(Clone, Debug)]
-pub struct LogConfig {
-    /// Log level filter (e.g. "info", "debug", "warn").
-    pub level: String,
-
-    /// Path to the log file.
-    pub file: String,
-
-    /// Maximum log file size in bytes before rotation.
-    pub max_bytes: u64,
-
-    /// Number of rotated log files to keep.
-    pub backup_count: u32,
-}
-
-impl Default for LogConfig {
-    fn default() -> Self {
-        Self {
-            level: "info".into(),
-            file: "logs/mcp_server.log".into(),
-            max_bytes: 10_485_760,
-            backup_count: 5,
-        }
-    }
-}
-
-// ---------------------------------------------------------------------------
-// Config (top-level)
-// ---------------------------------------------------------------------------
-
 /// Runtime configuration for the MCP server.
 ///
 /// Constructed from CLI arguments parsed by [`clap`].
-#[derive(Clone, Default)]
+#[derive(Clone)]
 pub struct Config {
     /// Database connection URL (sqlx DSN format).
     ///
@@ -118,23 +28,64 @@ pub struct Config {
     /// (e.g. `?ssl-mode=required&ssl-ca=/path/to/ca.pem`).
     pub database_url: String,
 
-    /// MCP server behavior settings.
-    pub mcp: McpConfig,
+    /// Whether the server runs in read-only mode.
+    pub read_only: bool,
 
-    /// Network and CORS settings.
-    pub network: NetworkConfig,
+    /// Maximum database connection pool size.
+    pub max_pool_size: u32,
 
-    /// Logging settings.
-    pub log: LogConfig,
+    /// Allowed CORS origins.
+    pub allowed_origins: Vec<String>,
+
+    /// Allowed host names.
+    pub allowed_hosts: Vec<String>,
+
+    /// Log level filter (e.g. "info", "debug", "warn").
+    pub log_level: String,
+
+    /// Path to the log file.
+    pub log_file: String,
+
+    /// Maximum log file size in bytes before rotation.
+    pub log_max_bytes: u64,
+
+    /// Number of rotated log files to keep.
+    pub log_backup_count: u32,
+}
+
+impl Default for Config {
+    fn default() -> Self {
+        Self {
+            database_url: String::new(),
+            read_only: true,
+            max_pool_size: 10,
+            allowed_origins: vec![
+                "http://localhost".into(),
+                "http://127.0.0.1".into(),
+                "https://localhost".into(),
+                "https://127.0.0.1".into(),
+            ],
+            allowed_hosts: vec!["localhost".into(), "127.0.0.1".into()],
+            log_level: "info".into(),
+            log_file: "logs/mcp_server.log".into(),
+            log_max_bytes: 10_485_760,
+            log_backup_count: 5,
+        }
+    }
 }
 
 impl std::fmt::Debug for Config {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.debug_struct("Config")
             .field("database_url", &"[REDACTED]")
-            .field("mcp", &self.mcp)
-            .field("network", &self.network)
-            .field("log", &self.log)
+            .field("read_only", &self.read_only)
+            .field("max_pool_size", &self.max_pool_size)
+            .field("allowed_origins", &self.allowed_origins)
+            .field("allowed_hosts", &self.allowed_hosts)
+            .field("log_level", &self.log_level)
+            .field("log_file", &self.log_file)
+            .field("log_max_bytes", &self.log_max_bytes)
+            .field("log_backup_count", &self.log_backup_count)
             .finish()
     }
 }
@@ -153,16 +104,16 @@ mod tests {
 
         assert!(config.database_url.is_empty());
 
-        assert!(config.mcp.read_only);
-        assert_eq!(config.mcp.max_pool_size, 10);
+        assert!(config.read_only);
+        assert_eq!(config.max_pool_size, 10);
 
-        assert_eq!(config.network.allowed_origins.len(), 4);
-        assert_eq!(config.network.allowed_hosts.len(), 2);
+        assert_eq!(config.allowed_origins.len(), 4);
+        assert_eq!(config.allowed_hosts.len(), 2);
 
-        assert_eq!(config.log.level, "info");
-        assert_eq!(config.log.file, "logs/mcp_server.log");
-        assert_eq!(config.log.max_bytes, 10_485_760);
-        assert_eq!(config.log.backup_count, 5);
+        assert_eq!(config.log_level, "info");
+        assert_eq!(config.log_file, "logs/mcp_server.log");
+        assert_eq!(config.log_max_bytes, 10_485_760);
+        assert_eq!(config.log_backup_count, 5);
     }
 
     #[test]

--- a/src/db/mysql.rs
+++ b/src/db/mysql.rs
@@ -36,22 +36,22 @@ impl MysqlBackend {
     /// Returns [`AppError::Connection`] if the connection fails.
     pub async fn new(config: &Config) -> Result<Self, AppError> {
         let pool = MySqlPoolOptions::new()
-            .max_connections(config.mcp.max_pool_size)
+            .max_connections(config.max_pool_size)
             .connect(&config.database_url)
             .await
             .map_err(|e| AppError::Connection(format!("Failed to connect to MySQL: {e}")))?;
 
         info!(
             "MySQL connection pool initialized (max size: {})",
-            config.mcp.max_pool_size
+            config.max_pool_size
         );
 
         let backend = Self {
             pool,
-            read_only: config.mcp.read_only,
+            read_only: config.read_only,
         };
 
-        if config.mcp.read_only {
+        if config.read_only {
             backend.warn_if_file_privilege().await;
         }
 

--- a/src/db/postgres.rs
+++ b/src/db/postgres.rs
@@ -35,19 +35,19 @@ impl PostgresBackend {
     /// Returns [`AppError::Connection`] if the connection fails.
     pub async fn new(config: &Config) -> Result<Self, AppError> {
         let pool = PgPoolOptions::new()
-            .max_connections(config.mcp.max_pool_size)
+            .max_connections(config.max_pool_size)
             .connect(&config.database_url)
             .await
             .map_err(|e| AppError::Connection(format!("Failed to connect to PostgreSQL: {e}")))?;
 
         info!(
             "PostgreSQL connection pool initialized (max size: {})",
-            config.mcp.max_pool_size
+            config.max_pool_size
         );
 
         Ok(Self {
             pool,
-            read_only: config.mcp.read_only,
+            read_only: config.read_only,
         })
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -33,7 +33,7 @@ use rmcp::ServiceExt;
 use rmcp::transport::streamable_http_server::{
     StreamableHttpServerConfig, StreamableHttpService, session::local::LocalSessionManager,
 };
-use sql_mcp::config::{Config, LogConfig, McpConfig, NetworkConfig};
+use sql_mcp::config::Config;
 use sql_mcp::db;
 use sql_mcp::db::backend::Backend;
 use sql_mcp::server::Server;
@@ -111,25 +111,18 @@ struct Cli {
     log_backup_count: u32,
 }
 
-impl Cli {
-    /// Constructs a [`Config`] from parsed CLI arguments.
-    fn into_config(self) -> Config {
-        Config {
-            database_url: self.database_url,
-            mcp: McpConfig {
-                read_only: self.read_only,
-                max_pool_size: self.max_pool_size,
-            },
-            network: NetworkConfig {
-                allowed_origins: self.allowed_origins,
-                allowed_hosts: self.allowed_hosts,
-            },
-            log: LogConfig {
-                level: self.log_level,
-                file: self.log_file,
-                max_bytes: self.log_max_bytes,
-                backup_count: self.log_backup_count,
-            },
+impl From<Cli> for Config {
+    fn from(cli: Cli) -> Self {
+        Self {
+            database_url: cli.database_url,
+            read_only: cli.read_only,
+            max_pool_size: cli.max_pool_size,
+            allowed_origins: cli.allowed_origins,
+            allowed_hosts: cli.allowed_hosts,
+            log_level: cli.log_level,
+            log_file: cli.log_file,
+            log_max_bytes: cli.log_max_bytes,
+            log_backup_count: cli.log_backup_count,
         }
     }
 }
@@ -172,15 +165,15 @@ async fn main() {
         .init();
 
     // Build config from CLI args
-    let config = cli.into_config();
+    let config: Config = cli.into();
 
-    if config.mcp.read_only {
+    if config.read_only {
         info!("Server running in READ-ONLY mode. Write operations are disabled.");
     }
 
     // Detect database type from URL scheme and create the appropriate backend
     let backend: Backend = if config.database_url.starts_with("sqlite:") {
-        match db::sqlite::SqliteBackend::new(&config.database_url, config.mcp.read_only).await {
+        match db::sqlite::SqliteBackend::new(&config.database_url, config.read_only).await {
             Ok(b) => Backend::Sqlite(b),
             Err(e) => {
                 eprintln!("Failed to open SQLite: {e}");
@@ -237,7 +230,7 @@ async fn run_http(backend: Backend, config: Arc<Config>, host: &str, port: u16) 
 
     let ct = CancellationToken::new();
 
-    let allowed_origins = config.network.allowed_origins.clone();
+    let allowed_origins = config.allowed_origins.clone();
     let cors = tower_http::cors::CorsLayer::new()
         .allow_origin(
             allowed_origins

--- a/tests/mysql/mysql.rs
+++ b/tests/mysql/mysql.rs
@@ -5,7 +5,7 @@
 //! ./tests/run.sh --filter mysql      # MySQL
 //! ```
 
-use sql_mcp::config::{Config, McpConfig};
+use sql_mcp::config::Config;
 use sql_mcp::db::backend::Backend;
 use sql_mcp::db::mysql::MysqlBackend;
 
@@ -20,10 +20,7 @@ fn test_config() -> Config {
 
     Config {
         database_url: format!("mysql://{user}:{password}@{host}:{port}/mcp"),
-        mcp: McpConfig {
-            read_only: false,
-            ..McpConfig::default()
-        },
+        read_only: false,
         ..Config::default()
     }
 }
@@ -39,10 +36,7 @@ async fn backend() -> Backend {
 
 async fn readonly_backend() -> Backend {
     let config = Config {
-        mcp: McpConfig {
-            read_only: true,
-            ..McpConfig::default()
-        },
+        read_only: true,
         ..test_config()
     };
     Backend::Mysql(

--- a/tests/postgres/postgres.rs
+++ b/tests/postgres/postgres.rs
@@ -4,7 +4,7 @@
 //! ./tests/run.sh --filter postgres
 //! ```
 
-use sql_mcp::config::{Config, McpConfig};
+use sql_mcp::config::Config;
 use sql_mcp::db::backend::Backend;
 use sql_mcp::db::postgres::PostgresBackend;
 
@@ -19,10 +19,7 @@ fn test_config() -> Config {
 
     Config {
         database_url: format!("postgres://{user}:{password}@{host}:{port}/mcp"),
-        mcp: McpConfig {
-            read_only: false,
-            ..McpConfig::default()
-        },
+        read_only: false,
         ..Config::default()
     }
 }
@@ -38,10 +35,7 @@ async fn backend() -> Backend {
 
 async fn readonly_backend() -> Backend {
     let config = Config {
-        mcp: McpConfig {
-            read_only: true,
-            ..McpConfig::default()
-        },
+        read_only: true,
         ..test_config()
     };
     Backend::Postgres(


### PR DESCRIPTION
Remove McpConfig, NetworkConfig, and LogConfig sub-structs, promoting all fields directly onto Config. Replace Cli::into_config() with From<Cli> for Config. All defaults, Debug redaction, and behavior preserved.