### PR TITLE
refactor: introduce SQLite-local request types without database_name

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -545,6 +545,7 @@ dependencies = [
  "database-mcp-server",
  "database-mcp-sql",
  "rmcp",
+ "serde",
  "serde_json",
  "sqlparser",
  "sqlx",

--- a/crates/sqlite/Cargo.toml
+++ b/crates/sqlite/Cargo.toml
@@ -11,6 +11,7 @@ database-mcp-config = { workspace = true }
 database-mcp-server = { workspace = true }
 database-mcp-sql = { workspace = true }
 rmcp = { workspace = true }
+serde = { workspace = true }
 serde_json = { workspace = true }
 sqlparser = { workspace = true }
 sqlx = { workspace = true, features = ["sqlite"] }

--- a/crates/sqlite/src/lib.rs
+++ b/crates/sqlite/src/lib.rs
@@ -8,5 +8,6 @@ mod handler;
 mod operations;
 mod schema;
 mod tools;
+mod types;
 
 pub use adapter::SqliteAdapter;

--- a/crates/sqlite/src/operations.rs
+++ b/crates/sqlite/src/operations.rs
@@ -8,12 +8,12 @@ use sqlx_to_json::RowExt;
 use super::SqliteAdapter;
 
 impl SqliteAdapter {
-    /// Lists all tables in a database.
+    /// Lists all tables in the connected database.
     ///
     /// # Errors
     ///
     /// Returns [`AppError`] if the identifier is invalid or the query fails.
-    pub async fn list_tables(&self, _database: &str) -> Result<Vec<String>, AppError> {
+    pub async fn list_tables(&self) -> Result<Vec<String>, AppError> {
         let rows: Vec<(String,)> = sqlx::query_as(
             "SELECT name FROM sqlite_master WHERE type='table' AND name NOT LIKE 'sqlite_%' ORDER BY name",
         )
@@ -28,7 +28,7 @@ impl SqliteAdapter {
     /// # Errors
     ///
     /// Returns [`AppError`] if the query fails.
-    pub async fn execute_query(&self, sql: &str, _database: Option<&str>) -> Result<Value, AppError> {
+    pub async fn execute_query(&self, sql: &str) -> Result<Value, AppError> {
         let rows: Vec<SqliteRow> = sqlx::query(sql)
             .fetch_all(&self.pool)
             .await

--- a/crates/sqlite/src/schema.rs
+++ b/crates/sqlite/src/schema.rs
@@ -16,7 +16,7 @@ impl SqliteAdapter {
     /// # Errors
     ///
     /// Returns [`AppError`] if validation fails or the query errors.
-    pub async fn get_table_schema(&self, _database: &str, table: &str) -> Result<Value, AppError> {
+    pub async fn get_table_schema(&self, table: &str) -> Result<Value, AppError> {
         validate_identifier(table)?;
 
         // 1. Get basic schema

--- a/crates/sqlite/src/tools.rs
+++ b/crates/sqlite/src/tools.rs
@@ -4,7 +4,7 @@
 //! on [`SqliteAdapter`], eliminating manual [`ToolBase`] and
 //! [`AsyncTool`] implementations.
 
-use database_mcp_server::types::{GetTableSchemaRequest, ListTablesRequest, QueryRequest};
+use super::types::{GetTableSchemaRequest, QueryRequest};
 use rmcp::handler::server::tool::ToolRouter;
 use rmcp::handler::server::wrapper::Parameters;
 use rmcp::model::{CallToolResult, Content, ErrorData};
@@ -33,8 +33,7 @@ impl SqliteAdapter {
 
 #[rmcp::tool_router]
 impl SqliteAdapter {
-    /// List all tables in a specific database.
-    /// Requires `database_name` from `list_databases`.
+    /// List all tables in the connected `SQLite` database.
     #[tool(
         name = "list_tables",
         annotations(
@@ -44,16 +43,13 @@ impl SqliteAdapter {
             open_world_hint = false
         )
     )]
-    async fn tool_list_tables(
-        &self,
-        Parameters(request): Parameters<ListTablesRequest>,
-    ) -> Result<CallToolResult, ErrorData> {
-        let result = self.list_tables(&request.database_name).await?;
+    async fn tool_list_tables(&self) -> Result<CallToolResult, ErrorData> {
+        let result = self.list_tables().await?;
         Ok(CallToolResult::success(vec![Content::json(result)?]))
     }
 
     /// Get column definitions (type, nullable, key, default) and foreign key
-    /// relationships for a table. Requires `database_name` and `table_name`.
+    /// relationships for a table.
     #[tool(
         name = "get_table_schema",
         annotations(
@@ -67,9 +63,7 @@ impl SqliteAdapter {
         &self,
         Parameters(request): Parameters<GetTableSchemaRequest>,
     ) -> Result<CallToolResult, ErrorData> {
-        let result = self
-            .get_table_schema(&request.database_name, &request.table_name)
-            .await?;
+        let result = self.get_table_schema(&request.table_name).await?;
         Ok(CallToolResult::success(vec![Content::json(result)?]))
     }
 
@@ -89,8 +83,7 @@ impl SqliteAdapter {
     ) -> Result<CallToolResult, ErrorData> {
         validate_read_only_with_dialect(&request.query, &sqlparser::dialect::SQLiteDialect {})?;
 
-        let db = Some(request.database_name.trim()).filter(|s| !s.is_empty());
-        let result = self.execute_query(&request.query, db).await?;
+        let result = self.execute_query(&request.query).await?;
         Ok(CallToolResult::success(vec![Content::json(result)?]))
     }
 
@@ -108,8 +101,7 @@ impl SqliteAdapter {
         &self,
         Parameters(request): Parameters<QueryRequest>,
     ) -> Result<CallToolResult, ErrorData> {
-        let db = Some(request.database_name.trim()).filter(|s| !s.is_empty());
-        let result = self.execute_query(&request.query, db).await?;
+        let result = self.execute_query(&request.query).await?;
         Ok(CallToolResult::success(vec![Content::json(result)?]))
     }
 }

--- a/crates/sqlite/src/types.rs
+++ b/crates/sqlite/src/types.rs
@@ -1,0 +1,23 @@
+//! SQLite-specific MCP tool request types.
+//!
+//! Unlike `MySQL` and `PostgreSQL`, `SQLite` operates on a single file and
+//! has no database selection. These types omit the `database_name`
+//! field present in the shared server types.
+
+use rmcp::schemars;
+use rmcp::schemars::JsonSchema;
+use serde::Deserialize;
+
+/// Request to get a table's schema.
+#[derive(Debug, Default, Deserialize, JsonSchema)]
+pub struct GetTableSchemaRequest {
+    #[schemars(description = "The table name to inspect. Use list_tables first to see available tables.")]
+    pub table_name: String,
+}
+
+/// Request for `read_query` and `write_query` tools.
+#[derive(Debug, Default, Deserialize, JsonSchema)]
+pub struct QueryRequest {
+    #[schemars(description = "The SQL query to execute.")]
+    pub query: String,
+}

--- a/tests/sqlite/sqlite.rs
+++ b/tests/sqlite/sqlite.rs
@@ -38,7 +38,7 @@ async fn readonly_backend() -> SqliteAdapter {
 #[tokio::test]
 async fn it_lists_tables() {
     let b = backend().await;
-    let tables = b.list_tables("main").await.expect("failed");
+    let tables = b.list_tables().await.expect("failed");
     for expected in ["users", "posts", "tags", "post_tags"] {
         assert!(
             tables.iter().any(|t| t == expected),
@@ -50,7 +50,7 @@ async fn it_lists_tables() {
 #[tokio::test]
 async fn it_gets_table_schema() {
     let b = backend().await;
-    let schema = b.get_table_schema("main", "users").await.expect("failed");
+    let schema = b.get_table_schema("users").await.expect("failed");
     let obj = schema.as_object().expect("object");
     assert!(obj.contains_key("table_name"), "Response should contain table_name");
     assert!(obj.contains_key("columns"), "Response should contain columns");
@@ -63,7 +63,7 @@ async fn it_gets_table_schema() {
 #[tokio::test]
 async fn it_gets_table_schema_with_relations() {
     let b = backend().await;
-    let schema = b.get_table_schema("main", "posts").await.expect("failed");
+    let schema = b.get_table_schema("posts").await.expect("failed");
     let columns = schema["columns"].as_object().expect("columns object");
     assert!(columns.contains_key("user_id"), "Missing 'user_id' column");
     let user_id = columns["user_id"].as_object().expect("user_id object");
@@ -81,7 +81,7 @@ async fn it_gets_table_schema_with_relations() {
 async fn it_executes_sql() {
     let b = backend().await;
     let results = b
-        .execute_query("SELECT * FROM users ORDER BY id", Some("main"))
+        .execute_query("SELECT * FROM users ORDER BY id")
         .await
         .expect("failed");
     let rows = results.as_array().expect("array");
@@ -105,7 +105,7 @@ async fn it_preserves_json_types() {
 
     // COUNT(*) should return a JSON number, not a string or null
     let results = b
-        .execute_query("SELECT COUNT(*) as cnt FROM users", Some("main"))
+        .execute_query("SELECT COUNT(*) as cnt FROM users")
         .await
         .expect("failed");
     let rows = results.as_array().expect("array");
@@ -115,7 +115,7 @@ async fn it_preserves_json_types() {
 
     // Integer and text columns should have correct types
     let results = b
-        .execute_query("SELECT id, name FROM users ORDER BY id LIMIT 1", Some("main"))
+        .execute_query("SELECT id, name FROM users ORDER BY id LIMIT 1")
         .await
         .expect("failed");
     let rows = results.as_array().expect("array");
@@ -138,7 +138,7 @@ async fn it_has_consistent_seed_data() {
     async fn check(b: &SqliteAdapter, table: &str, expected: usize) {
         let sql = format!("SELECT CAST(COUNT(*) AS CHAR) as cnt FROM {table}");
         let results = b
-            .execute_query(&sql, Some("main"))
+            .execute_query(&sql)
             .await
             .unwrap_or_else(|e| panic!("count {table}: {e}"));
         let rows = results.as_array().expect("array");


### PR DESCRIPTION
## Summary

- Creates a `types.rs` module in the SQLite crate with `GetTableSchemaRequest` and `QueryRequest` that omit the irrelevant `database_name` field
- Removes unused `_database` parameters from `list_tables()`, `execute_query()`, and `get_table_schema()` in the SQLite backend
- Updates `tool_list_tables` to take no parameters (matching the `list_databases` pattern in other backends)
- Updates integration tests to match new function signatures

## Test plan

- [x] `cargo fmt` — no formatting issues
- [x] `cargo clippy -- -D warnings` — no lint warnings
- [x] `cargo test --workspace --lib --bins` ��� 84 unit tests pass
- [x] `./tests/run.sh` — 54 integration tests pass across all 4 backends (MariaDB, MySQL, PostgreSQL, SQLite)