### PR TITLE
refactor: replace URL string construction with From<&DatabaseConfig> for ConnectOptions

### DIFF
--- a/src/db/mysql.rs
+++ b/src/db/mysql.rs
@@ -10,10 +10,51 @@ use crate::error::AppError;
 use base64::Engine as _;
 use base64::engine::general_purpose::STANDARD as BASE64;
 use serde_json::{Map, Value, json};
-use sqlx::mysql::{MySqlPoolOptions, MySqlRow};
+use sqlx::mysql::{MySqlConnectOptions, MySqlPoolOptions, MySqlRow, MySqlSslMode};
 use sqlx::{Column, Executor, MySqlPool, Row, TypeInfo, ValueRef};
 use std::collections::HashMap;
 use tracing::{error, info};
+
+/// Converts [`DatabaseConfig`] into [`MySqlConnectOptions`].
+impl From<&DatabaseConfig> for MySqlConnectOptions {
+    fn from(config: &DatabaseConfig) -> Self {
+        let mut opts = MySqlConnectOptions::new()
+            .host(&config.host)
+            .port(config.port)
+            .username(&config.user);
+
+        if let Some(ref password) = config.password {
+            opts = opts.password(password);
+        }
+        if let Some(ref name) = config.name
+            && !name.is_empty()
+        {
+            opts = opts.database(name);
+        }
+        if let Some(ref charset) = config.charset {
+            opts = opts.charset(charset);
+        }
+
+        if config.ssl {
+            opts = if config.ssl_verify_cert {
+                opts.ssl_mode(MySqlSslMode::VerifyCa)
+            } else {
+                opts.ssl_mode(MySqlSslMode::Required)
+            };
+            if let Some(ref ca) = config.ssl_ca {
+                opts = opts.ssl_ca(ca);
+            }
+            if let Some(ref cert) = config.ssl_cert {
+                opts = opts.ssl_client_cert(cert);
+            }
+            if let Some(ref key) = config.ssl_key {
+                opts = opts.ssl_client_key(key);
+            }
+        }
+
+        opts
+    }
+}
 
 /// MySQL/MariaDB database backend.
 #[derive(Clone)]
@@ -37,10 +78,9 @@ impl MysqlBackend {
     ///
     /// Returns [`AppError::Connection`] if the connection fails.
     pub async fn new(config: &DatabaseConfig) -> Result<Self, AppError> {
-        let url = Self::build_connection_url(config);
         let pool = MySqlPoolOptions::new()
             .max_connections(config.max_pool_size)
-            .connect(&url)
+            .connect_with(config.into())
             .await
             .map_err(|e| AppError::Connection(format!("Failed to connect to MySQL: {e}")))?;
 
@@ -99,39 +139,6 @@ impl MysqlBackend {
         if let Err(e) = result {
             tracing::debug!("Unable to determine whether FILE privilege is enabled: {e}");
         }
-    }
-
-    /// Builds a sqlx connection URL from individual config fields.
-    fn build_connection_url(config: &DatabaseConfig) -> String {
-        let password = config.password.as_deref().unwrap_or_default();
-        let name = config.name.as_deref().unwrap_or_default();
-        let mut url = format!(
-            "mysql://{}:{}@{}:{}/{}",
-            config.user, password, config.host, config.port, name
-        );
-
-        let mut params = Vec::new();
-        if let Some(ref charset) = config.charset {
-            params.push(format!("charset={charset}"));
-        }
-
-        if config.ssl {
-            params.push("ssl-mode=required".into());
-            if let Some(ref ca) = config.ssl_ca {
-                params.push(format!("ssl-ca={ca}"));
-            }
-            if let Some(ref cert) = config.ssl_cert {
-                params.push(format!("ssl-cert={cert}"));
-            }
-            if let Some(ref key) = config.ssl_key {
-                params.push(format!("ssl-key={key}"));
-            }
-        }
-        if !params.is_empty() {
-            url.push('?');
-            url.push_str(&params.join("&"));
-        }
-        url
     }
 
     /// Wraps `name` in backticks for safe use in `MySQL` SQL statements.
@@ -447,6 +454,19 @@ fn mysql_bytes_to_json(row: &MySqlRow, idx: usize) -> Value {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::config::DatabaseBackend;
+
+    fn base_config() -> DatabaseConfig {
+        DatabaseConfig {
+            backend: DatabaseBackend::Mysql,
+            host: "db.example.com".into(),
+            port: 3307,
+            user: "admin".into(),
+            password: Some("s3cret".into()),
+            name: Some("mydb".into()),
+            ..DatabaseConfig::default()
+        }
+    }
 
     #[test]
     fn quote_identifier_wraps_in_backticks() {
@@ -458,5 +478,82 @@ mod tests {
     fn quote_identifier_escapes_backticks() {
         assert_eq!(MysqlBackend::quote_identifier("test`db"), "`test``db`");
         assert_eq!(MysqlBackend::quote_identifier("a`b`c"), "`a``b``c`");
+    }
+
+    #[test]
+    fn try_from_basic_config() {
+        let config = base_config();
+        let opts = MySqlConnectOptions::from(&config);
+
+        assert_eq!(opts.get_host(), "db.example.com");
+        assert_eq!(opts.get_port(), 3307);
+        assert_eq!(opts.get_username(), "admin");
+        assert_eq!(opts.get_database(), Some("mydb"));
+    }
+
+    #[test]
+    fn try_from_with_charset() {
+        let config = DatabaseConfig {
+            charset: Some("utf8mb4".into()),
+            ..base_config()
+        };
+        let opts = MySqlConnectOptions::from(&config);
+
+        assert_eq!(opts.get_charset(), "utf8mb4");
+    }
+
+    #[test]
+    fn try_from_with_ssl_required() {
+        let config = DatabaseConfig {
+            ssl: true,
+            ssl_verify_cert: false,
+            ..base_config()
+        };
+        let opts = MySqlConnectOptions::from(&config);
+
+        assert!(
+            matches!(opts.get_ssl_mode(), MySqlSslMode::Required),
+            "expected Required, got {:?}",
+            opts.get_ssl_mode()
+        );
+    }
+
+    #[test]
+    fn try_from_with_ssl_verify_ca() {
+        let config = DatabaseConfig {
+            ssl: true,
+            ssl_verify_cert: true,
+            ..base_config()
+        };
+        let opts = MySqlConnectOptions::from(&config);
+
+        assert!(
+            matches!(opts.get_ssl_mode(), MySqlSslMode::VerifyCa),
+            "expected VerifyCa, got {:?}",
+            opts.get_ssl_mode()
+        );
+    }
+
+    #[test]
+    fn try_from_without_password() {
+        let config = DatabaseConfig {
+            password: None,
+            ..base_config()
+        };
+        let opts = MySqlConnectOptions::from(&config);
+
+        // Should not panic — password is simply omitted
+        assert_eq!(opts.get_host(), "db.example.com");
+    }
+
+    #[test]
+    fn try_from_without_database_name() {
+        let config = DatabaseConfig {
+            name: None,
+            ..base_config()
+        };
+        let opts = MySqlConnectOptions::from(&config);
+
+        assert_eq!(opts.get_database(), None);
     }
 }

--- a/src/db/postgres.rs
+++ b/src/db/postgres.rs
@@ -12,13 +12,55 @@ use base64::Engine as _;
 use base64::engine::general_purpose::STANDARD as BASE64;
 use moka::future::Cache;
 use serde_json::{Map, Value, json};
-use sqlx::postgres::{PgPoolOptions, PgRow};
+use sqlx::postgres::{PgConnectOptions, PgPoolOptions, PgRow, PgSslMode};
 use sqlx::{Column, PgPool, Row, TypeInfo, ValueRef};
 use std::collections::HashMap;
 use tracing::info;
 
 /// Maximum number of database connection pools to cache (including the default).
 const POOL_CACHE_CAPACITY: u64 = 6;
+
+/// Converts [`DatabaseConfig`] into [`PgConnectOptions`].
+///
+/// Uses [`PgConnectOptions::new_without_pgpass`] to avoid unintended
+/// `PG*` environment variable influence, since our config already
+/// resolves values from CLI/env.
+impl From<&DatabaseConfig> for PgConnectOptions {
+    fn from(config: &DatabaseConfig) -> Self {
+        let mut opts = PgConnectOptions::new_without_pgpass()
+            .host(&config.host)
+            .port(config.port)
+            .username(&config.user);
+
+        if let Some(ref password) = config.password {
+            opts = opts.password(password);
+        }
+        if let Some(ref name) = config.name
+            && !name.is_empty()
+        {
+            opts = opts.database(name);
+        }
+
+        if config.ssl {
+            opts = if config.ssl_verify_cert {
+                opts.ssl_mode(PgSslMode::VerifyCa)
+            } else {
+                opts.ssl_mode(PgSslMode::Require)
+            };
+            if let Some(ref ca) = config.ssl_ca {
+                opts = opts.ssl_root_cert(ca);
+            }
+            if let Some(ref cert) = config.ssl_cert {
+                opts = opts.ssl_client_cert(cert);
+            }
+            if let Some(ref key) = config.ssl_key {
+                opts = opts.ssl_client_key(key);
+            }
+        }
+
+        opts
+    }
+}
 
 /// `PostgreSQL` database backend.
 ///
@@ -44,18 +86,17 @@ impl std::fmt::Debug for PostgresBackend {
 impl PostgresBackend {
     /// Creates a new `PostgreSQL` backend from configuration.
     ///
-    /// Stores a clone of the configuration for constructing connection URLs
-    /// to non-default databases at runtime. The initial pool is placed into
+    /// Stores a clone of the configuration for constructing connection options
+    /// for non-default databases at runtime. The initial pool is placed into
     /// the shared cache keyed by the configured database name.
     ///
     /// # Errors
     ///
     /// Returns [`AppError::Connection`] if the connection fails.
     pub async fn new(config: &DatabaseConfig) -> Result<Self, AppError> {
-        let url = Self::build_connection_url(config);
         let pool = PgPoolOptions::new()
             .max_connections(config.max_pool_size)
-            .connect(&url)
+            .connect_with(config.into())
             .await
             .map_err(|e| AppError::Connection(format!("Failed to connect to PostgreSQL: {e}")))?;
 
@@ -65,7 +106,11 @@ impl PostgresBackend {
         );
 
         // PostgreSQL defaults to a database named after the connecting user.
-        let default_db = config.name.clone().unwrap_or_else(|| config.user.clone());
+        let default_db = config
+            .name
+            .as_deref()
+            .filter(|n| !n.is_empty())
+            .map_or_else(|| config.user.clone(), String::from);
 
         let pools = Cache::builder()
             .max_capacity(POOL_CACHE_CAPACITY)
@@ -88,35 +133,6 @@ impl PostgresBackend {
 }
 
 impl PostgresBackend {
-    /// Builds a sqlx connection URL from individual config fields.
-    fn build_connection_url(config: &DatabaseConfig) -> String {
-        let password = config.password.as_deref().unwrap_or_default();
-        let name = config.name.as_deref().unwrap_or_default();
-        let mut url = format!(
-            "postgres://{}:{}@{}:{}/{}",
-            config.user, password, config.host, config.port, name
-        );
-
-        let mut params = Vec::new();
-        if config.ssl {
-            params.push("sslmode=require".into());
-            if let Some(ref ca) = config.ssl_ca {
-                params.push(format!("sslrootcert={ca}"));
-            }
-            if let Some(ref cert) = config.ssl_cert {
-                params.push(format!("sslcert={cert}"));
-            }
-            if let Some(ref key) = config.ssl_key {
-                params.push(format!("sslkey={key}"));
-            }
-        }
-        if !params.is_empty() {
-            url.push('?');
-            url.push_str(&params.join("&"));
-        }
-        url
-    }
-
     /// Wraps `name` in double quotes for safe use in `PostgreSQL` SQL statements.
     ///
     /// Escapes internal double quotes by doubling them.
@@ -156,11 +172,9 @@ impl PostgresBackend {
             .try_get_with(db_key_owned, async {
                 let mut cfg = config;
                 cfg.name = Some(db_key.to_owned());
-                let url = Self::build_connection_url(&cfg);
-
                 PgPoolOptions::new()
                     .max_connections(cfg.max_pool_size)
-                    .connect(&url)
+                    .connect_with((&cfg).into())
                     .await
                     .map_err(|e| {
                         AppError::Connection(format!("Failed to connect to PostgreSQL database '{db_key}': {e}"))
@@ -412,6 +426,19 @@ fn pg_row_to_json(row: &PgRow) -> Map<String, Value> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::config::DatabaseBackend;
+
+    fn base_config() -> DatabaseConfig {
+        DatabaseConfig {
+            backend: DatabaseBackend::Postgres,
+            host: "pg.example.com".into(),
+            port: 5433,
+            user: "pgadmin".into(),
+            password: Some("pgpass".into()),
+            name: Some("mydb".into()),
+            ..DatabaseConfig::default()
+        }
+    }
 
     #[test]
     fn quote_identifier_wraps_in_double_quotes() {
@@ -423,5 +450,70 @@ mod tests {
     fn quote_identifier_escapes_double_quotes() {
         assert_eq!(PostgresBackend::quote_identifier("test\"db"), "\"test\"\"db\"");
         assert_eq!(PostgresBackend::quote_identifier("a\"b\"c"), "\"a\"\"b\"\"c\"");
+    }
+
+    #[test]
+    fn try_from_basic_config() {
+        let config = base_config();
+        let opts = PgConnectOptions::from(&config);
+
+        assert_eq!(opts.get_host(), "pg.example.com");
+        assert_eq!(opts.get_port(), 5433);
+        assert_eq!(opts.get_username(), "pgadmin");
+        assert_eq!(opts.get_database(), Some("mydb"));
+    }
+
+    #[test]
+    fn try_from_with_ssl_require() {
+        let config = DatabaseConfig {
+            ssl: true,
+            ssl_verify_cert: false,
+            ..base_config()
+        };
+        let opts = PgConnectOptions::from(&config);
+
+        assert!(
+            matches!(opts.get_ssl_mode(), PgSslMode::Require),
+            "expected Require, got {:?}",
+            opts.get_ssl_mode()
+        );
+    }
+
+    #[test]
+    fn try_from_with_ssl_verify_ca() {
+        let config = DatabaseConfig {
+            ssl: true,
+            ssl_verify_cert: true,
+            ..base_config()
+        };
+        let opts = PgConnectOptions::from(&config);
+
+        assert!(
+            matches!(opts.get_ssl_mode(), PgSslMode::VerifyCa),
+            "expected VerifyCa, got {:?}",
+            opts.get_ssl_mode()
+        );
+    }
+
+    #[test]
+    fn try_from_without_database_name() {
+        let config = DatabaseConfig {
+            name: None,
+            ..base_config()
+        };
+        let opts = PgConnectOptions::from(&config);
+
+        assert_eq!(opts.get_database(), None);
+    }
+
+    #[test]
+    fn try_from_without_password() {
+        let config = DatabaseConfig {
+            password: None,
+            ..base_config()
+        };
+        let opts = PgConnectOptions::from(&config);
+
+        assert_eq!(opts.get_host(), "pg.example.com");
     }
 }

--- a/src/db/sqlite.rs
+++ b/src/db/sqlite.rs
@@ -9,10 +9,18 @@ use crate::error::AppError;
 use base64::Engine as _;
 use base64::engine::general_purpose::STANDARD as BASE64;
 use serde_json::{Map, Value, json};
-use sqlx::sqlite::{SqlitePoolOptions, SqliteRow};
+use sqlx::sqlite::{SqliteConnectOptions, SqlitePoolOptions, SqliteRow};
 use sqlx::{Column, Row, SqlitePool, TypeInfo, ValueRef};
 use std::collections::HashMap;
 use tracing::info;
+
+/// Converts [`DatabaseConfig`] into [`SqliteConnectOptions`].
+impl From<&DatabaseConfig> for SqliteConnectOptions {
+    fn from(config: &DatabaseConfig) -> Self {
+        let name = config.name.as_deref().unwrap_or_default();
+        SqliteConnectOptions::new().filename(name)
+    }
+}
 
 /// `SQLite` file-based database backend.
 #[derive(Clone)]
@@ -37,10 +45,9 @@ impl SqliteBackend {
     /// Returns [`AppError::Connection`] if the database file cannot be opened.
     pub async fn new(config: &DatabaseConfig) -> Result<Self, AppError> {
         let name = config.name.as_deref().unwrap_or_default();
-        let url = format!("sqlite:{name}");
         let pool = SqlitePoolOptions::new()
             .max_connections(1) // SQLite is single-writer
-            .connect(&url)
+            .connect_with(config.into())
             .await
             .map_err(|e| AppError::Connection(format!("Failed to open SQLite: {e}")))?;
 
@@ -248,7 +255,7 @@ fn sqlite_dynamic_probe(row: &SqliteRow, idx: usize) -> Value {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use sqlx::sqlite::SqlitePoolOptions;
+    use crate::config::DatabaseBackend;
 
     #[test]
     fn quote_identifier_wraps_in_double_quotes() {
@@ -260,6 +267,31 @@ mod tests {
     fn quote_identifier_escapes_double_quotes() {
         assert_eq!(SqliteBackend::quote_identifier("test\"db"), "\"test\"\"db\"");
         assert_eq!(SqliteBackend::quote_identifier("a\"b\"c"), "\"a\"\"b\"\"c\"");
+    }
+
+    #[test]
+    fn try_from_sets_filename() {
+        let config = DatabaseConfig {
+            backend: DatabaseBackend::Sqlite,
+            name: Some("test.db".into()),
+            ..DatabaseConfig::default()
+        };
+        let opts = SqliteConnectOptions::from(&config);
+
+        assert_eq!(opts.get_filename().to_str().expect("valid path"), "test.db");
+    }
+
+    #[test]
+    fn try_from_empty_name_defaults() {
+        let config = DatabaseConfig {
+            backend: DatabaseBackend::Sqlite,
+            name: None,
+            ..DatabaseConfig::default()
+        };
+        let opts = SqliteConnectOptions::from(&config);
+
+        // Empty string filename — validated elsewhere by Config::validate()
+        assert_eq!(opts.get_filename().to_str().expect("valid path"), "");
     }
 
     /// Helper: creates an in-memory `SQLite` pool for unit tests.


### PR DESCRIPTION
## Motivation

Each database backend (`mysql.rs`, `postgres.rs`, `sqlite.rs`) had a private `build_connection_url` method that assembled a URL string from `DatabaseConfig` fields. This string was then passed to `PoolOptions::connect(&str)`, which immediately re-parsed it internally via `ConnectOptions::from_str()`. This round-trip was redundant and coupled the config-to-connection logic to URL string formatting quirks (percent-encoding, query parameter naming).

## Solution

- Replaced `build_connection_url` methods with `From<&DatabaseConfig>` trait implementations for each backend's sqlx `ConnectOptions` type (`MySqlConnectOptions`, `PgConnectOptions`, `SqliteConnectOptions`)
- Backends now call `PoolOptions::connect_with(config.into())` instead of `PoolOptions::connect(&url)`
- PostgreSQL's `get_pool()` for cross-database pooling also uses the `From` trait (clone config → modify name → `.into()`)
- Used `PgConnectOptions::new_without_pgpass()` to avoid unintended `PG*` environment variable influence
- The `ssl_verify_cert` config flag is now correctly mapped to `VerifyCa` SSL mode (was previously unused in URL generation)
- Added unit tests for each `From` impl verifying host, port, credentials, SSL modes, charset, and edge cases
- Config module (`src/config.rs`) remains free of sqlx imports

## Test Plan

- `cargo fmt --check` — pass
- `cargo clippy -- -D warnings` — pass
- `cargo test --lib` — 76 tests pass (including 13 new `From` conversion tests)
- `./tests/run.sh` — 54 integration tests pass across all backends:
  - MariaDB 12: 15 passed
  - MySQL 9: 15 passed
  - PostgreSQL 18: 16 passed
  - SQLite: 8 passed

---

- [ ] Linked to an issue (if applicable)
- [x] Tests pass (`cargo test`)
- [x] Lints pass (`cargo clippy -- -D warnings`)
- [x] Formatted (`cargo fmt --check`)