### PR TITLE
fix: replace file logging with stderr to prevent panic on read-only filesystem

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -365,15 +365,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "19d374276b40fb8bbdee95aef7c7fa6b5316ec764510eb64b8dd0e2ed0d7e7f5"
 
 [[package]]
-name = "crossbeam-channel"
-version = "0.5.15"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "82b8f8f868b36967f9606790d1903570de9ceaf870a7bf9fbbd3016d636a2cb2"
-dependencies = [
- "crossbeam-utils",
-]
-
-[[package]]
 name = "crossbeam-queue"
 version = "0.3.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -441,15 +432,6 @@ dependencies = [
  "const-oid",
  "pem-rfc7468",
  "zeroize",
-]
-
-[[package]]
-name = "deranged"
-version = "0.5.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7cd812cc2bc1d69d4764bd80df88b4317eaef9e773c75226407d9bc0876b211c"
-dependencies = [
- "powerfmt",
 ]
 
 [[package]]
@@ -1194,12 +1176,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "num-conv"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cf97ec579c3c42f953ef76dbf8d55ac91fb219dde70e49aa4a6b7d74e9919050"
-
-[[package]]
 name = "num-integer"
 version = "0.1.46"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1353,12 +1329,6 @@ checksum = "b73949432f5e2a09657003c25bca5e19a0e9c84f8058ca374f49e0ebe605af77"
 dependencies = [
  "zerovec",
 ]
-
-[[package]]
-name = "powerfmt"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "439ee305def115ba05938db6eb1644ff94165c5ab5e9420d1c1bcedbba909391"
 
 [[package]]
 name = "ppv-lite86"
@@ -1893,7 +1863,6 @@ dependencies = [
  "tokio-util",
  "tower-http",
  "tracing",
- "tracing-appender",
  "tracing-subscriber",
 ]
 
@@ -2222,37 +2191,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "time"
-version = "0.3.47"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "743bd48c283afc0388f9b8827b976905fb217ad9e647fae3a379a9283c4def2c"
-dependencies = [
- "deranged",
- "itoa",
- "num-conv",
- "powerfmt",
- "serde_core",
- "time-core",
- "time-macros",
-]
-
-[[package]]
-name = "time-core"
-version = "0.1.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7694e1cfe791f8d31026952abf09c69ca6f6fa4e1a1229e18988f06a04a12dca"
-
-[[package]]
-name = "time-macros"
-version = "0.2.27"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2e70e4c5a0e0a8a4823ad65dfe1a6930e4f4d756dcd9dd7939022b5e8c501215"
-dependencies = [
- "num-conv",
- "time-core",
-]
-
-[[package]]
 name = "tinystr"
 version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2382,18 +2320,6 @@ dependencies = [
  "pin-project-lite",
  "tracing-attributes",
  "tracing-core",
-]
-
-[[package]]
-name = "tracing-appender"
-version = "0.2.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "786d480bce6247ab75f005b14ae1624ad978d3029d9113f0a22fa1ac773faeaf"
-dependencies = [
- "crossbeam-channel",
- "thiserror",
- "time",
- "tracing-subscriber",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,6 @@ axum = "0.8"
 tower-http = { version = "0.6", features = ["cors"] }
 tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }
-tracing-appender = "0.2"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 sqlparser = { version = "0.61", features = ["visitor"] }

--- a/README.md
+++ b/README.md
@@ -127,7 +127,6 @@ Environment variables are typically set by your MCP client (via `env` or `envFil
 | Flag | Env Variable | Default | Description |
 |------|-------------|---------|-------------|
 | `--log-level` | `LOG_LEVEL` | `info` | Log level (trace/debug/info/warn/error) |
-| `--log-file` | `LOG_FILE` | `logs/mcp_server.log` | Log file path |
 
 ### HTTP-only Options (only available with `http` subcommand)
 

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -115,15 +115,6 @@ struct Cli {
         global = true
     )]
     log_level: String,
-
-    /// Log file path
-    #[arg(
-        long = "log-file",
-        env = "LOG_FILE",
-        default_value = Config::DEFAULT_LOG_FILE,
-        global = true
-    )]
-    log_file: String,
 }
 
 #[derive(Subcommand)]
@@ -181,7 +172,6 @@ impl From<&Cli> for Config {
             db_read_only: cli.read_only,
             db_max_pool_size: cli.max_pool_size,
             log_level: cli.log_level.clone(),
-            log_file: cli.log_file.clone(),
             http_host: Config::DEFAULT_HTTP_HOST.into(),
             http_port: Config::DEFAULT_HTTP_PORT,
             http_allowed_origins: Config::DEFAULT_HTTP_ALLOWED_ORIGINS
@@ -227,20 +217,8 @@ pub async fn run() -> Result<ExitCode, Box<dyn std::error::Error>> {
     let env_filter = tracing_subscriber::EnvFilter::try_new(&cli.log_level)
         .unwrap_or_else(|_| tracing_subscriber::EnvFilter::new("info"));
 
-    let log_path = std::path::Path::new(&cli.log_file);
-    if let Some(parent) = log_path.parent() {
-        std::fs::create_dir_all(parent).ok();
-    }
-
-    let file_appender = tracing_appender::rolling::never(
-        log_path.parent().unwrap_or(std::path::Path::new(".")),
-        log_path
-            .file_name()
-            .unwrap_or(std::ffi::OsStr::new("mcp_server.log")),
-    );
-
     tracing_subscriber::fmt()
-        .with_writer(file_appender)
+        .with_writer(std::io::stderr)
         .with_env_filter(env_filter)
         .with_ansi(false)
         .init();

--- a/src/config.rs
+++ b/src/config.rs
@@ -122,9 +122,6 @@ pub struct Config {
     /// Log level filter (e.g. "info", "debug", "warn").
     pub log_level: String,
 
-    /// Path to the log file.
-    pub log_file: String,
-
     /// Bind host for HTTP transport.
     pub http_host: String,
 
@@ -156,7 +153,6 @@ impl std::fmt::Debug for Config {
             .field("db_read_only", &self.db_read_only)
             .field("db_max_pool_size", &self.db_max_pool_size)
             .field("log_level", &self.log_level)
-            .field("log_file", &self.log_file)
             .field("http_host", &self.http_host)
             .field("http_port", &self.http_port)
             .field("http_allowed_origins", &self.http_allowed_origins)
@@ -180,8 +176,6 @@ impl Config {
     pub const DEFAULT_DB_MAX_POOL_SIZE: u32 = 10;
     /// Default log level.
     pub const DEFAULT_LOG_LEVEL: &'static str = "info";
-    /// Default log file path.
-    pub const DEFAULT_LOG_FILE: &'static str = "logs/mcp_server.log";
     /// Default HTTP bind host.
     pub const DEFAULT_HTTP_HOST: &'static str = "127.0.0.1";
     /// Default HTTP bind port.
@@ -251,7 +245,6 @@ mod tests {
             db_read_only: Config::DEFAULT_DB_READ_ONLY,
             db_max_pool_size: Config::DEFAULT_DB_MAX_POOL_SIZE,
             log_level: Config::DEFAULT_LOG_LEVEL.into(),
-            log_file: Config::DEFAULT_LOG_FILE.into(),
             http_host: Config::DEFAULT_HTTP_HOST.into(),
             http_port: Config::DEFAULT_HTTP_PORT,
             http_allowed_origins: Config::DEFAULT_HTTP_ALLOWED_ORIGINS

--- a/tests/mysql/mysql.rs
+++ b/tests/mysql/mysql.rs
@@ -34,7 +34,6 @@ fn test_config() -> Config {
         db_ssl_key: None,
         db_ssl_verify_cert: true,
         log_level: "info".into(),
-        log_file: "logs/mcp_server.log".into(),
         http_host: "127.0.0.1".into(),
         http_port: 9001,
         http_allowed_origins: vec!["http://localhost".into()],

--- a/tests/postgres/postgres.rs
+++ b/tests/postgres/postgres.rs
@@ -33,7 +33,6 @@ fn test_config() -> Config {
         db_ssl_key: None,
         db_ssl_verify_cert: true,
         log_level: "info".into(),
-        log_file: "logs/mcp_server.log".into(),
         http_host: "127.0.0.1".into(),
         http_port: 9001,
         http_allowed_origins: vec!["http://localhost".into()],

--- a/tests/sqlite/sqlite.rs
+++ b/tests/sqlite/sqlite.rs
@@ -54,7 +54,6 @@ fn sqlite_config(db_path: &str, read_only: bool) -> Config {
         db_ssl_key: None,
         db_ssl_verify_cert: true,
         log_level: "info".into(),
-        log_file: "logs/mcp_server.log".into(),
         http_host: "127.0.0.1".into(),
         http_port: 9001,
         http_allowed_origins: vec!["http://localhost".into()],


### PR DESCRIPTION
## Summary

- Replace `tracing-appender` file logging with `std::io::stderr`, matching the MCP specification and ecosystem conventions
- Remove `--log-file` CLI flag, `LOG_FILE` env var, and `tracing-appender` dependency entirely
- Eliminates the panic when the log directory cannot be created on a read-only filesystem

Closes #8