### PR TITLE
fix: preserve JSON types in row-to-JSON conversion

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1903,6 +1903,7 @@ name = "sql-mcp"
 version = "0.1.0"
 dependencies = [
  "axum",
+ "base64",
  "clap",
  "mimalloc",
  "moka",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,6 +24,7 @@ sqlparser = { version = "0.61", features = ["visitor"] }
 thiserror = "2"
 moka = { version = "0.12", features = ["future"] }
 mimalloc = "0.1"
+base64 = "0.22"
 
 [lints.rust]
 ambiguous_negative_literals = "warn"

--- a/src/db/mysql.rs
+++ b/src/db/mysql.rs
@@ -7,9 +7,11 @@ use crate::config::DatabaseConfig;
 use crate::db::backend::DatabaseBackend;
 use crate::db::identifier::validate_identifier;
 use crate::error::AppError;
+use base64::Engine as _;
+use base64::engine::general_purpose::STANDARD as BASE64;
 use serde_json::{Map, Value, json};
 use sqlx::mysql::{MySqlPoolOptions, MySqlRow};
-use sqlx::{Column, Executor, MySqlPool, Row};
+use sqlx::{Column, Executor, MySqlPool, Row, TypeInfo, ValueRef};
 use std::collections::HashMap;
 use tracing::{error, info};
 
@@ -172,33 +174,7 @@ impl MysqlBackend {
 
         let rows: Vec<MySqlRow> = conn.fetch_all(sql).await.map_err(|e| AppError::Query(e.to_string()))?;
 
-        let mut results = Vec::new();
-        for row in &rows {
-            let mut map = Map::new();
-            for col in row.columns() {
-                let name = col.name().to_string();
-                let idx = col.ordinal();
-                // MySQL may return columns with BINARY flag where try_get::<String>
-                // fails. Fall through: String → i64 → f64 → bool → Vec<u8> → Null.
-                let value = if let Ok(s) = row.try_get::<String, _>(idx) {
-                    Value::String(s)
-                } else if let Ok(n) = row.try_get::<i64, _>(idx) {
-                    Value::Number(n.into())
-                } else if let Ok(f) = row.try_get::<f64, _>(idx) {
-                    serde_json::Number::from_f64(f).map_or(Value::Null, Value::Number)
-                } else if let Ok(b) = row.try_get::<bool, _>(idx) {
-                    Value::Bool(b)
-                } else if let Ok(bytes) = row.try_get::<Vec<u8>, _>(idx) {
-                    Value::String(String::from_utf8_lossy(&bytes).into_owned())
-                } else {
-                    Value::Null
-                };
-                map.insert(name, value);
-            }
-            results.push(map);
-        }
-
-        Ok(results)
+        Ok(rows.iter().map(mysql_row_to_json).collect())
     }
 }
 
@@ -400,6 +376,72 @@ impl DatabaseBackend for MysqlBackend {
     fn read_only(&self) -> bool {
         self.read_only
     }
+}
+
+/// Converts a `MySQL` row to a JSON object with type-aware value extraction.
+///
+/// Uses `column.type_info().name()` to pick the right Rust type for each column.
+/// `MySQL` 9 reports `information_schema` text columns as `VARBINARY`; these
+/// are decoded as UTF-8 strings rather than base64.
+fn mysql_row_to_json(row: &MySqlRow) -> Map<String, Value> {
+    let columns = row.columns();
+    let mut map = Map::with_capacity(columns.len());
+
+    for column in columns {
+        let idx = column.ordinal();
+        let type_name = column.type_info().name();
+
+        let value = if row.try_get_raw(idx).is_ok_and(|v| v.is_null()) {
+            Value::Null
+        } else {
+            match type_name {
+                "BOOLEAN" => row.try_get::<bool, _>(idx).map(Value::Bool).unwrap_or(Value::Null),
+
+                "TINYINT" | "SMALLINT" | "INT" | "MEDIUMINT" | "BIGINT" | "TINYINT UNSIGNED" | "SMALLINT UNSIGNED"
+                | "INT UNSIGNED" | "MEDIUMINT UNSIGNED" | "YEAR" => row
+                    .try_get::<i64, _>(idx)
+                    .map(|v| Value::Number(v.into()))
+                    .unwrap_or(Value::Null),
+
+                "BIGINT UNSIGNED" => row.try_get::<u64, _>(idx).map_or(Value::Null, |v| {
+                    i64::try_from(v)
+                        .map_or_else(|_| Value::String(v.to_string()), |signed| Value::Number(signed.into()))
+                }),
+
+                "FLOAT" | "DOUBLE" | "DECIMAL" => row
+                    .try_get::<f64, _>(idx)
+                    .ok()
+                    .and_then(serde_json::Number::from_f64)
+                    .map_or(Value::Null, Value::Number),
+
+                "JSON" => row.try_get::<Value, _>(idx).unwrap_or(Value::Null),
+
+                // MySQL 9 returns information_schema columns as BINARY/VARBINARY
+                // even when they contain valid UTF-8. Try String first, then bytes.
+                "BINARY" | "VARBINARY" => row
+                    .try_get::<String, _>(idx)
+                    .map_or_else(|_| mysql_bytes_to_json(row, idx), Value::String),
+
+                "BLOB" | "TINYBLOB" | "MEDIUMBLOB" | "LONGBLOB" | "BIT" | "GEOMETRY" => mysql_bytes_to_json(row, idx),
+
+                // All other types (VARCHAR, TEXT, DATE, TIME, ENUM, etc.) → String
+                _ => row
+                    .try_get::<String, _>(idx)
+                    .map_or_else(|_| mysql_bytes_to_json(row, idx), Value::String),
+            }
+        };
+
+        map.insert(column.name().to_string(), value);
+    }
+
+    map
+}
+
+/// Extracts a `MySQL` binary column as UTF-8 string, falling back to base64.
+fn mysql_bytes_to_json(row: &MySqlRow, idx: usize) -> Value {
+    row.try_get::<Vec<u8>, _>(idx).map_or(Value::Null, |bytes| {
+        String::from_utf8(bytes.clone()).map_or_else(|_| Value::String(BASE64.encode(&bytes)), Value::String)
+    })
 }
 
 #[cfg(test)]

--- a/src/db/postgres.rs
+++ b/src/db/postgres.rs
@@ -8,10 +8,12 @@ use crate::config::DatabaseConfig;
 use crate::db::backend::DatabaseBackend;
 use crate::db::identifier::validate_identifier;
 use crate::error::AppError;
+use base64::Engine as _;
+use base64::engine::general_purpose::STANDARD as BASE64;
 use moka::future::Cache;
 use serde_json::{Map, Value, json};
 use sqlx::postgres::{PgPoolOptions, PgRow};
-use sqlx::{Column, PgPool, Row};
+use sqlx::{Column, PgPool, Row, TypeInfo, ValueRef};
 use std::collections::HashMap;
 use tracing::info;
 
@@ -311,17 +313,7 @@ impl DatabaseBackend for PostgresBackend {
             .await
             .map_err(|e| AppError::Query(e.to_string()))?;
 
-        let mut results = Vec::new();
-        for row in &rows {
-            let mut map = Map::new();
-            for col in row.columns() {
-                let name = col.name().to_string();
-                let val: Option<String> = row.try_get(col.ordinal()).ok();
-                map.insert(name, val.map_or(Value::Null, Value::String));
-            }
-            results.push(map);
-        }
-        Ok(results)
+        Ok(rows.iter().map(pg_row_to_json).collect())
     }
 
     async fn create_database(&self, name: &str) -> Result<Value, AppError> {
@@ -358,6 +350,63 @@ impl DatabaseBackend for PostgresBackend {
     fn read_only(&self) -> bool {
         self.read_only
     }
+}
+
+/// Converts a `PostgreSQL` row to a JSON object with type-aware value extraction.
+///
+/// Type names are normalized to uppercase because sqlx may return either case
+/// depending on query context. Integer types use size-specific Rust types
+/// (`i16`, `i32`, `i64`) because sqlx enforces strict type matching for
+/// `PostgreSQL`.
+fn pg_row_to_json(row: &PgRow) -> Map<String, Value> {
+    let columns = row.columns();
+    let mut map = Map::with_capacity(columns.len());
+
+    for column in columns {
+        let idx = column.ordinal();
+        let type_name = column.type_info().name().to_ascii_uppercase();
+
+        let value = if row.try_get_raw(idx).is_ok_and(|v| v.is_null()) {
+            Value::Null
+        } else {
+            match type_name.as_str() {
+                "BOOL" => row.try_get::<bool, _>(idx).map(Value::Bool).unwrap_or(Value::Null),
+
+                "INT8" => row
+                    .try_get::<i64, _>(idx)
+                    .map(|v| Value::Number(v.into()))
+                    .unwrap_or(Value::Null),
+
+                "INT4" | "OID" => row
+                    .try_get::<i32, _>(idx)
+                    .map(|v| Value::Number(i64::from(v).into()))
+                    .unwrap_or(Value::Null),
+
+                "INT2" => row
+                    .try_get::<i16, _>(idx)
+                    .map(|v| Value::Number(i64::from(v).into()))
+                    .unwrap_or(Value::Null),
+
+                "FLOAT4" | "FLOAT8" | "NUMERIC" | "MONEY" => row
+                    .try_get::<f64, _>(idx)
+                    .ok()
+                    .and_then(serde_json::Number::from_f64)
+                    .map_or(Value::Null, Value::Number),
+
+                "BYTEA" => row
+                    .try_get::<Vec<u8>, _>(idx)
+                    .map_or(Value::Null, |bytes| Value::String(BASE64.encode(&bytes))),
+
+                "JSON" | "JSONB" => row.try_get::<Value, _>(idx).unwrap_or(Value::Null),
+
+                _ => row.try_get::<String, _>(idx).map(Value::String).unwrap_or(Value::Null),
+            }
+        };
+
+        map.insert(column.name().to_string(), value);
+    }
+
+    map
 }
 
 #[cfg(test)]

--- a/src/db/sqlite.rs
+++ b/src/db/sqlite.rs
@@ -6,9 +6,11 @@ use crate::config::DatabaseConfig;
 use crate::db::backend::DatabaseBackend;
 use crate::db::identifier::validate_identifier;
 use crate::error::AppError;
+use base64::Engine as _;
+use base64::engine::general_purpose::STANDARD as BASE64;
 use serde_json::{Map, Value, json};
 use sqlx::sqlite::{SqlitePoolOptions, SqliteRow};
-use sqlx::{Column, Row, SqlitePool};
+use sqlx::{Column, Row, SqlitePool, TypeInfo, ValueRef};
 use std::collections::HashMap;
 use tracing::info;
 
@@ -162,17 +164,7 @@ impl DatabaseBackend for SqliteBackend {
             .await
             .map_err(|e| AppError::Query(e.to_string()))?;
 
-        let mut results = Vec::new();
-        for row in &rows {
-            let mut map = Map::new();
-            for col in row.columns() {
-                let name = col.name().to_string();
-                let val: Option<String> = row.try_get(col.ordinal()).ok();
-                map.insert(name, val.map_or(Value::Null, Value::String));
-            }
-            results.push(map);
-        }
-        Ok(results)
+        Ok(rows.iter().map(sqlite_row_to_json).collect())
     }
 
     #[allow(clippy::unused_async)]
@@ -192,9 +184,71 @@ impl DatabaseBackend for SqliteBackend {
     }
 }
 
+/// Converts a `SQLite` row to a JSON object with type-aware value extraction.
+///
+/// Uses `column.type_info().name()` to pick the right Rust type for each column.
+/// Unknown or `NULL`-declared types (e.g., `COUNT(*)`) fall back to probing:
+/// i64 → f64 → String → Null.
+fn sqlite_row_to_json(row: &SqliteRow) -> Map<String, Value> {
+    let columns = row.columns();
+    let mut map = Map::with_capacity(columns.len());
+
+    for column in columns {
+        let idx = column.ordinal();
+        let type_name = column.type_info().name();
+
+        let value = if row.try_get_raw(idx).is_ok_and(|v| v.is_null()) {
+            Value::Null
+        } else {
+            match type_name {
+                "BOOLEAN" | "BOOL" => row.try_get::<bool, _>(idx).map(Value::Bool).unwrap_or(Value::Null),
+
+                "INTEGER" | "INT" | "BIGINT" | "SMALLINT" | "TINYINT" | "MEDIUMINT" => row
+                    .try_get::<i64, _>(idx)
+                    .map(|v| Value::Number(v.into()))
+                    .unwrap_or(Value::Null),
+
+                "REAL" | "FLOAT" | "DOUBLE" | "NUMERIC" => row
+                    .try_get::<f64, _>(idx)
+                    .ok()
+                    .and_then(serde_json::Number::from_f64)
+                    .map_or(Value::Null, Value::Number),
+
+                "BLOB" => row
+                    .try_get::<Vec<u8>, _>(idx)
+                    .map_or(Value::Null, |bytes| Value::String(BASE64.encode(&bytes))),
+
+                "TEXT" | "VARCHAR" | "CHAR" | "CLOB" | "DATE" | "DATETIME" | "TIMESTAMP" | "TIME" => {
+                    row.try_get::<String, _>(idx).map(Value::String).unwrap_or(Value::Null)
+                }
+
+                // SQLite reports "NULL" type for expressions like COUNT(*), SUM().
+                // The value is not null (checked above), so probe: i64 → f64 → String.
+                _ => sqlite_dynamic_probe(row, idx),
+            }
+        };
+
+        map.insert(column.name().to_string(), value);
+    }
+
+    map
+}
+
+/// Probes a `SQLite` value by trying types in order: i64 → f64 → String → Null.
+fn sqlite_dynamic_probe(row: &SqliteRow, idx: usize) -> Value {
+    if let Ok(n) = row.try_get::<i64, _>(idx) {
+        return Value::Number(n.into());
+    }
+    if let Ok(f) = row.try_get::<f64, _>(idx) {
+        return serde_json::Number::from_f64(f).map_or(Value::Null, Value::Number);
+    }
+    row.try_get::<String, _>(idx).map(Value::String).unwrap_or(Value::Null)
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
+    use sqlx::sqlite::SqlitePoolOptions;
 
     #[test]
     fn quote_identifier_wraps_in_double_quotes() {
@@ -206,5 +260,203 @@ mod tests {
     fn quote_identifier_escapes_double_quotes() {
         assert_eq!(SqliteBackend::quote_identifier("test\"db"), "\"test\"\"db\"");
         assert_eq!(SqliteBackend::quote_identifier("a\"b\"c"), "\"a\"\"b\"\"c\"");
+    }
+
+    /// Helper: creates an in-memory `SQLite` pool for unit tests.
+    async fn mem_pool() -> SqlitePool {
+        SqlitePoolOptions::new()
+            .max_connections(1)
+            .connect("sqlite::memory:")
+            .await
+            .expect("in-memory SQLite")
+    }
+
+    /// Helper: runs a query and converts all rows via [`sqlite_row_to_json`].
+    async fn query_json(pool: &SqlitePool, sql: &str) -> Vec<Map<String, Value>> {
+        let rows: Vec<SqliteRow> = sqlx::query(sql).fetch_all(pool).await.expect("query failed");
+        rows.iter().map(sqlite_row_to_json).collect()
+    }
+
+    #[tokio::test]
+    async fn row_to_json_integer_types() {
+        let pool = mem_pool().await;
+        let rows = query_json(&pool, "SELECT 42 AS val").await;
+        assert_eq!(rows[0]["val"], Value::Number(42.into()));
+    }
+
+    #[tokio::test]
+    async fn row_to_json_typed_integer_column() {
+        let pool = mem_pool().await;
+        sqlx::query("CREATE TABLE t (id INTEGER PRIMARY KEY, n BIGINT)")
+            .execute(&pool)
+            .await
+            .unwrap();
+        sqlx::query("INSERT INTO t VALUES (1, 9999999999)")
+            .execute(&pool)
+            .await
+            .unwrap();
+
+        let rows = query_json(&pool, "SELECT id, n FROM t").await;
+        assert_eq!(rows[0]["id"], Value::Number(1.into()));
+        assert_eq!(rows[0]["n"], Value::Number(9_999_999_999_i64.into()));
+    }
+
+    #[tokio::test]
+    async fn row_to_json_real_type() {
+        let pool = mem_pool().await;
+        sqlx::query("CREATE TABLE t (v REAL)").execute(&pool).await.unwrap();
+        sqlx::query("INSERT INTO t VALUES (3.14)").execute(&pool).await.unwrap();
+
+        let rows = query_json(&pool, "SELECT v FROM t").await;
+        let n = rows[0]["v"].as_f64().expect("should be f64");
+        assert!((n - 3.14).abs() < f64::EPSILON);
+    }
+
+    #[tokio::test]
+    async fn row_to_json_text_type() {
+        let pool = mem_pool().await;
+        sqlx::query("CREATE TABLE t (name TEXT)").execute(&pool).await.unwrap();
+        sqlx::query("INSERT INTO t VALUES ('hello')")
+            .execute(&pool)
+            .await
+            .unwrap();
+
+        let rows = query_json(&pool, "SELECT name FROM t").await;
+        assert_eq!(rows[0]["name"], Value::String("hello".into()));
+    }
+
+    #[tokio::test]
+    async fn row_to_json_boolean_type() {
+        let pool = mem_pool().await;
+        sqlx::query("CREATE TABLE t (flag BOOLEAN)")
+            .execute(&pool)
+            .await
+            .unwrap();
+        sqlx::query("INSERT INTO t VALUES (1)").execute(&pool).await.unwrap();
+
+        let rows = query_json(&pool, "SELECT flag FROM t").await;
+        assert_eq!(rows[0]["flag"], Value::Bool(true));
+    }
+
+    #[tokio::test]
+    async fn row_to_json_null_value() {
+        let pool = mem_pool().await;
+        sqlx::query("CREATE TABLE t (v INTEGER)").execute(&pool).await.unwrap();
+        sqlx::query("INSERT INTO t VALUES (NULL)").execute(&pool).await.unwrap();
+
+        let rows = query_json(&pool, "SELECT v FROM t").await;
+        assert_eq!(rows[0]["v"], Value::Null);
+    }
+
+    #[tokio::test]
+    async fn row_to_json_blob_base64() {
+        let pool = mem_pool().await;
+        sqlx::query("CREATE TABLE t (data BLOB)").execute(&pool).await.unwrap();
+        sqlx::query("INSERT INTO t VALUES (X'DEADBEEF')")
+            .execute(&pool)
+            .await
+            .unwrap();
+
+        let rows = query_json(&pool, "SELECT data FROM t").await;
+        assert_eq!(rows[0]["data"], Value::String(BASE64.encode(b"\xDE\xAD\xBE\xEF")));
+    }
+
+    #[tokio::test]
+    async fn row_to_json_count_aggregate() {
+        let pool = mem_pool().await;
+        sqlx::query("CREATE TABLE t (id INTEGER)").execute(&pool).await.unwrap();
+        sqlx::query("INSERT INTO t VALUES (1),(2),(3)")
+            .execute(&pool)
+            .await
+            .unwrap();
+
+        let rows = query_json(&pool, "SELECT COUNT(*) AS cnt FROM t").await;
+        assert_eq!(rows[0]["cnt"], Value::Number(3.into()), "COUNT(*) must be a number");
+    }
+
+    #[tokio::test]
+    async fn row_to_json_sum_aggregate() {
+        let pool = mem_pool().await;
+        sqlx::query("CREATE TABLE t (v INTEGER)").execute(&pool).await.unwrap();
+        sqlx::query("INSERT INTO t VALUES (10),(20),(30)")
+            .execute(&pool)
+            .await
+            .unwrap();
+
+        let rows = query_json(&pool, "SELECT SUM(v) AS total FROM t").await;
+        assert_eq!(rows[0]["total"], Value::Number(60.into()));
+    }
+
+    #[tokio::test]
+    async fn row_to_json_avg_aggregate() {
+        let pool = mem_pool().await;
+        sqlx::query("CREATE TABLE t (v REAL)").execute(&pool).await.unwrap();
+        sqlx::query("INSERT INTO t VALUES (1.0),(2.0),(3.0)")
+            .execute(&pool)
+            .await
+            .unwrap();
+
+        let rows = query_json(&pool, "SELECT AVG(v) AS avg_v FROM t").await;
+        let n = rows[0]["avg_v"].as_f64().expect("AVG should be f64");
+        assert!((n - 2.0).abs() < f64::EPSILON);
+    }
+
+    #[tokio::test]
+    async fn row_to_json_date_as_string() {
+        let pool = mem_pool().await;
+        sqlx::query("CREATE TABLE t (d DATE)").execute(&pool).await.unwrap();
+        sqlx::query("INSERT INTO t VALUES ('2026-03-20')")
+            .execute(&pool)
+            .await
+            .unwrap();
+
+        let rows = query_json(&pool, "SELECT d FROM t").await;
+        assert_eq!(rows[0]["d"], Value::String("2026-03-20".into()));
+    }
+
+    #[tokio::test]
+    async fn row_to_json_empty_result() {
+        let pool = mem_pool().await;
+        sqlx::query("CREATE TABLE t (v INTEGER)").execute(&pool).await.unwrap();
+
+        let rows = query_json(&pool, "SELECT v FROM t").await;
+        assert!(rows.is_empty());
+    }
+
+    #[tokio::test]
+    async fn row_to_json_multiple_columns_and_rows() {
+        let pool = mem_pool().await;
+        sqlx::query("CREATE TABLE t (id INTEGER, name TEXT, score REAL)")
+            .execute(&pool)
+            .await
+            .unwrap();
+        sqlx::query("INSERT INTO t VALUES (1, 'alice', 9.5), (2, 'bob', 8.0)")
+            .execute(&pool)
+            .await
+            .unwrap();
+
+        let rows = query_json(&pool, "SELECT id, name, score FROM t ORDER BY id").await;
+        assert_eq!(rows.len(), 2);
+
+        assert_eq!(rows[0]["id"], Value::Number(1.into()));
+        assert_eq!(rows[0]["name"], Value::String("alice".into()));
+        assert!(rows[0]["score"].is_number());
+
+        assert_eq!(rows[1]["id"], Value::Number(2.into()));
+        assert_eq!(rows[1]["name"], Value::String("bob".into()));
+    }
+
+    #[tokio::test]
+    async fn row_to_json_null_literal_expression() {
+        let pool = mem_pool().await;
+        let rows = query_json(&pool, "SELECT NULL AS v").await;
+        assert_eq!(rows[0]["v"], Value::Null);
+    }
+
+    #[tokio::test]
+    async fn row_to_json_cast_expression() {
+        let pool = mem_pool().await;
+        let rows = query_json(&pool, "SELECT CAST(42 AS TEXT) AS v").await;
+        assert_eq!(rows[0]["v"], Value::String("42".into()));
     }
 }

--- a/tests/mysql/mysql.rs
+++ b/tests/mysql/mysql.rs
@@ -108,6 +108,38 @@ async fn it_blocks_writes_in_read_only_mode() {
 }
 
 #[tokio::test]
+async fn it_preserves_json_types() {
+    let b = backend().await;
+
+    // COUNT(*) should return a JSON number, not a string or null
+    let result = b
+        .tool_execute_sql("SELECT COUNT(*) as cnt FROM users", "app", None)
+        .await
+        .expect("failed");
+    let rows: Vec<serde_json::Value> = serde_json::from_str(&result).expect("bad json");
+    let cnt = &rows[0]["cnt"];
+    assert!(cnt.is_number(), "COUNT(*) should be a number, got: {cnt}");
+    assert_eq!(cnt.as_i64(), Some(3), "Expected COUNT(*)=3");
+
+    // Integer and text columns should have correct types
+    let result = b
+        .tool_execute_sql("SELECT id, name FROM users ORDER BY id LIMIT 1", "app", None)
+        .await
+        .expect("failed");
+    let rows: Vec<serde_json::Value> = serde_json::from_str(&result).expect("bad json");
+    assert!(
+        rows[0]["id"].is_number(),
+        "id should be a number, got: {}",
+        rows[0]["id"]
+    );
+    assert!(
+        rows[0]["name"].is_string(),
+        "name should be a string, got: {}",
+        rows[0]["name"]
+    );
+}
+
+#[tokio::test]
 async fn it_creates_database() {
     let b = backend().await;
     let result = b.tool_create_database("app_new").await.expect("failed");

--- a/tests/postgres/postgres.rs
+++ b/tests/postgres/postgres.rs
@@ -115,6 +115,38 @@ async fn it_blocks_writes_in_read_only_mode() {
 }
 
 #[tokio::test]
+async fn it_preserves_json_types() {
+    let b = backend().await;
+
+    // COUNT(*) should return a JSON number, not a string or null
+    let result = b
+        .tool_execute_sql("SELECT COUNT(*) as cnt FROM users", "app", None)
+        .await
+        .expect("failed");
+    let rows: Vec<serde_json::Value> = serde_json::from_str(&result).expect("bad json");
+    let cnt = &rows[0]["cnt"];
+    assert!(cnt.is_number(), "COUNT(*) should be a number, got: {cnt}");
+    assert_eq!(cnt.as_i64(), Some(3), "Expected COUNT(*)=3");
+
+    // Integer and text columns should have correct types
+    let result = b
+        .tool_execute_sql("SELECT id, name FROM users ORDER BY id LIMIT 1", "app", None)
+        .await
+        .expect("failed");
+    let rows: Vec<serde_json::Value> = serde_json::from_str(&result).expect("bad json");
+    assert!(
+        rows[0]["id"].is_number(),
+        "id should be a number, got: {}",
+        rows[0]["id"]
+    );
+    assert!(
+        rows[0]["name"].is_string(),
+        "name should be a string, got: {}",
+        rows[0]["name"]
+    );
+}
+
+#[tokio::test]
 async fn it_creates_database() {
     let b = backend().await;
     let result = b.tool_create_database("app_new").await.expect("failed");

--- a/tests/sqlite/sqlite.rs
+++ b/tests/sqlite/sqlite.rs
@@ -104,6 +104,38 @@ async fn it_blocks_writes_in_read_only_mode() {
 }
 
 #[tokio::test]
+async fn it_preserves_json_types() {
+    let b = backend().await;
+
+    // COUNT(*) should return a JSON number, not a string or null
+    let result = b
+        .tool_execute_sql("SELECT COUNT(*) as cnt FROM users", "main", None)
+        .await
+        .expect("failed");
+    let rows: Vec<serde_json::Value> = serde_json::from_str(&result).expect("bad json");
+    let cnt = &rows[0]["cnt"];
+    assert!(cnt.is_number(), "COUNT(*) should be a number, got: {cnt}");
+    assert_eq!(cnt.as_i64(), Some(3), "Expected COUNT(*)=3");
+
+    // Integer and text columns should have correct types
+    let result = b
+        .tool_execute_sql("SELECT id, name FROM users ORDER BY id LIMIT 1", "main", None)
+        .await
+        .expect("failed");
+    let rows: Vec<serde_json::Value> = serde_json::from_str(&result).expect("bad json");
+    assert!(
+        rows[0]["id"].is_number(),
+        "id should be a number, got: {}",
+        rows[0]["id"]
+    );
+    assert!(
+        rows[0]["name"].is_string(),
+        "name should be a string, got: {}",
+        rows[0]["name"]
+    );
+}
+
+#[tokio::test]
 async fn it_has_consistent_seed_data() {
     let b = backend().await;
 


### PR DESCRIPTION
## Motivation

SQLite and PostgreSQL `execute_query` converted all column values to strings (or null), causing queries like `SELECT COUNT(*) FROM users` to return `"3"` or `null` instead of `3`. MySQL used a fragile `try_get` fallback chain (String → i64 → f64 → bool → bytes → Null) that could misidentify types (e.g., a string `"123"` decoded as i64). The three backends had inconsistent type fidelity — MySQL preserved numbers, while PostgreSQL and SQLite lost all type information.

## Solution

Replace all three per-backend row-to-JSON converters with `type_info().name()` dispatch that maps SQL column types to the correct `serde_json::Value` variant. Each backend gets a dedicated `*_row_to_json(&Row) -> Map<String, Value>` function:

- **SQLite**: Handles `NULL`-typed expressions (`COUNT(*)`, `SUM()`) via a dynamic probe (i64 → f64 → String), since SQLite cannot determine the type statically for aggregates.
- **PostgreSQL**: Normalizes type names to uppercase (sqlx returns either case depending on context) and uses size-specific Rust types (`i16`/`i32`/`i64`) required by sqlx's strict PG type matching.
- **MySQL**: Handles `BINARY`/`VARBINARY` columns from MySQL 9's `information_schema` as UTF-8 text instead of base64 (MySQL 9 reports text columns with BINARY type), and `BIGINT UNSIGNED` with i64 overflow fallback to string.

Other changes:
- Added `base64` crate for BLOB/bytea encoding (previously MySQL used lossy UTF-8).
- Pre-allocated JSON maps with `Map::with_capacity()`.
- Aliased base64 engine as `BASE64` across all backends.

## Test Plan

- `cargo fmt --check` — pass
- `cargo clippy -- -D warnings` — pass
- `cargo test --lib` — 63/63 pass (15 new `sqlite_row_to_json` unit tests covering all type branches, aggregates, NULLs, BLOBs, dates, mixed columns, CAST, empty results)
- `./tests/run.sh` — 54/54 pass across all backends:
  - MariaDB 12: 15/15 (including `it_preserves_json_types`)
  - MySQL 9: 15/15 (including `it_preserves_json_types`)
  - PostgreSQL 18: 16/16 (including `it_preserves_json_types`)
  - SQLite: 8/8 (including `it_preserves_json_types`)

---

- [ ] Linked to an issue (if applicable)
- [x] Tests pass (`cargo test`)
- [x] Lints pass (`cargo clippy -- -D warnings`)
- [x] Formatted (`cargo fmt --check`)