### PR TITLE
refactor: replace schemars description attributes with doc comments

### DIFF
--- a/crates/server/src/types.rs
+++ b/crates/server/src/types.rs
@@ -9,41 +9,31 @@ use serde::Deserialize;
 /// Request to list tables in a database.
 #[derive(Debug, Default, Deserialize, JsonSchema)]
 pub struct ListTablesRequest {
-    #[schemars(
-        description = "The database name to list tables from. Required. Use list_databases first to see available databases."
-    )]
+    /// The database name to list tables from. Required. Use `list_databases` first to see available databases.
     pub database_name: String,
 }
 
 /// Request to get a table's schema.
 #[derive(Debug, Default, Deserialize, JsonSchema)]
 pub struct GetTableSchemaRequest {
-    #[schemars(
-        description = "The database name containing the table. Required. Use list_databases first to see available databases."
-    )]
+    /// The database name containing the table. Required. Use `list_databases` first to see available databases.
     pub database_name: String,
-    #[schemars(
-        description = "The table name to inspect. Use list_tables first to see available tables in the database."
-    )]
+    /// The table name to inspect. Use `list_tables` first to see available tables in the database.
     pub table_name: String,
 }
 
 /// Request for `read_query` and `write_query` tools.
 #[derive(Debug, Default, Deserialize, JsonSchema)]
 pub struct QueryRequest {
-    #[schemars(description = "The SQL query to execute.")]
+    /// The SQL query to execute.
     pub query: String,
-    #[schemars(
-        description = "The database to run the query against. Required. Use list_databases first to see available databases."
-    )]
+    /// The database to run the query against. Required. Use `list_databases` first to see available databases.
     pub database_name: String,
 }
 
 /// Request to create a database.
 #[derive(Debug, Default, Deserialize, JsonSchema)]
 pub struct CreateDatabaseRequest {
-    #[schemars(
-        description = "Name of the database to create. Must contain only alphanumeric characters and underscores."
-    )]
+    /// Name of the database to create. Must contain only alphanumeric characters and underscores.
     pub database_name: String,
 }

--- a/crates/sqlite/src/types.rs
+++ b/crates/sqlite/src/types.rs
@@ -11,13 +11,13 @@ use serde::Deserialize;
 /// Request to get a table's schema.
 #[derive(Debug, Default, Deserialize, JsonSchema)]
 pub struct GetTableSchemaRequest {
-    #[schemars(description = "The table name to inspect. Use list_tables first to see available tables.")]
+    /// The table name to inspect. Use `list_tables` first to see available tables.
     pub table_name: String,
 }
 
 /// Request for `read_query` and `write_query` tools.
 #[derive(Debug, Default, Deserialize, JsonSchema)]
 pub struct QueryRequest {
-    #[schemars(description = "The SQL query to execute.")]
+    /// The SQL query to execute.
     pub query: String,
 }


### PR DESCRIPTION
## Summary

- Replace `#[schemars(description = "...")]` attributes with idiomatic `///` doc comments on MCP tool request struct fields
- Descriptions now serve double duty: visible in rustdoc/IDE tooltips and in the generated JSON Schema
- Add backticks around tool names (`list_databases`, `list_tables`) to satisfy `clippy::doc_markdown`

## Test plan

- [x] `cargo fmt` — clean
- [x] `cargo clippy -- -D warnings` — zero warnings
- [x] `cargo test --workspace --lib --bins` — all 78 tests pass
- [x] Verified zero `#[schemars(description)]` attributes remain in codebase