### PR TITLE
refactor!: merge schema tools into single get_table_schema

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ A single-binary [MCP](https://modelcontextprotocol.io/) server for SQL databases
 ## Features
 
 - **Multi-database** — MySQL/MariaDB, PostgreSQL, and SQLite from one binary
-- **7 MCP tools** — `list_databases`, `list_tables`, `get_table_schema`, `get_table_schema_with_relations`, `read_query`, `write_query`, `create_database`
+- **6 MCP tools** — `list_databases`, `list_tables`, `get_table_schema`, `read_query`, `write_query`, `create_database`
 - **Single binary** — ~7 MB, no Python/Node/Docker needed
 - **Multiple transports** — stdio (for Claude Desktop, Cursor) and HTTP (for remote/multi-client)
 - **Two-layer config** — CLI flags > environment variables, with sensible defaults per backend
@@ -158,11 +158,7 @@ Lists all tables in a database. Parameters: `database_name`.
 
 ### get_table_schema
 
-Returns column definitions (type, nullable, key, default, extra) for a table. Parameters: `database_name`, `table_name`.
-
-### get_table_schema_with_relations
-
-Same as `get_table_schema` plus foreign key relationships (constraint name, referenced table/column, on update/delete rules). Parameters: `database_name`, `table_name`.
+Returns column definitions (type, nullable, key, default, extra) and foreign key relationships (constraint name, referenced table/column, on update/delete rules) for a table. Parameters: `database_name`, `table_name`.
 
 ### read_query
 

--- a/docs/content/docs/features.mdx
+++ b/docs/content/docs/features.mdx
@@ -29,7 +29,6 @@ Database MCP exposes tools through the MCP protocol. The available tool set depe
 | `list_databases` | Yes | Yes | No | No |
 | `list_tables` | Yes | Yes | Yes | No |
 | `get_table_schema` | Yes | Yes | Yes | No |
-| `get_table_schema_with_relations` | Yes | Yes | Yes | No |
 | `read_query` | Yes | Yes | Yes | No |
 | `write_query` | Yes | Yes | Yes | Yes |
 | `create_database` | Yes | Yes | No | Yes |
@@ -46,11 +45,7 @@ List all tables in a specific database. Requires a database name (use `list_data
 
 ### `get_table_schema`
 
-Inspect column definitions for a table — column names, types, nullability, keys, and default values. Useful for understanding table structure before writing queries.
-
-### `get_table_schema_with_relations`
-
-Like `get_table_schema`, but also includes foreign key relationships. Helps assistants understand how tables connect to each other.
+Inspect column definitions for a table — column names, types, nullability, keys, default values, and foreign key relationships (constraint name, referenced table/column, cascade rules). Helps assistants understand both table structure and how tables connect to each other.
 
 ### `read_query`
 

--- a/src/db/backend.rs
+++ b/src/db/backend.rs
@@ -23,11 +23,8 @@ pub trait DatabaseBackend {
     /// Lists all tables in a database.
     async fn list_tables(&self, database: &str) -> Result<Vec<String>, AppError>;
 
-    /// Returns column definitions for a table.
+    /// Returns column definitions with foreign key relationships for a table.
     async fn get_table_schema(&self, database: &str, table: &str) -> Result<Value, AppError>;
-
-    /// Returns column definitions with foreign key relationships.
-    async fn get_table_schema_with_relations(&self, database: &str, table: &str) -> Result<Value, AppError>;
 
     /// Executes a SQL query and returns rows as a JSON array.
     async fn execute_query(&self, sql: &str, database: Option<&str>) -> Result<Value, AppError>;
@@ -79,14 +76,6 @@ impl DatabaseBackend for Backend {
             Self::Mysql(b) => b.get_table_schema(database, table).await,
             Self::Postgres(b) => b.get_table_schema(database, table).await,
             Self::Sqlite(b) => b.get_table_schema(database, table).await,
-        }
-    }
-
-    async fn get_table_schema_with_relations(&self, database: &str, table: &str) -> Result<Value, AppError> {
-        match self {
-            Self::Mysql(b) => b.get_table_schema_with_relations(database, table).await,
-            Self::Postgres(b) => b.get_table_schema_with_relations(database, table).await,
-            Self::Sqlite(b) => b.get_table_schema_with_relations(database, table).await,
         }
     }
 
@@ -154,7 +143,7 @@ impl Backend {
         Ok(serde_json::to_string_pretty(&table_list).unwrap_or_else(|_| "[]".into()))
     }
 
-    /// Returns column definitions for a table as JSON.
+    /// Returns column definitions with foreign key relationships as JSON.
     ///
     /// # Errors
     ///
@@ -164,22 +153,6 @@ impl Backend {
         let schema = self.get_table_schema(database_name, table_name).await?;
         info!("TOOL: get_table_schema completed");
         Ok(serde_json::to_string_pretty(&schema).unwrap_or_else(|_| "{}".into()))
-    }
-
-    /// Returns column definitions with foreign key relationships.
-    ///
-    /// # Errors
-    ///
-    /// Returns [`AppError`] if identifiers are invalid or the backend query fails.
-    pub async fn tool_get_table_schema_with_relations(
-        &self,
-        database_name: &str,
-        table_name: &str,
-    ) -> Result<String, AppError> {
-        info!("TOOL: get_table_schema_with_relations called. database_name={database_name}, table_name={table_name}");
-        let result = self.get_table_schema_with_relations(database_name, table_name).await?;
-        info!("TOOL: get_table_schema_with_relations completed");
-        Ok(serde_json::to_string_pretty(&result).unwrap_or_else(|_| "{}".into()))
     }
 
     /// Executes a SQL query and returns results as a JSON string.

--- a/src/db/mysql.rs
+++ b/src/db/mysql.rs
@@ -216,41 +216,6 @@ impl DatabaseBackend for MysqlBackend {
         validate_identifier(database)?;
         validate_identifier(table)?;
 
-        let sql = format!(
-            "DESCRIBE {}.{}",
-            Self::quote_identifier(database),
-            Self::quote_identifier(table)
-        );
-        let results = self.query_to_json(&sql, None).await?;
-        let rows = results.as_array().map_or([].as_slice(), Vec::as_slice);
-
-        if rows.is_empty() {
-            return Err(AppError::TableNotFound(format!("{database}.{table}")));
-        }
-
-        let mut schema: HashMap<String, Value> = HashMap::new();
-        for row in rows {
-            if let Some(col_name) = row.get("Field").and_then(|v| v.as_str()) {
-                schema.insert(
-                    col_name.to_string(),
-                    json!({
-                        "type": row.get("Type").unwrap_or(&Value::Null),
-                        "nullable": row.get("Null").and_then(|v| v.as_str()).is_some_and(|s| s.to_uppercase() == "YES"),
-                        "key": row.get("Key").unwrap_or(&Value::Null),
-                        "default": row.get("Default").unwrap_or(&Value::Null),
-                        "extra": row.get("Extra").unwrap_or(&Value::Null),
-                    }),
-                );
-            }
-        }
-
-        Ok(json!(schema))
-    }
-
-    async fn get_table_schema_with_relations(&self, database: &str, table: &str) -> Result<Value, AppError> {
-        validate_identifier(database)?;
-        validate_identifier(table)?;
-
         // 1. Get basic schema
         let describe_sql = format!(
             "DESCRIBE {}.{}",

--- a/src/db/postgres.rs
+++ b/src/db/postgres.rs
@@ -218,6 +218,8 @@ impl DatabaseBackend for PostgresBackend {
         validate_identifier(table)?;
         let db = if database.is_empty() { None } else { Some(database) };
         let pool = self.get_pool(db).await?;
+
+        // 1. Get basic schema
         let rows: Vec<PgRow> = sqlx::query(
             r"SELECT column_name, data_type, is_nullable, column_default,
                       character_maximum_length
@@ -234,13 +236,13 @@ impl DatabaseBackend for PostgresBackend {
             return Err(AppError::TableNotFound(table.to_string()));
         }
 
-        let mut schema: HashMap<String, Value> = HashMap::new();
+        let mut columns: HashMap<String, Value> = HashMap::new();
         for row in &rows {
             let col_name: String = row.try_get("column_name").unwrap_or_default();
             let data_type: String = row.try_get("data_type").unwrap_or_default();
             let nullable: String = row.try_get("is_nullable").unwrap_or_default();
             let default: Option<String> = row.try_get("column_default").ok();
-            schema.insert(
+            columns.insert(
                 col_name,
                 json!({
                     "type": data_type,
@@ -248,26 +250,12 @@ impl DatabaseBackend for PostgresBackend {
                     "key": Value::Null,
                     "default": default,
                     "extra": Value::Null,
+                    "foreign_key": Value::Null,
                 }),
             );
         }
-        Ok(json!(schema))
-    }
 
-    async fn get_table_schema_with_relations(&self, database: &str, table: &str) -> Result<Value, AppError> {
-        let schema = self.get_table_schema(database, table).await?;
-        let mut columns: HashMap<String, Value> = serde_json::from_value(schema).unwrap_or_default();
-
-        // Add null foreign_key to all columns
-        for col in columns.values_mut() {
-            if let Some(obj) = col.as_object_mut() {
-                obj.entry("foreign_key".to_string()).or_insert(Value::Null);
-            }
-        }
-
-        // Get FK info using the same pool as the schema query
-        let db = if database.is_empty() { None } else { Some(database) };
-        let pool = self.get_pool(db).await?;
+        // 2. Get FK relationships
         let fk_rows: Vec<PgRow> = sqlx::query(
             r"SELECT
                 kcu.column_name,

--- a/src/db/sqlite.rs
+++ b/src/db/sqlite.rs
@@ -98,6 +98,8 @@ impl DatabaseBackend for SqliteBackend {
 
     async fn get_table_schema(&self, _database: &str, table: &str) -> Result<Value, AppError> {
         validate_identifier(table)?;
+
+        // 1. Get basic schema
         let rows: Vec<SqliteRow> = sqlx::query(&format!("PRAGMA table_info({})", Self::quote_identifier(table)))
             .fetch_all(&self.pool)
             .await
@@ -107,14 +109,14 @@ impl DatabaseBackend for SqliteBackend {
             return Err(AppError::TableNotFound(table.to_string()));
         }
 
-        let mut schema: HashMap<String, Value> = HashMap::new();
+        let mut columns: HashMap<String, Value> = HashMap::new();
         for row in &rows {
             let col_name: String = row.try_get("name").unwrap_or_default();
             let col_type: String = row.try_get("type").unwrap_or_default();
             let notnull: i32 = row.try_get("notnull").unwrap_or(0);
             let default: Option<String> = row.try_get("dflt_value").ok();
             let pk: i32 = row.try_get("pk").unwrap_or(0);
-            schema.insert(
+            columns.insert(
                 col_name,
                 json!({
                     "type": col_type,
@@ -122,24 +124,12 @@ impl DatabaseBackend for SqliteBackend {
                     "key": if pk > 0 { "PRI" } else { "" },
                     "default": default,
                     "extra": Value::Null,
+                    "foreign_key": Value::Null,
                 }),
             );
         }
-        Ok(json!(schema))
-    }
 
-    async fn get_table_schema_with_relations(&self, database: &str, table: &str) -> Result<Value, AppError> {
-        let schema = self.get_table_schema(database, table).await?;
-        let mut columns: HashMap<String, Value> = serde_json::from_value(schema).unwrap_or_default();
-
-        // Add null foreign_key to all columns
-        for col in columns.values_mut() {
-            if let Some(obj) = col.as_object_mut() {
-                obj.entry("foreign_key".to_string()).or_insert(Value::Null);
-            }
-        }
-
-        // Get FK info via PRAGMA
+        // 2. Get FK info via PRAGMA
         let fk_rows: Vec<SqliteRow> =
             sqlx::query(&format!("PRAGMA foreign_key_list({})", Self::quote_identifier(table)))
                 .fetch_all(&self.pool)

--- a/src/server.rs
+++ b/src/server.rs
@@ -134,7 +134,7 @@ fn get_table_schema_route() -> ToolRoute<Server> {
     ToolRoute::new_dyn(
         Tool::new(
             "get_table_schema",
-            "Get column definitions (type, nullable, key, default) for a table. Requires database_name and table_name.",
+            "Get column definitions (type, nullable, key, default) and foreign key relationships for a table. Requires database_name and table_name.",
             schema_for::<GetTableSchemaRequest>(),
         )
         .with_annotations(
@@ -150,33 +150,6 @@ fn get_table_schema_route() -> ToolRoute<Server> {
             Box::pin(async move {
                 let params = params?;
                 server.get_table_schema(params).await
-            })
-        },
-    )
-}
-
-/// Route for the `get_table_schema_with_relations` tool.
-#[must_use]
-fn get_table_schema_with_relations_route() -> ToolRoute<Server> {
-    ToolRoute::new_dyn(
-        Tool::new(
-            "get_table_schema_with_relations",
-            "Get column definitions plus foreign key relationships for a table. Requires database_name and table_name.",
-            schema_for::<GetTableSchemaRequest>(),
-        )
-        .with_annotations(
-            ToolAnnotations::new()
-                .read_only(true)
-                .destructive(false)
-                .idempotent(true)
-                .open_world(false),
-        ),
-        |mut ctx: ToolCallContext<'_, Server>| {
-            let params = Parameters::<GetTableSchemaRequest>::from_context_part(&mut ctx);
-            let server = ctx.service;
-            Box::pin(async move {
-                let params = params?;
-                server.get_table_schema_with_relations(params).await
             })
         },
     )
@@ -310,7 +283,6 @@ impl Server {
 
         router.add_route(list_tables_route());
         router.add_route(get_table_schema_route());
-        router.add_route(get_table_schema_with_relations_route());
         router.add_route(read_query_route());
 
         if backend.read_only() {
@@ -356,7 +328,7 @@ impl Server {
         Ok(CallToolResult::success(vec![Content::text(result)]))
     }
 
-    /// Get column definitions for a table.
+    /// Get column definitions and foreign key relationships for a table.
     ///
     /// # Errors
     ///
@@ -365,23 +337,6 @@ impl Server {
         let result = self
             .backend
             .tool_get_table_schema(&req.0.database_name, &req.0.table_name)
-            .await
-            .map_err(map_error)?;
-        Ok(CallToolResult::success(vec![Content::text(result)]))
-    }
-
-    /// Get column definitions plus foreign key relationships.
-    ///
-    /// # Errors
-    ///
-    /// Returns [`ErrorData`] if the backend query fails.
-    pub async fn get_table_schema_with_relations(
-        &self,
-        req: Parameters<GetTableSchemaRequest>,
-    ) -> Result<CallToolResult, ErrorData> {
-        let result = self
-            .backend
-            .tool_get_table_schema_with_relations(&req.0.database_name, &req.0.table_name)
             .await
             .map_err(map_error)?;
         Ok(CallToolResult::success(vec![Content::text(result)]))
@@ -557,17 +512,6 @@ mod tests {
     }
 
     #[test]
-    fn get_table_schema_with_relations_route_has_correct_name() {
-        let route = get_table_schema_with_relations_route();
-        assert_eq!(route.attr.name.as_ref(), "get_table_schema_with_relations");
-        let props = route.attr.input_schema.get("properties").and_then(|v| v.as_object());
-        assert!(
-            props.is_some_and(|p| p.contains_key("database_name") && p.contains_key("table_name")),
-            "schema should have database_name and table_name properties"
-        );
-    }
-
-    #[test]
     fn read_query_route_has_correct_name_and_schema() {
         let route = read_query_route();
         assert_eq!(route.attr.name.as_ref(), "read_query");
@@ -687,16 +631,6 @@ mod tests {
     }
 
     #[test]
-    fn get_table_schema_with_relations_annotations_are_read_only_closed_world() {
-        let route = get_table_schema_with_relations_route();
-        let ann = annotations(&route);
-        assert_eq!(ann.read_only_hint, Some(true));
-        assert_eq!(ann.destructive_hint, Some(false));
-        assert_eq!(ann.idempotent_hint, Some(true));
-        assert_eq!(ann.open_world_hint, Some(false));
-    }
-
-    #[test]
     fn read_query_annotations_are_read_only_open_world() {
         let route = read_query_route();
         let ann = annotations(&route);
@@ -745,20 +679,19 @@ mod tests {
     // MySQL/Postgres router behavior is verified by integration tests.
 
     #[tokio::test]
-    async fn router_sqlite_read_only_returns_4_tools() {
+    async fn router_sqlite_read_only_returns_3_tools() {
         let names = router_tool_names(&sqlite_backend(true));
-        assert_eq!(names.len(), 4);
+        assert_eq!(names.len(), 3);
         assert!(!names.contains(&"list_databases".to_string()));
         assert!(names.contains(&"list_tables".to_string()));
         assert!(names.contains(&"get_table_schema".to_string()));
-        assert!(names.contains(&"get_table_schema_with_relations".to_string()));
         assert!(names.contains(&"read_query".to_string()));
     }
 
     #[tokio::test]
-    async fn router_sqlite_read_write_returns_5_tools() {
+    async fn router_sqlite_read_write_returns_4_tools() {
         let names = router_tool_names(&sqlite_backend(false));
-        assert_eq!(names.len(), 5);
+        assert_eq!(names.len(), 4);
         assert!(!names.contains(&"list_databases".to_string()));
         assert!(names.contains(&"write_query".to_string()));
         assert!(!names.contains(&"create_database".to_string()));

--- a/tests/mysql/mysql.rs
+++ b/tests/mysql/mysql.rs
@@ -64,22 +64,30 @@ async fn it_gets_table_schema() {
     let b = backend().await;
     let result = b.tool_get_table_schema("app", "users").await.expect("failed");
     let schema: serde_json::Value = serde_json::from_str(&result).expect("bad json");
-    let columns: Vec<String> = schema.as_object().expect("object").keys().cloned().collect();
+    let obj = schema.as_object().expect("object");
+    assert!(obj.contains_key("table_name"), "Response should contain table_name");
+    assert!(obj.contains_key("columns"), "Response should contain columns");
+    let columns = obj["columns"].as_object().expect("columns object");
     for col in ["id", "name", "email", "created_at"] {
-        assert!(columns.iter().any(|c| c == col), "Missing '{col}' in: {columns:?}");
+        assert!(columns.contains_key(col), "Missing '{col}' in: {columns:?}");
     }
 }
 
 #[tokio::test]
-async fn it_gets_table_relations() {
+async fn it_gets_table_schema_with_relations() {
     let b = backend().await;
-    let result = b
-        .tool_get_table_schema_with_relations("app", "posts")
-        .await
-        .expect("failed");
+    let result = b.tool_get_table_schema("app", "posts").await.expect("failed");
+    let schema: serde_json::Value = serde_json::from_str(&result).expect("bad json");
+    let columns = schema["columns"].as_object().expect("columns object");
+    assert!(columns.contains_key("user_id"), "Missing 'user_id' column");
+    let user_id = columns["user_id"].as_object().expect("user_id object");
     assert!(
-        result.contains("user_id") || result.contains("users"),
-        "Expected foreign key reference in: {result}"
+        user_id.contains_key("foreign_key"),
+        "Missing 'foreign_key' in user_id column"
+    );
+    assert!(
+        !user_id["foreign_key"].is_null(),
+        "foreign_key should not be null for user_id"
     );
 }
 
@@ -181,10 +189,12 @@ async fn it_gets_table_schema_cross_database() {
     let b = backend().await;
     let result = b.tool_get_table_schema("analytics", "events").await.expect("failed");
     let schema: serde_json::Value = serde_json::from_str(&result).expect("bad json");
-    let columns: Vec<String> = schema.as_object().expect("object").keys().cloned().collect();
+    let obj = schema.as_object().expect("object");
+    assert!(obj.contains_key("table_name"), "Response should contain table_name");
+    let columns = obj["columns"].as_object().expect("columns object");
     for col in ["id", "name", "payload", "created_at"] {
         assert!(
-            columns.iter().any(|c| c == col),
+            columns.contains_key(col),
             "Missing '{col}' in analytics events schema: {columns:?}"
         );
     }

--- a/tests/postgres/postgres.rs
+++ b/tests/postgres/postgres.rs
@@ -71,22 +71,30 @@ async fn it_gets_table_schema() {
     let b = backend().await;
     let result = b.tool_get_table_schema("app", "users").await.expect("failed");
     let schema: serde_json::Value = serde_json::from_str(&result).expect("bad json");
-    let columns: Vec<String> = schema.as_object().expect("object").keys().cloned().collect();
+    let obj = schema.as_object().expect("object");
+    assert!(obj.contains_key("table_name"), "Response should contain table_name");
+    assert!(obj.contains_key("columns"), "Response should contain columns");
+    let columns = obj["columns"].as_object().expect("columns object");
     for col in ["id", "name", "email", "created_at"] {
-        assert!(columns.iter().any(|c| c == col), "Missing '{col}' in: {columns:?}");
+        assert!(columns.contains_key(col), "Missing '{col}' in: {columns:?}");
     }
 }
 
 #[tokio::test]
-async fn it_gets_table_relations() {
+async fn it_gets_table_schema_with_relations() {
     let b = backend().await;
-    let result = b
-        .tool_get_table_schema_with_relations("app", "posts")
-        .await
-        .expect("failed");
+    let result = b.tool_get_table_schema("app", "posts").await.expect("failed");
+    let schema: serde_json::Value = serde_json::from_str(&result).expect("bad json");
+    let columns = schema["columns"].as_object().expect("columns object");
+    assert!(columns.contains_key("user_id"), "Missing 'user_id' column");
+    let user_id = columns["user_id"].as_object().expect("user_id object");
     assert!(
-        result.contains("user_id") || result.contains("users"),
-        "Expected foreign key reference in: {result}"
+        user_id.contains_key("foreign_key"),
+        "Missing 'foreign_key' in user_id column"
+    );
+    assert!(
+        !user_id["foreign_key"].is_null(),
+        "foreign_key should not be null for user_id"
     );
 }
 
@@ -187,10 +195,12 @@ async fn it_gets_table_schema_cross_database() {
     let b = backend().await;
     let result = b.tool_get_table_schema("analytics", "events").await.expect("failed");
     let schema: serde_json::Value = serde_json::from_str(&result).expect("bad json");
-    let columns: Vec<String> = schema.as_object().expect("object").keys().cloned().collect();
+    let obj = schema.as_object().expect("object");
+    assert!(obj.contains_key("table_name"), "Response should contain table_name");
+    let columns = obj["columns"].as_object().expect("columns object");
     for col in ["id", "name", "payload", "created_at"] {
         assert!(
-            columns.iter().any(|c| c == col),
+            columns.contains_key(col),
             "Missing '{col}' in analytics events schema: {columns:?}"
         );
     }

--- a/tests/sqlite/sqlite.rs
+++ b/tests/sqlite/sqlite.rs
@@ -62,22 +62,30 @@ async fn it_gets_table_schema() {
     let b = backend().await;
     let result = b.tool_get_table_schema("main", "users").await.expect("failed");
     let schema: serde_json::Value = serde_json::from_str(&result).expect("bad json");
-    let columns: Vec<String> = schema.as_object().expect("object").keys().cloned().collect();
+    let obj = schema.as_object().expect("object");
+    assert!(obj.contains_key("table_name"), "Response should contain table_name");
+    assert!(obj.contains_key("columns"), "Response should contain columns");
+    let columns = obj["columns"].as_object().expect("columns object");
     for col in ["id", "name", "email", "created_at"] {
-        assert!(columns.iter().any(|c| c == col), "Missing '{col}' in: {columns:?}");
+        assert!(columns.contains_key(col), "Missing '{col}' in: {columns:?}");
     }
 }
 
 #[tokio::test]
-async fn it_gets_table_relations() {
+async fn it_gets_table_schema_with_relations() {
     let b = backend().await;
-    let result = b
-        .tool_get_table_schema_with_relations("main", "posts")
-        .await
-        .expect("failed");
+    let result = b.tool_get_table_schema("main", "posts").await.expect("failed");
+    let schema: serde_json::Value = serde_json::from_str(&result).expect("bad json");
+    let columns = schema["columns"].as_object().expect("columns object");
+    assert!(columns.contains_key("user_id"), "Missing 'user_id' column");
+    let user_id = columns["user_id"].as_object().expect("user_id object");
     assert!(
-        result.contains("user_id") || result.contains("users"),
-        "Expected foreign key reference in: {result}"
+        user_id.contains_key("foreign_key"),
+        "Missing 'foreign_key' in user_id column"
+    );
+    assert!(
+        !user_id["foreign_key"].is_null(),
+        "foreign_key should not be null for user_id"
     );
 }
 


### PR DESCRIPTION
## Summary

- Merged `get_table_schema` and `get_table_schema_with_relations` into a single `get_table_schema` tool that always returns column definitions **and** foreign key relationships
- Reduces tool count from 7 to 6, aligning with the dominant pattern across database MCP servers
- Response format now uses `{table_name, columns}` wrapper with a `foreign_key` field on every column (`null` when no FK exists)

## Breaking Changes

- `get_table_schema` response changed from flat column map to `{table_name, columns}` with `foreign_key` on each column
- `get_table_schema_with_relations` tool has been removed

## Test plan

- [x] `cargo fmt` — clean
- [x] `cargo clippy -- -D warnings` — no warnings
- [x] `cargo test --lib` — 82 unit tests pass
- [x] `./tests/run.sh` — 55 integration tests pass across MariaDB 12, MySQL 9, PostgreSQL 18, SQLite
- [x] No remaining references to `get_table_schema_with_relations` in source or tests
- [x] README and docs updated