### PR TITLE
ci: add GitHub issue and PR templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,111 @@
+name: Bug Report
+description: Report a bug or unexpected behavior in sql-mcp
+labels: ["bug"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for reporting a bug! Please fill out the form below to help us investigate.
+
+        Before submitting, please:
+        - Search [existing issues](https://github.com/athopen/sql-mcp/issues) for duplicates
+        - Make sure you're using the latest version of sql-mcp
+
+  - type: checkboxes
+    id: prerequisites
+    attributes:
+      label: Prerequisites
+      options:
+        - label: I have searched existing issues for duplicates
+          required: true
+        - label: I am using the latest version of sql-mcp
+          required: true
+
+  - type: input
+    id: version
+    attributes:
+      label: Version
+      description: Which version or commit of sql-mcp are you using?
+      placeholder: "e.g., 0.1.0, git commit abc1234, or latest main"
+    validations:
+      required: true
+
+  - type: dropdown
+    id: database-backend
+    attributes:
+      label: Database Backend
+      description: Which database backend are you using?
+      options:
+        - MySQL
+        - MariaDB
+        - PostgreSQL
+        - SQLite
+        - Not applicable
+    validations:
+      required: true
+
+  - type: dropdown
+    id: transport-mode
+    attributes:
+      label: Transport Mode
+      description: Which transport mode are you using?
+      options:
+        - stdio
+        - HTTP
+        - Not applicable
+    validations:
+      required: true
+
+  - type: input
+    id: operating-system
+    attributes:
+      label: Operating System
+      description: Your OS and version
+      placeholder: "e.g., Ubuntu 24.04, macOS 15.2, Windows 11"
+    validations:
+      required: true
+
+  - type: textarea
+    id: description
+    attributes:
+      label: Description
+      description: A clear and concise description of the bug
+    validations:
+      required: true
+
+  - type: textarea
+    id: steps-to-reproduce
+    attributes:
+      label: Steps to Reproduce
+      description: Steps to reproduce the behavior
+      placeholder: |
+        1. Configure sql-mcp with '...'
+        2. Run command '...'
+        3. Execute query '...'
+        4. See error
+    validations:
+      required: true
+
+  - type: textarea
+    id: expected-behavior
+    attributes:
+      label: Expected Behavior
+      description: What you expected to happen
+    validations:
+      required: true
+
+  - type: textarea
+    id: actual-behavior
+    attributes:
+      label: Actual Behavior
+      description: What actually happened
+    validations:
+      required: true
+
+  - type: textarea
+    id: additional-context
+    attributes:
+      label: Additional Context
+      description: Any additional context, logs, screenshots, or configuration that might help
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,1 @@
+blank_issues_enabled: false

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,21 @@
+---
+name: Feature Request
+description: Suggest a new feature or enhancement
+labels: ["enhancement"]
+---
+
+## Problem / Motivation
+
+<!-- What problem are you trying to solve? Why is this feature needed? -->
+
+## Proposed Solution
+
+<!-- What would you like to happen? Describe your ideal solution. -->
+
+## Alternatives Considered
+
+<!-- What other approaches have you considered? Why were they not suitable? -->
+
+## Additional Context
+
+<!-- Any additional context, examples, or references that support this request. -->

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,18 @@
+## Motivation
+
+<!-- Why is this change necessary? What problem does it solve? Link to related issues with "Closes #123" or "Fixes #123". -->
+
+## Solution
+
+<!-- What was changed and how? Describe your approach at a high level. -->
+
+## Test Plan
+
+<!-- How was this tested? Include relevant commands, test output, or manual verification steps. -->
+
+---
+
+- [ ] Linked to an issue (if applicable)
+- [ ] Tests pass (`cargo test`)
+- [ ] Lints pass (`cargo clippy -- -D warnings`)
+- [ ] Formatted (`cargo fmt --check`)


### PR DESCRIPTION
## Motivation

The repository lacks structured issue and PR templates, making it harder to collect consistent bug reports and maintain PR quality. Contributors have no guidance on what information to provide.

## Solution

- Added a YAML-based bug report form with database backend/transport mode dropdowns, version, OS, reproduction steps, and required field validation
- Added a markdown feature request template with problem/motivation, proposed solution, and alternatives sections
- Added a PR template with motivation, solution, and test plan sections (following the tokio/axum pattern)
- Configured the issue template chooser to disable blank issues

## Test Plan

- [ ] Verify bug report form renders at `/issues/new?template=bug_report.yml` with all dropdowns and required fields
- [ ] Verify feature request template appears in the template chooser
- [ ] Verify blank issues are disabled on the "New Issue" page
- [ ] Verify PR template pre-populates when creating a new pull request

---

- [x] Linked to an issue (if applicable)
- [x] Tests pass (`cargo test`)
- [x] Lints pass (`cargo clippy -- -D warnings`)
- [x] Formatted (`cargo fmt --check`)