### PR TITLE
refactor: rename sql-mcp to database-mcp

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,5 +1,5 @@
 name: Bug Report
-description: Report a bug or unexpected behavior in sql-mcp
+description: Report a bug or unexpected behavior in database-mcp
 labels: ["bug"]
 body:
   - type: markdown
@@ -8,8 +8,8 @@ body:
         Thanks for reporting a bug! Please fill out the form below to help us investigate.
 
         Before submitting, please:
-        - Search [existing issues](https://github.com/haymon-ai/sql-mcp/issues) for duplicates
-        - Make sure you're using the latest version of sql-mcp
+        - Search [existing issues](https://github.com/haymon-ai/database-mcp/issues) for duplicates
+        - Make sure you're using the latest version of database-mcp
 
   - type: checkboxes
     id: prerequisites
@@ -18,14 +18,14 @@ body:
       options:
         - label: I have searched existing issues for duplicates
           required: true
-        - label: I am using the latest version of sql-mcp
+        - label: I am using the latest version of database-mcp
           required: true
 
   - type: input
     id: version
     attributes:
       label: Version
-      description: Which version or commit of sql-mcp are you using?
+      description: Which version or commit of database-mcp are you using?
       placeholder: "e.g., 0.1.0, git commit abc1234, or latest main"
     validations:
       required: true
@@ -79,7 +79,7 @@ body:
       label: Steps to Reproduce
       description: Steps to reproduce the behavior
       placeholder: |
-        1. Configure sql-mcp with '...'
+        1. Configure database-mcp with '...'
         2. Run command '...'
         3. Execute query '...'
         4. See error

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,13 +20,13 @@ jobs:
         include:
           - target: x86_64-unknown-linux-gnu
             os: ubuntu-latest
-            artifact: sql-mcp
+            artifact: database-mcp
           - target: aarch64-unknown-linux-gnu
             os: ubuntu-latest
-            artifact: sql-mcp
+            artifact: database-mcp
           - target: aarch64-apple-darwin
             os: macos-latest
-            artifact: sql-mcp
+            artifact: database-mcp
     steps:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@stable
@@ -50,12 +50,12 @@ jobs:
       - name: Package artifact
         run: |
           cd target/${{ matrix.target }}/release
-          tar czf ../../../sql-mcp-${{ matrix.target }}.tar.gz ${{ matrix.artifact }}
+          tar czf ../../../database-mcp-${{ matrix.target }}.tar.gz ${{ matrix.artifact }}
 
       - uses: actions/upload-artifact@v4
         with:
-          name: sql-mcp-${{ matrix.target }}
-          path: sql-mcp-${{ matrix.target }}.tar.gz
+          name: database-mcp-${{ matrix.target }}
+          path: database-mcp-${{ matrix.target }}.tar.gz
 
   release:
     name: Create Release

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -453,6 +453,29 @@ dependencies = [
 ]
 
 [[package]]
+name = "database-mcp"
+version = "0.1.0"
+dependencies = [
+ "axum",
+ "base64",
+ "clap",
+ "mimalloc",
+ "moka",
+ "rmcp",
+ "serde",
+ "serde_json",
+ "sqlparser",
+ "sqlx",
+ "sqlx_to_json",
+ "thiserror",
+ "tokio",
+ "tokio-util",
+ "tower-http",
+ "tracing",
+ "tracing-subscriber",
+]
+
+[[package]]
 name = "der"
 version = "0.7.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1896,29 +1919,6 @@ checksum = "d91ed6c858b01f942cd56b37a94b3e0a1798290327d1236e4d9cf4eaca44d29d"
 dependencies = [
  "base64ct",
  "der",
-]
-
-[[package]]
-name = "sql-mcp"
-version = "0.1.0"
-dependencies = [
- "axum",
- "base64",
- "clap",
- "mimalloc",
- "moka",
- "rmcp",
- "serde",
- "serde_json",
- "sqlparser",
- "sqlx",
- "sqlx_to_json",
- "thiserror",
- "tokio",
- "tokio-util",
- "tower-http",
- "tracing",
- "tracing-subscriber",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,12 +2,12 @@
 members = [".", "crates/sqlx_to_json"]
 
 [package]
-name = "sql-mcp"
+name = "database-mcp"
 version = "0.1.0"
 edition = "2024"
 description = "A single-binary MCP server for MySQL, PostgreSQL, and SQLite"
 license = "MIT"
-repository = "https://github.com/haymon-ai/sql-mcp"
+repository = "https://github.com/haymon-ai/database-mcp"
 keywords = ["mcp", "database", "mysql", "postgresql", "sqlite"]
 categories = ["database", "command-line-utilities"]
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# sql-mcp
+# database-mcp
 
 A single-binary [MCP](https://modelcontextprotocol.io/) server for SQL databases. Connect your AI assistant to MySQL/MariaDB, PostgreSQL, or SQLite with zero runtime dependencies.
 
@@ -21,8 +21,8 @@ Add a `.mcp.json` file to your project root. MCP clients read this file and conf
 ```json
 {
   "mcpServers": {
-    "sql-mcp": {
-      "command": "sql-mcp",
+    "database-mcp": {
+      "command": "database-mcp",
       "env": {
         "DB_BACKEND": "mysql",
         "DB_HOST": "127.0.0.1",
@@ -40,13 +40,13 @@ Add a `.mcp.json` file to your project root. MCP clients read this file and conf
 
 ```bash
 # Start the server first
-sql-mcp http --db-backend mysql --db-user root --db-name mydb --port 9001
+database-mcp http --db-backend mysql --db-user root --db-name mydb --port 9001
 ```
 
 ```json
 {
   "mcpServers": {
-    "sql-mcp": {
+    "database-mcp": {
       "type": "http",
       "url": "http://127.0.0.1:9001/mcp"
     }
@@ -60,22 +60,22 @@ sql-mcp http --db-backend mysql --db-user root --db-name mydb --port 9001
 
 ```bash
 # MySQL/MariaDB
-sql-mcp --db-backend mysql --db-host localhost --db-user root --db-name mydb
+database-mcp --db-backend mysql --db-host localhost --db-user root --db-name mydb
 
 # PostgreSQL
-sql-mcp --db-backend postgres --db-host localhost --db-user postgres --db-name mydb
+database-mcp --db-backend postgres --db-host localhost --db-user postgres --db-name mydb
 
 # SQLite
-sql-mcp --db-backend sqlite --db-name ./data.db
+database-mcp --db-backend sqlite --db-name ./data.db
 
 # HTTP transport
-sql-mcp http --db-backend mysql --db-user root --db-name mydb --host 0.0.0.0 --port 9001
+database-mcp http --db-backend mysql --db-user root --db-name mydb --host 0.0.0.0 --port 9001
 ```
 
 ### Using environment variables
 
 ```bash
-DB_BACKEND=mysql DB_USER=root DB_NAME=mydb sql-mcp
+DB_BACKEND=mysql DB_USER=root DB_NAME=mydb database-mcp
 ```
 
 ## Configuration
@@ -189,7 +189,7 @@ cargo test --lib
 ./tests/run.sh --filter sqlite
 
 # With MCP Inspector
-npx @modelcontextprotocol/inspector ./target/release/sql-mcp
+npx @modelcontextprotocol/inspector ./target/release/database-mcp
 
 # HTTP mode testing
 curl -X POST http://localhost:9001/mcp \
@@ -204,7 +204,7 @@ This is a Cargo workspace with two crates:
 
 | Crate | Path | Description |
 |-------|------|-------------|
-| `sql-mcp` | `.` (root) | Main binary — CLI, transports, database backends |
+| `database-mcp` | `.` (root) | Main binary — CLI, transports, database backends |
 | `sqlx_to_json` | `crates/sqlx_to_json/` | Internal library — type-safe row-to-JSON conversion for sqlx (`RowExt` trait) |
 
 ## Development

--- a/cog.toml
+++ b/cog.toml
@@ -31,7 +31,7 @@ path = "CHANGELOG.md"
 template = "remote"
 remote = "github.com"
 owner = "haymon-ai"
-repository = "sql-mcp"
+repository = "database-mcp"
 
 # Commit type visibility in the changelog
 [commit_types]

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -9,14 +9,14 @@
 //! - `stdio` (default) — runs the MCP server over stdin/stdout
 //! - `http` — runs the MCP server over HTTP with Streamable HTTP transport
 
+use database_mcp::config::{Config, DatabaseBackend, DatabaseConfig, HttpConfig};
+use database_mcp::db;
+use database_mcp::db::backend::Backend;
+use database_mcp::server::Server;
 use rmcp::ServiceExt;
 use rmcp::transport::streamable_http_server::{
     StreamableHttpServerConfig, StreamableHttpService, session::local::LocalSessionManager,
 };
-use sql_mcp::config::{Config, DatabaseBackend, DatabaseConfig, HttpConfig};
-use sql_mcp::db;
-use sql_mcp::db::backend::Backend;
-use sql_mcp::server::Server;
 use std::process::ExitCode;
 use std::sync::Arc;
 use tokio_util::sync::CancellationToken;
@@ -67,7 +67,7 @@ impl From<LogLevel> for tracing::Level {
 }
 
 #[derive(Parser)]
-#[command(name = "sql-mcp", about = "Database MCP Server")]
+#[command(name = "database-mcp", about = "Database MCP Server")]
 struct Cli {
     #[command(subcommand)]
     command: Option<Command>,
@@ -361,21 +361,21 @@ mod tests {
 
     #[test]
     fn parse_db_backend_after_http_subcommand() {
-        let cli = Cli::try_parse_from(["sql-mcp", "http", "--db-backend", "mysql"]).unwrap();
+        let cli = Cli::try_parse_from(["database-mcp", "http", "--db-backend", "mysql"]).unwrap();
         assert_eq!(cli.db_backend, DatabaseBackend::Mysql);
         assert!(matches!(cli.command, Some(Command::Http { .. })));
     }
 
     #[test]
     fn parse_db_backend_before_http_subcommand() {
-        let cli = Cli::try_parse_from(["sql-mcp", "--db-backend", "mysql", "http"]).unwrap();
+        let cli = Cli::try_parse_from(["database-mcp", "--db-backend", "mysql", "http"]).unwrap();
         assert_eq!(cli.db_backend, DatabaseBackend::Mysql);
         assert!(matches!(cli.command, Some(Command::Http { .. })));
     }
 
     #[test]
     fn parse_db_backend_with_no_subcommand() {
-        let cli = Cli::try_parse_from(["sql-mcp", "--db-backend", "postgres"]).unwrap();
+        let cli = Cli::try_parse_from(["database-mcp", "--db-backend", "postgres"]).unwrap();
         assert_eq!(cli.db_backend, DatabaseBackend::Postgres);
         assert!(cli.command.is_none());
     }
@@ -383,7 +383,7 @@ mod tests {
     #[test]
     fn parse_multiple_global_args_after_subcommand() {
         let cli = Cli::try_parse_from([
-            "sql-mcp",
+            "database-mcp",
             "http",
             "--db-backend",
             "mysql",
@@ -400,32 +400,32 @@ mod tests {
 
     #[test]
     fn parse_db_backend_defaults_to_mysql() {
-        let cli = Cli::try_parse_from(["sql-mcp", "http"]).unwrap();
+        let cli = Cli::try_parse_from(["database-mcp", "http"]).unwrap();
         assert_eq!(cli.db_backend, DatabaseBackend::Mysql);
     }
 
     #[test]
     fn cli_flag_overrides_default_backend() {
-        let cli = Cli::try_parse_from(["sql-mcp", "http", "--db-backend", "postgres"]).unwrap();
+        let cli = Cli::try_parse_from(["database-mcp", "http", "--db-backend", "postgres"]).unwrap();
         assert_eq!(cli.db_backend, DatabaseBackend::Postgres);
     }
 
     #[test]
     fn parse_valid_log_levels() {
         for level in ["error", "warn", "info", "debug", "trace"] {
-            let cli = Cli::try_parse_from(["sql-mcp", "--log-level", level]).unwrap();
+            let cli = Cli::try_parse_from(["database-mcp", "--log-level", level]).unwrap();
             assert_eq!(cli.log_level.to_string(), level);
         }
     }
 
     #[test]
     fn parse_invalid_log_level_is_rejected() {
-        assert!(Cli::try_parse_from(["sql-mcp", "--log-level", "nonsense"]).is_err());
+        assert!(Cli::try_parse_from(["database-mcp", "--log-level", "nonsense"]).is_err());
     }
 
     #[test]
     fn log_level_defaults_to_info() {
-        let cli = Cli::try_parse_from(["sql-mcp"]).unwrap();
+        let cli = Cli::try_parse_from(["database-mcp"]).unwrap();
         assert_eq!(cli.log_level, LogLevel::Info);
     }
 
@@ -433,7 +433,7 @@ mod tests {
     fn parse_log_level_case_insensitive() {
         for level in ["DEBUG", "Info", "TRACE", "Warn", "ERROR"] {
             assert!(
-                Cli::try_parse_from(["sql-mcp", "--log-level", level]).is_ok(),
+                Cli::try_parse_from(["database-mcp", "--log-level", level]).is_ok(),
                 "expected '{level}' to be accepted case-insensitively"
             );
         }

--- a/tests/mysql/mysql.rs
+++ b/tests/mysql/mysql.rs
@@ -5,9 +5,9 @@
 //! ./tests/run.sh --filter mysql      # MySQL
 //! ```
 
-use sql_mcp::config::{DatabaseBackend, DatabaseConfig};
-use sql_mcp::db::backend::Backend;
-use sql_mcp::db::mysql::MysqlBackend;
+use database_mcp::config::{DatabaseBackend, DatabaseConfig};
+use database_mcp::db::backend::Backend;
+use database_mcp::db::mysql::MysqlBackend;
 
 fn test_config() -> DatabaseConfig {
     DatabaseConfig {

--- a/tests/postgres/postgres.rs
+++ b/tests/postgres/postgres.rs
@@ -4,9 +4,9 @@
 //! ./tests/run.sh --filter postgres
 //! ```
 
-use sql_mcp::config::{DatabaseBackend, DatabaseConfig};
-use sql_mcp::db::backend::Backend;
-use sql_mcp::db::postgres::PostgresBackend;
+use database_mcp::config::{DatabaseBackend, DatabaseConfig};
+use database_mcp::db::backend::Backend;
+use database_mcp::db::postgres::PostgresBackend;
 
 fn test_config() -> DatabaseConfig {
     DatabaseConfig {

--- a/tests/sqlite/sqlite.rs
+++ b/tests/sqlite/sqlite.rs
@@ -7,9 +7,9 @@
 //! ./tests/run.sh --filter sqlite
 //! ```
 
-use sql_mcp::config::{DatabaseBackend, DatabaseConfig};
-use sql_mcp::db::backend::Backend;
-use sql_mcp::db::sqlite::SqliteBackend;
+use database_mcp::config::{DatabaseBackend, DatabaseConfig};
+use database_mcp::db::backend::Backend;
+use database_mcp::db::sqlite::SqliteBackend;
 
 fn sqlite_config(db_path: &str, read_only: bool) -> DatabaseConfig {
     DatabaseConfig {


### PR DESCRIPTION
## Summary

- Rename project from `sql-mcp` to `database-mcp` to match the new repository name
- Update package name, binary name, CLI command name, and all Rust import paths (`sql_mcp::` → `database_mcp::`)
- Update release workflow artifacts, documentation examples, issue templates, and cocogitto config

## Test plan

- [x] `cargo fmt --check` passes
- [x] `cargo clippy -- -D warnings` passes (0 warnings)
- [x] `cargo test --lib` passes (63 unit tests)
- [x] `./tests/run.sh` passes (54 integration tests across MariaDB, MySQL, PostgreSQL, SQLite)
- [x] Zero remaining `sql-mcp` / `sql_mcp` references outside `specs/`
- [x] Built binary is named `database-mcp`