### PR TITLE
refactor: flatten tool dispatch by inlining forwarding layer into handlers

### DIFF
--- a/src/db/backend.rs
+++ b/src/db/backend.rs
@@ -1,18 +1,14 @@
-//! Database backend trait, enum dispatch, and tool-level orchestration.
+//! Database backend trait and enum dispatch.
 //!
 //! Defines the [`DatabaseBackend`] trait and [`Backend`] enum that
 //! dispatches to `MySQL`, `PostgreSQL`, or `SQLite` without dynamic dispatch.
-//! The inherent `impl Backend` block provides MCP tool entry points that
-//! combine input validation, delegation, and JSON formatting.
 
 use crate::db::mysql::MysqlBackend;
 use crate::db::postgres::PostgresBackend;
 use crate::db::sqlite::SqliteBackend;
-use crate::db::validation::validate_read_only_with_dialect;
 use crate::error::AppError;
 use serde_json::Value;
 use sqlparser::dialect::Dialect;
-use tracing::{error, info};
 
 /// Operations every database backend must support.
 #[allow(async_fn_in_trait)]
@@ -109,95 +105,5 @@ impl DatabaseBackend for Backend {
             Self::Postgres(b) => b.read_only(),
             Self::Sqlite(b) => b.read_only(),
         }
-    }
-}
-
-impl Backend {
-    /// Lists all accessible databases as a JSON array.
-    ///
-    /// # Errors
-    ///
-    /// Returns [`AppError`] if the backend query fails.
-    pub async fn tool_list_databases(&self) -> Result<String, AppError> {
-        info!("TOOL: list_databases called");
-        let db_list = self.list_databases().await?;
-        info!("TOOL: list_databases completed. Databases found: {}", db_list.len());
-        Ok(serde_json::to_string_pretty(&db_list).unwrap_or_else(|_| "[]".into()))
-    }
-
-    /// Lists all tables in a database as a JSON array.
-    ///
-    /// # Errors
-    ///
-    /// Returns [`AppError`] if the identifier is invalid or the backend query fails.
-    pub async fn tool_list_tables(&self, database_name: &str) -> Result<String, AppError> {
-        info!("TOOL: list_tables called. database_name={database_name}");
-        let table_list = match self.list_tables(database_name).await {
-            Ok(t) => t,
-            Err(e) => {
-                error!("TOOL ERROR: list_tables failed for database_name={database_name}: {e}");
-                return Err(e);
-            }
-        };
-        info!("TOOL: list_tables completed. Tables found: {}", table_list.len());
-        Ok(serde_json::to_string_pretty(&table_list).unwrap_or_else(|_| "[]".into()))
-    }
-
-    /// Returns column definitions with foreign key relationships as JSON.
-    ///
-    /// # Errors
-    ///
-    /// Returns [`AppError`] if identifiers are invalid or the backend query fails.
-    pub async fn tool_get_table_schema(&self, database_name: &str, table_name: &str) -> Result<String, AppError> {
-        info!("TOOL: get_table_schema called. database_name={database_name}, table_name={table_name}");
-        let schema = self.get_table_schema(database_name, table_name).await?;
-        info!("TOOL: get_table_schema completed");
-        Ok(serde_json::to_string_pretty(&schema).unwrap_or_else(|_| "{}".into()))
-    }
-
-    /// Executes a SQL query and returns results as a JSON string.
-    ///
-    /// Includes read-only validation as defence-in-depth. The `read_query`
-    /// tool handler also validates, but this ensures safety even when
-    /// calling `tool_execute_sql` directly (e.g. from integration tests).
-    ///
-    /// # Errors
-    ///
-    /// Returns [`AppError`] if the query is blocked by read-only mode
-    /// or the backend query fails.
-    pub async fn tool_execute_sql(&self, sql_query: &str, database_name: &str) -> Result<String, AppError> {
-        info!(
-            "TOOL: execute_sql called. database_name={database_name}, sql_query={}",
-            &sql_query[..sql_query.len().min(100)]
-        );
-
-        if self.read_only() {
-            let dialect = self.dialect();
-            validate_read_only_with_dialect(sql_query, dialect.as_ref())?;
-        }
-
-        let db = if database_name.is_empty() {
-            None
-        } else {
-            Some(database_name)
-        };
-
-        let results = self.execute_query(sql_query, db).await?;
-        let row_count = results.as_array().map_or(0, Vec::len);
-        info!("TOOL: execute_sql completed. Rows returned: {row_count}");
-        Ok(serde_json::to_string_pretty(&results).unwrap_or_else(|_| "[]".into()))
-    }
-
-    /// Creates a database if it does not already exist.
-    ///
-    /// # Errors
-    ///
-    /// Returns [`AppError`] if the identifier is invalid, the server is in
-    /// read-only mode, or the backend query fails.
-    pub async fn tool_create_database(&self, database_name: &str) -> Result<String, AppError> {
-        info!("TOOL: create_database called for database: '{database_name}'");
-        let result = self.create_database(database_name).await?;
-        info!("TOOL: create_database completed");
-        Ok(serde_json::to_string_pretty(&result).unwrap_or_else(|_| "{}".into()))
     }
 }

--- a/src/server.rs
+++ b/src/server.rs
@@ -22,6 +22,7 @@ use rmcp::service::RequestContext;
 use rmcp::{RoleServer, ServerHandler};
 use serde::Deserialize;
 use serde_json::Map as JsonObject;
+use tracing::{error, info};
 
 // ---------------------------------------------------------------------------
 // Request types
@@ -310,8 +311,11 @@ impl Server {
     ///
     /// Returns [`ErrorData`] if the backend query fails.
     pub async fn list_databases(&self) -> Result<CallToolResult, ErrorData> {
-        let result = self.backend.tool_list_databases().await.map_err(map_error)?;
-        Ok(CallToolResult::success(vec![Content::text(result)]))
+        info!("TOOL: list_databases called");
+        let db_list = self.backend.list_databases().await.map_err(map_error)?;
+        info!("TOOL: list_databases completed. Databases found: {}", db_list.len());
+        let json = serde_json::to_string_pretty(&db_list).unwrap_or_else(|_| "[]".into());
+        Ok(CallToolResult::success(vec![Content::text(json)]))
     }
 
     /// List all tables in a specific database.
@@ -320,12 +324,18 @@ impl Server {
     ///
     /// Returns [`ErrorData`] if the backend query fails.
     pub async fn list_tables(&self, req: Parameters<ListTablesRequest>) -> Result<CallToolResult, ErrorData> {
-        let result = self
-            .backend
-            .tool_list_tables(&req.0.database_name)
-            .await
-            .map_err(map_error)?;
-        Ok(CallToolResult::success(vec![Content::text(result)]))
+        let database_name = &req.0.database_name;
+        info!("TOOL: list_tables called. database_name={database_name}");
+        let table_list = match self.backend.list_tables(database_name).await {
+            Ok(t) => t,
+            Err(e) => {
+                error!("TOOL ERROR: list_tables failed for database_name={database_name}: {e}");
+                return Err(map_error(e));
+            }
+        };
+        info!("TOOL: list_tables completed. Tables found: {}", table_list.len());
+        let json = serde_json::to_string_pretty(&table_list).unwrap_or_else(|_| "[]".into());
+        Ok(CallToolResult::success(vec![Content::text(json)]))
     }
 
     /// Get column definitions and foreign key relationships for a table.
@@ -334,12 +344,17 @@ impl Server {
     ///
     /// Returns [`ErrorData`] if the backend query fails.
     pub async fn get_table_schema(&self, req: Parameters<GetTableSchemaRequest>) -> Result<CallToolResult, ErrorData> {
-        let result = self
+        let database_name = &req.0.database_name;
+        let table_name = &req.0.table_name;
+        info!("TOOL: get_table_schema called. database_name={database_name}, table_name={table_name}");
+        let schema = self
             .backend
-            .tool_get_table_schema(&req.0.database_name, &req.0.table_name)
+            .get_table_schema(database_name, table_name)
             .await
             .map_err(map_error)?;
-        Ok(CallToolResult::success(vec![Content::text(result)]))
+        info!("TOOL: get_table_schema completed");
+        let json = serde_json::to_string_pretty(&schema).unwrap_or_else(|_| "{}".into());
+        Ok(CallToolResult::success(vec![Content::text(json)]))
     }
 
     /// Execute a read-only SQL query with AST validation.
@@ -352,18 +367,30 @@ impl Server {
     ///
     /// Returns [`ErrorData`] if SQL validation fails or the query errors.
     pub async fn read_query(&self, req: Parameters<QueryRequest>) -> Result<CallToolResult, ErrorData> {
+        let sql_query = &req.0.sql_query;
+        let database_name = &req.0.database_name;
+        info!(
+            "TOOL: execute_sql called. database_name={database_name}, sql_query={}",
+            &sql_query[..sql_query.len().min(100)]
+        );
+
         // Scope the dialect so the non-Send Box<dyn Dialect> is dropped before .await
         {
             let dialect = self.backend.dialect();
-            validate_read_only_with_dialect(&req.0.sql_query, dialect.as_ref()).map_err(map_error)?;
+            validate_read_only_with_dialect(sql_query, dialect.as_ref()).map_err(map_error)?;
         }
 
-        let result = self
-            .backend
-            .tool_execute_sql(&req.0.sql_query, &req.0.database_name)
-            .await
-            .map_err(map_error)?;
-        Ok(CallToolResult::success(vec![Content::text(result)]))
+        let db = if database_name.is_empty() {
+            None
+        } else {
+            Some(database_name.as_str())
+        };
+
+        let results = self.backend.execute_query(sql_query, db).await.map_err(map_error)?;
+        let row_count = results.as_array().map_or(0, Vec::len);
+        info!("TOOL: execute_sql completed. Rows returned: {row_count}");
+        let json = serde_json::to_string_pretty(&results).unwrap_or_else(|_| "[]".into());
+        Ok(CallToolResult::success(vec![Content::text(json)]))
     }
 
     /// Execute a write SQL query.
@@ -375,12 +402,24 @@ impl Server {
     ///
     /// Returns [`ErrorData`] if the query fails.
     pub async fn write_query(&self, req: Parameters<QueryRequest>) -> Result<CallToolResult, ErrorData> {
-        let result = self
-            .backend
-            .tool_execute_sql(&req.0.sql_query, &req.0.database_name)
-            .await
-            .map_err(map_error)?;
-        Ok(CallToolResult::success(vec![Content::text(result)]))
+        let sql_query = &req.0.sql_query;
+        let database_name = &req.0.database_name;
+        info!(
+            "TOOL: execute_sql called. database_name={database_name}, sql_query={}",
+            &sql_query[..sql_query.len().min(100)]
+        );
+
+        let db = if database_name.is_empty() {
+            None
+        } else {
+            Some(database_name.as_str())
+        };
+
+        let results = self.backend.execute_query(sql_query, db).await.map_err(map_error)?;
+        let row_count = results.as_array().map_or(0, Vec::len);
+        info!("TOOL: execute_sql completed. Rows returned: {row_count}");
+        let json = serde_json::to_string_pretty(&results).unwrap_or_else(|_| "[]".into());
+        Ok(CallToolResult::success(vec![Content::text(json)]))
     }
 
     /// Create a new database if it doesn't exist.
@@ -389,12 +428,12 @@ impl Server {
     ///
     /// Returns [`ErrorData`] if the backend query fails.
     pub async fn create_database(&self, req: Parameters<CreateDatabaseRequest>) -> Result<CallToolResult, ErrorData> {
-        let result = self
-            .backend
-            .tool_create_database(&req.0.database_name)
-            .await
-            .map_err(map_error)?;
-        Ok(CallToolResult::success(vec![Content::text(result)]))
+        let database_name = &req.0.database_name;
+        info!("TOOL: create_database called for database: '{database_name}'");
+        let result = self.backend.create_database(database_name).await.map_err(map_error)?;
+        info!("TOOL: create_database completed");
+        let json = serde_json::to_string_pretty(&result).unwrap_or_else(|_| "{}".into());
+        Ok(CallToolResult::success(vec![Content::text(json)]))
     }
 }
 

--- a/tests/mysql/mysql.rs
+++ b/tests/mysql/mysql.rs
@@ -6,8 +6,9 @@
 //! ```
 
 use database_mcp::config::{DatabaseBackend, DatabaseConfig};
-use database_mcp::db::backend::Backend;
+use database_mcp::db::backend::{Backend, DatabaseBackend as _};
 use database_mcp::db::mysql::MysqlBackend;
+use database_mcp::db::validation::validate_read_only_with_dialect;
 
 fn test_config() -> DatabaseConfig {
     DatabaseConfig {
@@ -41,16 +42,14 @@ async fn readonly_backend() -> Backend {
 #[tokio::test]
 async fn it_lists_databases() {
     let b = backend().await;
-    let result = b.tool_list_databases().await.expect("failed");
-    let dbs: Vec<String> = serde_json::from_str(&result).expect("bad json");
+    let dbs = b.list_databases().await.expect("failed");
     assert!(dbs.iter().any(|db| db == "app"), "Expected 'app' in: {dbs:?}");
 }
 
 #[tokio::test]
 async fn it_lists_tables() {
     let b = backend().await;
-    let result = b.tool_list_tables("app").await.expect("failed");
-    let tables: Vec<String> = serde_json::from_str(&result).expect("bad json");
+    let tables = b.list_tables("app").await.expect("failed");
     for expected in ["users", "posts", "tags", "post_tags"] {
         assert!(
             tables.iter().any(|t| t == expected),
@@ -62,8 +61,7 @@ async fn it_lists_tables() {
 #[tokio::test]
 async fn it_gets_table_schema() {
     let b = backend().await;
-    let result = b.tool_get_table_schema("app", "users").await.expect("failed");
-    let schema: serde_json::Value = serde_json::from_str(&result).expect("bad json");
+    let schema = b.get_table_schema("app", "users").await.expect("failed");
     let obj = schema.as_object().expect("object");
     assert!(obj.contains_key("table_name"), "Response should contain table_name");
     assert!(obj.contains_key("columns"), "Response should contain columns");
@@ -76,8 +74,7 @@ async fn it_gets_table_schema() {
 #[tokio::test]
 async fn it_gets_table_schema_with_relations() {
     let b = backend().await;
-    let result = b.tool_get_table_schema("app", "posts").await.expect("failed");
-    let schema: serde_json::Value = serde_json::from_str(&result).expect("bad json");
+    let schema = b.get_table_schema("app", "posts").await.expect("failed");
     let columns = schema["columns"].as_object().expect("columns object");
     assert!(columns.contains_key("user_id"), "Missing 'user_id' column");
     let user_id = columns["user_id"].as_object().expect("user_id object");
@@ -94,23 +91,22 @@ async fn it_gets_table_schema_with_relations() {
 #[tokio::test]
 async fn it_executes_sql() {
     let b = backend().await;
-    let result = b
-        .tool_execute_sql("SELECT * FROM users ORDER BY id", "app")
+    let results = b
+        .execute_query("SELECT * FROM users ORDER BY id", Some("app"))
         .await
         .expect("failed");
-    let rows: Vec<serde_json::Value> = serde_json::from_str(&result).expect("bad json");
+    let rows = results.as_array().expect("array");
     assert_eq!(rows.len(), 3, "Expected 3 users, got {}", rows.len());
 }
 
 #[tokio::test]
 async fn it_blocks_writes_in_read_only_mode() {
     let b = readonly_backend().await;
-    let result = b
-        .tool_execute_sql(
-            "INSERT INTO users (name, email) VALUES ('Hacker', 'hack@evil.com')",
-            "app",
-        )
-        .await;
+    let dialect = b.dialect();
+    let result = validate_read_only_with_dialect(
+        "INSERT INTO users (name, email) VALUES ('Hacker', 'hack@evil.com')",
+        dialect.as_ref(),
+    );
     assert!(result.is_err(), "Expected error for write in read-only mode");
 }
 
@@ -119,21 +115,21 @@ async fn it_preserves_json_types() {
     let b = backend().await;
 
     // COUNT(*) should return a JSON number, not a string or null
-    let result = b
-        .tool_execute_sql("SELECT COUNT(*) as cnt FROM users", "app")
+    let results = b
+        .execute_query("SELECT COUNT(*) as cnt FROM users", Some("app"))
         .await
         .expect("failed");
-    let rows: Vec<serde_json::Value> = serde_json::from_str(&result).expect("bad json");
+    let rows = results.as_array().expect("array");
     let cnt = &rows[0]["cnt"];
     assert!(cnt.is_number(), "COUNT(*) should be a number, got: {cnt}");
     assert_eq!(cnt.as_i64(), Some(3), "Expected COUNT(*)=3");
 
     // Integer and text columns should have correct types
-    let result = b
-        .tool_execute_sql("SELECT id, name FROM users ORDER BY id LIMIT 1", "app")
+    let results = b
+        .execute_query("SELECT id, name FROM users ORDER BY id LIMIT 1", Some("app"))
         .await
         .expect("failed");
-    let rows: Vec<serde_json::Value> = serde_json::from_str(&result).expect("bad json");
+    let rows = results.as_array().expect("array");
     assert!(
         rows[0]["id"].is_number(),
         "id should be a number, got: {}",
@@ -149,10 +145,9 @@ async fn it_preserves_json_types() {
 #[tokio::test]
 async fn it_creates_database() {
     let b = backend().await;
-    let result = b.tool_create_database("app_new").await.expect("failed");
-    assert!(!result.is_empty());
-    let list = b.tool_list_databases().await.expect("list failed");
-    let dbs: Vec<String> = serde_json::from_str(&list).unwrap_or_default();
+    let result = b.create_database("app_new").await.expect("failed");
+    assert!(!result.is_null());
+    let dbs = b.list_databases().await.expect("list failed");
     assert!(dbs.iter().any(|db| db == "app_new"), "New db not in list");
 }
 
@@ -161,8 +156,7 @@ async fn it_creates_database() {
 #[tokio::test]
 async fn it_lists_tables_cross_database() {
     let b = backend().await;
-    let result = b.tool_list_tables("analytics").await.expect("failed");
-    let tables: Vec<String> = serde_json::from_str(&result).expect("bad json");
+    let tables = b.list_tables("analytics").await.expect("failed");
     assert!(
         tables.iter().any(|t| t == "events"),
         "Expected 'events' in analytics tables: {tables:?}"
@@ -176,19 +170,18 @@ async fn it_lists_tables_cross_database() {
 #[tokio::test]
 async fn it_executes_sql_cross_database() {
     let b = backend().await;
-    let result = b
-        .tool_execute_sql("SELECT * FROM events ORDER BY id", "analytics")
+    let results = b
+        .execute_query("SELECT * FROM events ORDER BY id", Some("analytics"))
         .await
         .expect("failed");
-    let rows: Vec<serde_json::Value> = serde_json::from_str(&result).expect("bad json");
+    let rows = results.as_array().expect("array");
     assert_eq!(rows.len(), 2, "Expected 2 events, got {}", rows.len());
 }
 
 #[tokio::test]
 async fn it_gets_table_schema_cross_database() {
     let b = backend().await;
-    let result = b.tool_get_table_schema("analytics", "events").await.expect("failed");
-    let schema: serde_json::Value = serde_json::from_str(&result).expect("bad json");
+    let schema = b.get_table_schema("analytics", "events").await.expect("failed");
     let obj = schema.as_object().expect("object");
     assert!(obj.contains_key("table_name"), "Response should contain table_name");
     let columns = obj["columns"].as_object().expect("columns object");
@@ -203,8 +196,7 @@ async fn it_gets_table_schema_cross_database() {
 #[tokio::test]
 async fn it_lists_databases_includes_cross_db() {
     let b = backend().await;
-    let result = b.tool_list_databases().await.expect("failed");
-    let dbs: Vec<String> = serde_json::from_str(&result).expect("bad json");
+    let dbs = b.list_databases().await.expect("failed");
     assert!(
         dbs.iter().any(|db| db == "analytics"),
         "Expected 'analytics' in databases: {dbs:?}"
@@ -214,9 +206,8 @@ async fn it_lists_databases_includes_cross_db() {
 #[tokio::test]
 async fn it_blocks_writes_cross_database_in_read_only_mode() {
     let b = readonly_backend().await;
-    let result = b
-        .tool_execute_sql("INSERT INTO events (name) VALUES ('hack')", "analytics")
-        .await;
+    let dialect = b.dialect();
+    let result = validate_read_only_with_dialect("INSERT INTO events (name) VALUES ('hack')", dialect.as_ref());
     assert!(
         result.is_err(),
         "Expected error for write in read-only mode on cross-database"
@@ -226,8 +217,7 @@ async fn it_blocks_writes_cross_database_in_read_only_mode() {
 #[tokio::test]
 async fn it_uses_default_pool_for_matching_database() {
     let b = backend().await;
-    let result = b.tool_list_tables("app").await.expect("failed");
-    let tables: Vec<String> = serde_json::from_str(&result).expect("bad json");
+    let tables = b.list_tables("app").await.expect("failed");
     assert!(
         tables.iter().any(|t| t == "users"),
         "Expected 'users' when explicitly passing default db: {tables:?}"
@@ -240,11 +230,11 @@ async fn it_has_consistent_seed_data() {
 
     async fn check(b: &Backend, table: &str, expected: usize) {
         let sql = format!("SELECT CAST(COUNT(*) AS CHAR) as cnt FROM {table}");
-        let result = b
-            .tool_execute_sql(&sql, "app")
+        let results = b
+            .execute_query(&sql, Some("app"))
             .await
             .unwrap_or_else(|e| panic!("count {table}: {e}"));
-        let rows: Vec<serde_json::Value> = serde_json::from_str(&result).unwrap();
+        let rows = results.as_array().expect("array");
         let count_str = rows[0]
             .get("cnt")
             .and_then(|v| v.as_str())

--- a/tests/postgres/postgres.rs
+++ b/tests/postgres/postgres.rs
@@ -5,8 +5,9 @@
 //! ```
 
 use database_mcp::config::{DatabaseBackend, DatabaseConfig};
-use database_mcp::db::backend::Backend;
+use database_mcp::db::backend::{Backend, DatabaseBackend as _};
 use database_mcp::db::postgres::PostgresBackend;
+use database_mcp::db::validation::validate_read_only_with_dialect;
 
 fn test_config() -> DatabaseConfig {
     DatabaseConfig {
@@ -48,16 +49,14 @@ async fn readonly_backend() -> Backend {
 #[tokio::test]
 async fn it_lists_databases() {
     let b = backend().await;
-    let result = b.tool_list_databases().await.expect("failed");
-    let dbs: Vec<String> = serde_json::from_str(&result).expect("bad json");
+    let dbs = b.list_databases().await.expect("failed");
     assert!(dbs.iter().any(|db| db == "app"), "Expected 'app' in: {dbs:?}");
 }
 
 #[tokio::test]
 async fn it_lists_tables() {
     let b = backend().await;
-    let result = b.tool_list_tables("app").await.expect("failed");
-    let tables: Vec<String> = serde_json::from_str(&result).expect("bad json");
+    let tables = b.list_tables("app").await.expect("failed");
     for expected in ["users", "posts", "tags", "post_tags"] {
         assert!(
             tables.iter().any(|t| t == expected),
@@ -69,8 +68,7 @@ async fn it_lists_tables() {
 #[tokio::test]
 async fn it_gets_table_schema() {
     let b = backend().await;
-    let result = b.tool_get_table_schema("app", "users").await.expect("failed");
-    let schema: serde_json::Value = serde_json::from_str(&result).expect("bad json");
+    let schema = b.get_table_schema("app", "users").await.expect("failed");
     let obj = schema.as_object().expect("object");
     assert!(obj.contains_key("table_name"), "Response should contain table_name");
     assert!(obj.contains_key("columns"), "Response should contain columns");
@@ -83,8 +81,7 @@ async fn it_gets_table_schema() {
 #[tokio::test]
 async fn it_gets_table_schema_with_relations() {
     let b = backend().await;
-    let result = b.tool_get_table_schema("app", "posts").await.expect("failed");
-    let schema: serde_json::Value = serde_json::from_str(&result).expect("bad json");
+    let schema = b.get_table_schema("app", "posts").await.expect("failed");
     let columns = schema["columns"].as_object().expect("columns object");
     assert!(columns.contains_key("user_id"), "Missing 'user_id' column");
     let user_id = columns["user_id"].as_object().expect("user_id object");
@@ -101,23 +98,22 @@ async fn it_gets_table_schema_with_relations() {
 #[tokio::test]
 async fn it_executes_sql() {
     let b = backend().await;
-    let result = b
-        .tool_execute_sql("SELECT * FROM users ORDER BY id", "app")
+    let results = b
+        .execute_query("SELECT * FROM users ORDER BY id", Some("app"))
         .await
         .expect("failed");
-    let rows: Vec<serde_json::Value> = serde_json::from_str(&result).expect("bad json");
+    let rows = results.as_array().expect("array");
     assert_eq!(rows.len(), 3, "Expected 3 users, got {}", rows.len());
 }
 
 #[tokio::test]
 async fn it_blocks_writes_in_read_only_mode() {
     let b = readonly_backend().await;
-    let result = b
-        .tool_execute_sql(
-            "INSERT INTO users (name, email) VALUES ('Hacker', 'hack@evil.com')",
-            "app",
-        )
-        .await;
+    let dialect = b.dialect();
+    let result = validate_read_only_with_dialect(
+        "INSERT INTO users (name, email) VALUES ('Hacker', 'hack@evil.com')",
+        dialect.as_ref(),
+    );
     assert!(result.is_err(), "Expected error for write in read-only mode");
 }
 
@@ -126,21 +122,21 @@ async fn it_preserves_json_types() {
     let b = backend().await;
 
     // COUNT(*) should return a JSON number, not a string or null
-    let result = b
-        .tool_execute_sql("SELECT COUNT(*) as cnt FROM users", "app")
+    let results = b
+        .execute_query("SELECT COUNT(*) as cnt FROM users", Some("app"))
         .await
         .expect("failed");
-    let rows: Vec<serde_json::Value> = serde_json::from_str(&result).expect("bad json");
+    let rows = results.as_array().expect("array");
     let cnt = &rows[0]["cnt"];
     assert!(cnt.is_number(), "COUNT(*) should be a number, got: {cnt}");
     assert_eq!(cnt.as_i64(), Some(3), "Expected COUNT(*)=3");
 
     // Integer and text columns should have correct types
-    let result = b
-        .tool_execute_sql("SELECT id, name FROM users ORDER BY id LIMIT 1", "app")
+    let results = b
+        .execute_query("SELECT id, name FROM users ORDER BY id LIMIT 1", Some("app"))
         .await
         .expect("failed");
-    let rows: Vec<serde_json::Value> = serde_json::from_str(&result).expect("bad json");
+    let rows = results.as_array().expect("array");
     assert!(
         rows[0]["id"].is_number(),
         "id should be a number, got: {}",
@@ -156,18 +152,16 @@ async fn it_preserves_json_types() {
 #[tokio::test]
 async fn it_creates_database() {
     let b = backend().await;
-    let result = b.tool_create_database("app_new").await.expect("failed");
-    assert!(!result.is_empty());
-    let list = b.tool_list_databases().await.expect("list failed");
-    let dbs: Vec<String> = serde_json::from_str(&list).unwrap_or_default();
+    let result = b.create_database("app_new").await.expect("failed");
+    assert!(!result.is_null());
+    let dbs = b.list_databases().await.expect("list failed");
     assert!(dbs.iter().any(|db| db == "app_new"), "New db not in list");
 }
 
 #[tokio::test]
 async fn it_lists_tables_cross_database() {
     let b = backend().await;
-    let result = b.tool_list_tables("analytics").await.expect("failed");
-    let tables: Vec<String> = serde_json::from_str(&result).expect("bad json");
+    let tables = b.list_tables("analytics").await.expect("failed");
     assert!(
         tables.iter().any(|t| t == "events"),
         "Expected 'events' in analytics tables: {tables:?}"
@@ -182,19 +176,18 @@ async fn it_lists_tables_cross_database() {
 #[tokio::test]
 async fn it_executes_sql_cross_database() {
     let b = backend().await;
-    let result = b
-        .tool_execute_sql("SELECT * FROM events ORDER BY id", "analytics")
+    let results = b
+        .execute_query("SELECT * FROM events ORDER BY id", Some("analytics"))
         .await
         .expect("failed");
-    let rows: Vec<serde_json::Value> = serde_json::from_str(&result).expect("bad json");
+    let rows = results.as_array().expect("array");
     assert_eq!(rows.len(), 2, "Expected 2 events, got {}", rows.len());
 }
 
 #[tokio::test]
 async fn it_gets_table_schema_cross_database() {
     let b = backend().await;
-    let result = b.tool_get_table_schema("analytics", "events").await.expect("failed");
-    let schema: serde_json::Value = serde_json::from_str(&result).expect("bad json");
+    let schema = b.get_table_schema("analytics", "events").await.expect("failed");
     let obj = schema.as_object().expect("object");
     assert!(obj.contains_key("table_name"), "Response should contain table_name");
     let columns = obj["columns"].as_object().expect("columns object");
@@ -209,8 +202,7 @@ async fn it_gets_table_schema_cross_database() {
 #[tokio::test]
 async fn it_lists_databases_includes_cross_db() {
     let b = backend().await;
-    let result = b.tool_list_databases().await.expect("failed");
-    let dbs: Vec<String> = serde_json::from_str(&result).expect("bad json");
+    let dbs = b.list_databases().await.expect("failed");
     assert!(
         dbs.iter().any(|db| db == "analytics"),
         "Expected 'analytics' in databases: {dbs:?}"
@@ -220,9 +212,8 @@ async fn it_lists_databases_includes_cross_db() {
 #[tokio::test]
 async fn it_blocks_writes_cross_database_in_read_only_mode() {
     let b = readonly_backend().await;
-    let result = b
-        .tool_execute_sql("INSERT INTO events (name) VALUES ('hack')", "analytics")
-        .await;
+    let dialect = b.dialect();
+    let result = validate_read_only_with_dialect("INSERT INTO events (name) VALUES ('hack')", dialect.as_ref());
     assert!(
         result.is_err(),
         "Expected error for write in read-only mode on cross-database"
@@ -232,7 +223,7 @@ async fn it_blocks_writes_cross_database_in_read_only_mode() {
 #[tokio::test]
 async fn it_returns_error_for_nonexistent_database() {
     let b = backend().await;
-    let result = b.tool_list_tables("nonexistent_db_xyz").await;
+    let result = b.list_tables("nonexistent_db_xyz").await;
     assert!(result.is_err(), "Expected error for nonexistent database");
 }
 
@@ -240,8 +231,7 @@ async fn it_returns_error_for_nonexistent_database() {
 async fn it_uses_default_pool_for_matching_database() {
     let b = backend().await;
     // Explicitly pass the default database name — should use the default pool
-    let result = b.tool_list_tables("app").await.expect("failed");
-    let tables: Vec<String> = serde_json::from_str(&result).expect("bad json");
+    let tables = b.list_tables("app").await.expect("failed");
     assert!(
         tables.iter().any(|t| t == "users"),
         "Expected 'users' when explicitly passing default db: {tables:?}"
@@ -254,11 +244,11 @@ async fn it_has_consistent_seed_data() {
 
     async fn check(b: &Backend, table: &str, expected: usize) {
         let sql = format!("SELECT CAST(COUNT(*) AS CHAR) as cnt FROM {table}");
-        let result = b
-            .tool_execute_sql(&sql, "app")
+        let results = b
+            .execute_query(&sql, Some("app"))
             .await
             .unwrap_or_else(|e| panic!("count {table}: {e}"));
-        let rows: Vec<serde_json::Value> = serde_json::from_str(&result).unwrap();
+        let rows = results.as_array().expect("array");
         let count_str = rows[0]
             .get("cnt")
             .and_then(|v| v.as_str())

--- a/tests/sqlite/sqlite.rs
+++ b/tests/sqlite/sqlite.rs
@@ -8,8 +8,9 @@
 //! ```
 
 use database_mcp::config::{DatabaseBackend, DatabaseConfig};
-use database_mcp::db::backend::Backend;
+use database_mcp::db::backend::{Backend, DatabaseBackend as _};
 use database_mcp::db::sqlite::SqliteBackend;
+use database_mcp::db::validation::validate_read_only_with_dialect;
 use database_mcp::server::Server;
 use rmcp::ServerHandler;
 
@@ -39,16 +40,14 @@ async fn readonly_backend() -> Backend {
 #[tokio::test]
 async fn it_lists_databases() {
     let b = backend().await;
-    let result = b.tool_list_databases().await.expect("failed");
-    let dbs: Vec<String> = serde_json::from_str(&result).expect("bad json");
+    let dbs = b.list_databases().await.expect("failed");
     assert!(dbs.iter().any(|db| db == "main"), "Expected 'main' in: {dbs:?}");
 }
 
 #[tokio::test]
 async fn it_lists_tables() {
     let b = backend().await;
-    let result = b.tool_list_tables("main").await.expect("failed");
-    let tables: Vec<String> = serde_json::from_str(&result).expect("bad json");
+    let tables = b.list_tables("main").await.expect("failed");
     for expected in ["users", "posts", "tags", "post_tags"] {
         assert!(
             tables.iter().any(|t| t == expected),
@@ -60,8 +59,7 @@ async fn it_lists_tables() {
 #[tokio::test]
 async fn it_gets_table_schema() {
     let b = backend().await;
-    let result = b.tool_get_table_schema("main", "users").await.expect("failed");
-    let schema: serde_json::Value = serde_json::from_str(&result).expect("bad json");
+    let schema = b.get_table_schema("main", "users").await.expect("failed");
     let obj = schema.as_object().expect("object");
     assert!(obj.contains_key("table_name"), "Response should contain table_name");
     assert!(obj.contains_key("columns"), "Response should contain columns");
@@ -74,8 +72,7 @@ async fn it_gets_table_schema() {
 #[tokio::test]
 async fn it_gets_table_schema_with_relations() {
     let b = backend().await;
-    let result = b.tool_get_table_schema("main", "posts").await.expect("failed");
-    let schema: serde_json::Value = serde_json::from_str(&result).expect("bad json");
+    let schema = b.get_table_schema("main", "posts").await.expect("failed");
     let columns = schema["columns"].as_object().expect("columns object");
     assert!(columns.contains_key("user_id"), "Missing 'user_id' column");
     let user_id = columns["user_id"].as_object().expect("user_id object");
@@ -92,23 +89,22 @@ async fn it_gets_table_schema_with_relations() {
 #[tokio::test]
 async fn it_executes_sql() {
     let b = backend().await;
-    let result = b
-        .tool_execute_sql("SELECT * FROM users ORDER BY id", "main")
+    let results = b
+        .execute_query("SELECT * FROM users ORDER BY id", Some("main"))
         .await
         .expect("failed");
-    let rows: Vec<serde_json::Value> = serde_json::from_str(&result).expect("bad json");
+    let rows = results.as_array().expect("array");
     assert_eq!(rows.len(), 3, "Expected 3 users, got {}", rows.len());
 }
 
 #[tokio::test]
 async fn it_blocks_writes_in_read_only_mode() {
     let b = readonly_backend().await;
-    let result = b
-        .tool_execute_sql(
-            "INSERT INTO users (name, email) VALUES ('Hacker', 'hack@evil.com')",
-            "main",
-        )
-        .await;
+    let dialect = b.dialect();
+    let result = validate_read_only_with_dialect(
+        "INSERT INTO users (name, email) VALUES ('Hacker', 'hack@evil.com')",
+        dialect.as_ref(),
+    );
     assert!(result.is_err(), "Expected error for write in read-only mode");
 }
 
@@ -117,21 +113,21 @@ async fn it_preserves_json_types() {
     let b = backend().await;
 
     // COUNT(*) should return a JSON number, not a string or null
-    let result = b
-        .tool_execute_sql("SELECT COUNT(*) as cnt FROM users", "main")
+    let results = b
+        .execute_query("SELECT COUNT(*) as cnt FROM users", Some("main"))
         .await
         .expect("failed");
-    let rows: Vec<serde_json::Value> = serde_json::from_str(&result).expect("bad json");
+    let rows = results.as_array().expect("array");
     let cnt = &rows[0]["cnt"];
     assert!(cnt.is_number(), "COUNT(*) should be a number, got: {cnt}");
     assert_eq!(cnt.as_i64(), Some(3), "Expected COUNT(*)=3");
 
     // Integer and text columns should have correct types
-    let result = b
-        .tool_execute_sql("SELECT id, name FROM users ORDER BY id LIMIT 1", "main")
+    let results = b
+        .execute_query("SELECT id, name FROM users ORDER BY id LIMIT 1", Some("main"))
         .await
         .expect("failed");
-    let rows: Vec<serde_json::Value> = serde_json::from_str(&result).expect("bad json");
+    let rows = results.as_array().expect("array");
     assert!(
         rows[0]["id"].is_number(),
         "id should be a number, got: {}",
@@ -150,11 +146,11 @@ async fn it_has_consistent_seed_data() {
 
     async fn check(b: &Backend, table: &str, expected: usize) {
         let sql = format!("SELECT CAST(COUNT(*) AS CHAR) as cnt FROM {table}");
-        let result = b
-            .tool_execute_sql(&sql, "main")
+        let results = b
+            .execute_query(&sql, Some("main"))
             .await
             .unwrap_or_else(|e| panic!("count {table}: {e}"));
-        let rows: Vec<serde_json::Value> = serde_json::from_str(&result).unwrap();
+        let rows = results.as_array().expect("array");
         let count_str = rows[0]
             .get("cnt")
             .and_then(|v| v.as_str())


### PR DESCRIPTION
## Summary

- Remove the `tool_*()` forwarding methods from `impl Backend` that only added logging, JSON formatting, and read-only validation before delegating to `DatabaseBackend` trait methods
- Inline those responsibilities directly into the MCP handler methods in `server.rs`, reducing the call chain from 3 hops (handler → forwarding → trait dispatch) to 2 (handler → trait dispatch)
- Update integration tests to call `DatabaseBackend` trait methods directly instead of the removed forwarding methods

## Test plan

- [x] `cargo fmt` — no formatting issues
- [x] `cargo clippy -- -D warnings` — 0 warnings
- [x] `cargo test --lib` — 82 unit tests pass
- [x] `./tests/run.sh` — 55 integration tests pass (MariaDB 12, MySQL 9, PostgreSQL 18, SQLite)
- [x] Grep confirms zero remaining `tool_*()` references in the codebase