### PR TITLE
feat(ci): automate release publishing to ghcr.io, MCP Registry, and crates.io

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -79,10 +79,11 @@ jobs:
           body: ${{ steps.changelog.outputs.stdout }}
           files: artifacts/*.tar.gz
 
-  docker:
-    name: Docker
+  ghcr-io:
+    name: Publish to ghcr.io
     needs: [release]
     runs-on: ubuntu-latest
+    continue-on-error: true
     steps:
       - uses: actions/checkout@v6
 
@@ -118,3 +119,24 @@ jobs:
           labels: ${{ steps.meta.outputs.labels }}
           build-args: |
             VERSION=${{ github.ref_name }}
+
+  registry-modelcontextprotocol-io:
+    name: Publish to registry.modelcontextprotocol.io
+    needs: [release]
+    runs-on: ubuntu-latest
+    continue-on-error: true
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Install mcp-publisher
+        run: |
+          curl -fsSL "https://github.com/modelcontextprotocol/registry/releases/latest/download/mcp-publisher_$(uname -s | tr '[:upper:]' '[:lower:]')_$(uname -m | sed 's/x86_64/amd64/;s/aarch64/arm64/').tar.gz" | tar xz mcp-publisher
+
+      - name: Authenticate to MCP Registry
+        run: ./mcp-publisher login dns --domain=haymon.ai --private-key=${{ secrets.MCP_REGISTRY_PRIVATE_KEY }}
+
+      - name: Validate server.json
+        run: ./mcp-publisher validate
+
+      - name: Publish to MCP Registry
+        run: ./mcp-publisher publish

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -140,3 +140,24 @@ jobs:
 
       - name: Publish to MCP Registry
         run: ./mcp-publisher publish
+
+  crates-io:
+    name: Publish to crates.io
+    needs: [release]
+    runs-on: ubuntu-latest
+    continue-on-error: true
+    permissions:
+      id-token: write
+      contents: read
+    steps:
+      - uses: actions/checkout@v6
+      - uses: dtolnay/rust-toolchain@stable
+      - uses: Swatinem/rust-cache@v2
+
+      - uses: rust-lang/crates-io-auth-action@v1
+        id: auth
+
+      - name: Publish workspace
+        run: cargo publish --workspace
+        env:
+          CARGO_REGISTRY_TOKEN: ${{ steps.auth.outputs.token }}


### PR DESCRIPTION
## Summary

- Add `registry-modelcontextprotocol-io` job to automatically publish to the official MCP Registry using `mcp-publisher` with DNS authentication
- Add `crates-io` job to automatically publish all workspace crates using native `cargo publish --workspace` with trusted publishing (OIDC)
- Rename `docker` job to `ghcr-io` and add `continue-on-error: true`
- All three publish jobs run in parallel after the `release` job, all non-blocking

## Prerequisites

Before merging, the following must be set up:

- [ ] `MCP_REGISTRY_PRIVATE_KEY` GitHub Actions secret (hex-encoded Ed25519 key for DNS auth)
- [ ] DNS TXT record on `haymon.ai`: `v=MCPv1; k=ed25519; p=<BASE64_PUBLIC_KEY>`
- [ ] First manual publish of all crates to crates.io: `cargo publish --workspace`
- [ ] Configure trusted publishing on crates.io for each of the 8 crates (Settings > Trusted Publishing: owner=`haymon-ai`, repo=`database`, workflow=`release.yml`)

## Test plan

- [ ] Verify YAML syntax is valid
- [ ] Push a version tag and confirm all three publish jobs trigger after release
- [ ] Verify Docker images appear on ghcr.io
- [ ] Verify MCP Registry listing is updated
- [ ] Verify all 8 crates appear on crates.io at the new version