### PR TITLE
chore: add MIT license and README license section

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 Andreas Penz
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -208,3 +208,7 @@ cargo clippy -- -D warnings  # Lint
 cargo fmt                # Format
 cargo doc --no-deps      # Build documentation
 ```
+
+## License
+
+This project is licensed under the MIT License — see the [LICENSE](LICENSE) file for details.


### PR DESCRIPTION
## Motivation

The repository had no LICENSE file, causing GitHub to display a "No license" warning and preventing contributors and consumers from determining their rights. The `Cargo.toml` already declared `license = "MIT"` but the actual license text was missing.

## Solution

- Added a `LICENSE` file at the repository root with the standard MIT License text (Copyright 2026 Andreas Penz)
- Appended a `## License` section to `README.md` linking to the LICENSE file
- Verified `Cargo.toml` already declares `license = "MIT"` — no changes needed

## Test Plan

- Verified `LICENSE` file exists at repo root with correct MIT text
- Verified `Cargo.toml` contains `license = "MIT"` on line 6
- Verified `README.md` has `## License` section at the bottom
- All three license references are consistent (MIT)
- `cargo test --lib` — 76 passed
- `cargo clippy -- -D warnings` — 0 warnings
- `cargo fmt --check` — clean
- GitHub license sidebar detection will be verified after merge

---

- [ ] Linked to an issue (if applicable)
- [x] Tests pass (`cargo test`)
- [x] Lints pass (`cargo clippy -- -D warnings`)
- [x] Formatted (`cargo fmt --check`)