### PR TITLE
refactor(server): relocate Server wrapper to server crate

### DIFF
--- a/crates/mysql/src/handler.rs
+++ b/crates/mysql/src/handler.rs
@@ -7,8 +7,7 @@
 use std::time::Duration;
 
 use database_mcp_config::DatabaseConfig;
-use database_mcp_server::AppError;
-use database_mcp_server::server_info;
+use database_mcp_server::{AppError, Server, server_info};
 use database_mcp_sql::identifier::validate_identifier;
 use database_mcp_sql::timeout::execute_with_timeout;
 use rmcp::RoleServer;
@@ -135,6 +134,13 @@ impl MysqlHandler {
             Ok::<_, sqlx::Error>(Value::Array(rows.iter().map(RowExt::to_json).collect()))
         })
         .await
+    }
+}
+
+impl From<MysqlHandler> for Server {
+    /// Wraps a [`MysqlHandler`] in the type-erased MCP server.
+    fn from(handler: MysqlHandler) -> Self {
+        Self::new(handler)
     }
 }
 

--- a/crates/postgres/src/handler.rs
+++ b/crates/postgres/src/handler.rs
@@ -7,8 +7,7 @@
 use std::time::Duration;
 
 use database_mcp_config::DatabaseConfig;
-use database_mcp_server::AppError;
-use database_mcp_server::server_info;
+use database_mcp_server::{AppError, Server, server_info};
 use database_mcp_sql::identifier::validate_identifier;
 use moka::future::Cache;
 use rmcp::RoleServer;
@@ -162,6 +161,13 @@ impl PostgresHandler {
             .await;
 
         Ok(pool)
+    }
+}
+
+impl From<PostgresHandler> for Server {
+    /// Wraps a [`PostgresHandler`] in the type-erased MCP server.
+    fn from(handler: PostgresHandler) -> Self {
+        Self::new(handler)
     }
 }
 

--- a/crates/server/src/lib.rs
+++ b/crates/server/src/lib.rs
@@ -8,5 +8,5 @@ mod server;
 pub mod types;
 
 pub use error::AppError;
-pub use server::server_info;
+pub use server::{Server, server_info};
 pub use types::{CreateDatabaseRequest, ExplainQueryRequest, GetTableSchemaRequest, ListTablesRequest, QueryRequest};

--- a/crates/server/src/server.rs
+++ b/crates/server/src/server.rs
@@ -1,10 +1,16 @@
-//! Shared MCP server utilities.
+//! Shared MCP server wrapper and metadata.
 //!
-//! Provides [`server_info`] used by per-backend
-//! [`ServerHandler`](rmcp::ServerHandler) implementations and the
-//! binary crate's `ServerHandler` wrapper.
+//! Provides the cloneable, type-erased [`Server`] consumed by the
+//! stdio and HTTP transports, plus [`server_info`] used by per-backend
+//! [`ServerHandler`](rmcp::ServerHandler) implementations.
 
+use std::fmt;
+use std::sync::Arc;
+
+use rmcp::RoleServer;
+use rmcp::Service;
 use rmcp::model::{Implementation, ServerCapabilities, ServerInfo};
+use rmcp::service::{DynService, NotificationContext, RequestContext, ServiceExt};
 
 /// Hardcoded product name matching the root binary crate.
 const NAME: &str = "database-mcp";
@@ -17,6 +23,50 @@ const TITLE: &str = "Database MCP Server";
 
 /// Website URL, derived from the workspace `Cargo.toml` at compile time.
 const HOMEPAGE: &str = env!("CARGO_PKG_HOMEPAGE");
+
+/// Cloneable, type-erased MCP server.
+///
+/// Wraps any backend adapter behind an [`Arc`] using rmcp's [`DynService`]
+/// for type erasure. All database backends produce the same concrete
+/// type, eliminating the need for enum dispatch.
+#[derive(Clone)]
+pub struct Server(Arc<dyn DynService<RoleServer>>);
+
+impl fmt::Debug for Server {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("Server").finish_non_exhaustive()
+    }
+}
+
+impl Server {
+    /// Creates a new server from any backend adapter.
+    pub fn new(server: impl ServiceExt<RoleServer>) -> Self {
+        Self(Arc::from(server.into_dyn()))
+    }
+}
+
+impl Service<RoleServer> for Server {
+    fn handle_request(
+        &self,
+        request: <RoleServer as rmcp::service::ServiceRole>::PeerReq,
+        context: RequestContext<RoleServer>,
+    ) -> impl Future<Output = Result<<RoleServer as rmcp::service::ServiceRole>::Resp, rmcp::ErrorData>> + Send + '_
+    {
+        DynService::handle_request(self.0.as_ref(), request, context)
+    }
+
+    fn handle_notification(
+        &self,
+        notification: <RoleServer as rmcp::service::ServiceRole>::PeerNot,
+        context: NotificationContext<RoleServer>,
+    ) -> impl Future<Output = Result<(), rmcp::ErrorData>> + Send + '_ {
+        DynService::handle_notification(self.0.as_ref(), notification, context)
+    }
+
+    fn get_info(&self) -> <RoleServer as rmcp::service::ServiceRole>::Info {
+        DynService::get_info(self.0.as_ref())
+    }
+}
 
 /// Returns the shared [`ServerInfo`] for all server implementations.
 ///

--- a/crates/sqlite/src/handler.rs
+++ b/crates/sqlite/src/handler.rs
@@ -6,7 +6,7 @@
 use std::time::Duration;
 
 use database_mcp_config::DatabaseConfig;
-use database_mcp_server::server_info;
+use database_mcp_server::{Server, server_info};
 use rmcp::RoleServer;
 use rmcp::handler::server::router::tool::ToolRouter;
 use rmcp::handler::server::tool::ToolCallContext;
@@ -74,6 +74,13 @@ impl SqliteHandler {
     /// Wraps `name` in double quotes for safe use in `SQLite` SQL statements.
     pub(crate) fn quote_identifier(name: &str) -> String {
         database_mcp_sql::identifier::quote_identifier(name, '"')
+    }
+}
+
+impl From<SqliteHandler> for Server {
+    /// Wraps a [`SqliteHandler`] in the type-erased MCP server.
+    fn from(handler: SqliteHandler) -> Self {
+        Self::new(handler)
     }
 }
 

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -14,7 +14,7 @@ use crate::commands::http::HttpCommand;
 use crate::commands::stdio::StdioCommand;
 use crate::consts::{BIN, VERSION};
 use crate::error::Error;
-use crate::server::create_handler;
+use crate::server::create_server;
 
 /// Log severity levels for the MCP server.
 ///
@@ -275,10 +275,10 @@ pub async fn run() -> Result<ExitCode, Error> {
         info!("Server running in READ-ONLY mode. Write operations are disabled.");
     }
 
-    let handler = create_handler(&config);
+    let server = create_server(&config);
     match &arguments.command {
-        Some(Command::Http(cmd)) => cmd.execute(&config, handler).await?,
-        _ => StdioCommand.execute(handler).await?,
+        Some(Command::Http(cmd)) => cmd.execute(&config, server).await?,
+        _ => StdioCommand.execute(server).await?,
     }
 
     Ok(ExitCode::SUCCESS)

--- a/src/commands/http.rs
+++ b/src/commands/http.rs
@@ -14,7 +14,7 @@ use tokio_util::sync::CancellationToken;
 use tracing::info;
 
 use crate::error::Error;
-use crate::server::ServerHandler;
+use crate::server::Server;
 
 /// Runs the MCP server in HTTP mode.
 #[derive(Debug, Parser)]
@@ -59,7 +59,7 @@ impl HttpCommand {
     /// Returns an error if:
     /// - HTTP config is missing from the configuration.
     /// - TCP bind fails (port in use, permission denied).
-    pub async fn execute(&self, config: &Config, handler: ServerHandler) -> Result<(), Error> {
+    pub async fn execute(&self, config: &Config, server: Server) -> Result<(), Error> {
         let http_config = config
             .http
             .as_ref()
@@ -85,7 +85,7 @@ impl HttpCommand {
             .allow_headers([axum::http::header::CONTENT_TYPE, axum::http::header::ACCEPT]);
 
         let service = StreamableHttpService::new(
-            move || Ok(handler.clone()),
+            move || Ok(server.clone()),
             Arc::new(LocalSessionManager::default()),
             StreamableHttpServerConfig::default()
                 .with_stateful_mode(false)

--- a/src/commands/stdio.rs
+++ b/src/commands/stdio.rs
@@ -8,7 +8,7 @@ use rmcp::ServiceExt;
 use rmcp::service::ServerInitializeError;
 use tracing::info;
 
-use crate::server::ServerHandler;
+use crate::server::Server;
 
 /// Runs the MCP server in stdio mode.
 #[derive(Debug, Parser)]
@@ -23,11 +23,11 @@ impl StdioCommand {
     ///
     /// Returns an error if the stdio transport fails to initialize or
     /// the server encounters a fatal protocol error.
-    pub async fn execute(&self, handler: ServerHandler) -> Result<(), ServerInitializeError> {
+    pub async fn execute(&self, server: Server) -> Result<(), ServerInitializeError> {
         info!("Starting MCP server via stdio transport...");
 
         let transport = rmcp::transport::io::stdio();
-        let running = handler.serve(transport).await?;
+        let running = server.serve(transport).await?;
 
         running.waiting().await.ok();
         Ok(())

--- a/src/server.rs
+++ b/src/server.rs
@@ -1,69 +1,28 @@
-//! Server creation and type-erased dispatch.
+//! Backend-selection factory for the type-erased MCP server.
 //!
-//! Provides [`ServerHandler`], a cloneable, type-erased MCP server
-//! that wraps any database backend. The [`create_handler`] function
-//! constructs the appropriate adapter and returns a [`ServerHandler`]
-//! without establishing a database connection.
-
-use std::sync::Arc;
+//! The cloneable [`Server`] wrapper itself lives in
+//! [`database_mcp_server`]; this module only owns [`create_server`],
+//! which maps a configured [`DatabaseBackend`] onto the matching
+//! concrete adapter.
 
 use database_mcp_config::{Config, DatabaseBackend};
 use database_mcp_mysql::MysqlHandler;
 use database_mcp_postgres::PostgresHandler;
 use database_mcp_sqlite::SqliteHandler;
-use rmcp::RoleServer;
-use rmcp::Service;
-use rmcp::service::{DynService, NotificationContext, RequestContext, ServiceExt};
 
-/// Cloneable, type-erased MCP server.
-///
-/// Wraps any backend adapter behind an [`Arc`] using rmcp's [`DynService`]
-/// for type erasure. All database backends produce the same concrete
-/// type, eliminating the need for enum dispatch.
-#[derive(Clone)]
-pub struct ServerHandler(Arc<dyn DynService<RoleServer>>);
+pub use database_mcp_server::Server;
 
-impl ServerHandler {
-    /// Creates a new handler from any backend adapter.
-    pub fn new(server: impl ServiceExt<RoleServer>) -> Self {
-        Self(Arc::from(server.into_dyn()))
-    }
-}
-
-impl Service<RoleServer> for ServerHandler {
-    fn handle_request(
-        &self,
-        request: <RoleServer as rmcp::service::ServiceRole>::PeerReq,
-        context: RequestContext<RoleServer>,
-    ) -> impl Future<Output = Result<<RoleServer as rmcp::service::ServiceRole>::Resp, rmcp::ErrorData>> + Send + '_
-    {
-        DynService::handle_request(self.0.as_ref(), request, context)
-    }
-
-    fn handle_notification(
-        &self,
-        notification: <RoleServer as rmcp::service::ServiceRole>::PeerNot,
-        context: NotificationContext<RoleServer>,
-    ) -> impl Future<Output = Result<(), rmcp::ErrorData>> + Send + '_ {
-        DynService::handle_notification(self.0.as_ref(), notification, context)
-    }
-
-    fn get_info(&self) -> <RoleServer as rmcp::service::ServiceRole>::Info {
-        DynService::get_info(self.0.as_ref())
-    }
-}
-
-/// Creates a [`ServerHandler`] based on the configured database backend.
+/// Creates a [`Server`] based on the configured database backend.
 ///
 /// Does **not** establish a database connection. Each adapter defers
 /// pool creation until the first tool invocation, allowing the MCP
 /// server to start and respond to protocol messages even when the
 /// database is unreachable.
 #[must_use]
-pub fn create_handler(config: &Config) -> ServerHandler {
+pub fn create_server(config: &Config) -> Server {
     match config.database.backend {
-        DatabaseBackend::Sqlite => ServerHandler::new(SqliteHandler::new(&config.database)),
-        DatabaseBackend::Postgres => ServerHandler::new(PostgresHandler::new(&config.database)),
-        DatabaseBackend::Mysql | DatabaseBackend::Mariadb => ServerHandler::new(MysqlHandler::new(&config.database)),
+        DatabaseBackend::Sqlite => SqliteHandler::new(&config.database).into(),
+        DatabaseBackend::Postgres => PostgresHandler::new(&config.database).into(),
+        DatabaseBackend::Mysql | DatabaseBackend::Mariadb => MysqlHandler::new(&config.database).into(),
     }
 }

--- a/tests/approval/common.rs
+++ b/tests/approval/common.rs
@@ -3,22 +3,22 @@
 //! Provides duplex transport setup and client lifecycle management
 //! used by tool schema snapshot tests.
 
+use database_mcp_server::Server;
 use rmcp::service::{Peer, RunningService, ServiceExt};
 
-/// Connects an MCP adapter over a duplex transport, runs a closure, then cleans up.
+/// Connects a [`Server`] over a duplex transport, runs a closure, then cleans up.
 ///
 /// Handles the full client lifecycle: duplex creation, server spawn, closure
 /// execution, client cancellation, and server join.
-pub async fn run_with_client<S, F, Fut>(adapter: S, f: F)
+pub async fn run_with_client<F, Fut>(server: Server, f: F)
 where
-    S: ServiceExt<rmcp::RoleServer> + Send + 'static,
     F: FnOnce(Peer<rmcp::RoleClient>) -> Fut,
     Fut: Future<Output = ()>,
 {
     let (server_transport, client_transport) = tokio::io::duplex(4096);
 
     let server_handle = tokio::spawn(async move {
-        let running = adapter.serve(server_transport).await.expect("server serve failed");
+        let running = server.serve(server_transport).await.expect("server serve failed");
         running.waiting().await.ok();
     });
 

--- a/tests/approval/mysql.rs
+++ b/tests/approval/mysql.rs
@@ -6,9 +6,10 @@ mod common;
 
 use database_mcp_config::{DatabaseBackend, DatabaseConfig};
 use database_mcp_mysql::MysqlHandler;
+use database_mcp_server::Server;
 
-/// Creates a `MySQL` adapter from `DB_HOST` and `DB_PORT` environment variables.
-fn adapter(read_only: bool) -> MysqlHandler {
+/// Creates a `MySQL`-backed [`Server`] from `DB_HOST` and `DB_PORT` environment variables.
+fn server(read_only: bool) -> Server {
     let config = DatabaseConfig {
         backend: DatabaseBackend::Mysql,
         host: std::env::var("DB_HOST").expect("DB_HOST must be set"),
@@ -20,12 +21,12 @@ fn adapter(read_only: bool) -> MysqlHandler {
         read_only,
         ..DatabaseConfig::default()
     };
-    MysqlHandler::new(&config)
+    MysqlHandler::new(&config).into()
 }
 
 #[tokio::test]
 async fn test_server_info() {
-    common::run_with_client(adapter(false), |peer| async move {
+    common::run_with_client(server(false), |peer| async move {
         let info = peer.peer_info().expect("missing peer_info");
         insta::assert_json_snapshot!("server_info", info, {
             ".serverInfo.version" => "[version]"
@@ -36,7 +37,7 @@ async fn test_server_info() {
 
 #[tokio::test]
 async fn test_list_tools() {
-    common::run_with_client(adapter(false), |peer| async move {
+    common::run_with_client(server(false), |peer| async move {
         let tools = peer.list_all_tools().await.expect("list_all_tools failed");
         insta::assert_json_snapshot!("list_tools", tools);
     })
@@ -45,7 +46,7 @@ async fn test_list_tools() {
 
 #[tokio::test]
 async fn test_list_tools_read_only() {
-    common::run_with_client(adapter(true), |peer| async move {
+    common::run_with_client(server(true), |peer| async move {
         let tools = peer.list_all_tools().await.expect("list_all_tools failed");
         insta::assert_json_snapshot!("list_tools_read_only", tools);
     })

--- a/tests/approval/postgres.rs
+++ b/tests/approval/postgres.rs
@@ -6,9 +6,10 @@ mod common;
 
 use database_mcp_config::{DatabaseBackend, DatabaseConfig};
 use database_mcp_postgres::PostgresHandler;
+use database_mcp_server::Server;
 
-/// Creates a `PostgreSQL` adapter from `DB_HOST` and `DB_PORT` environment variables.
-fn adapter(read_only: bool) -> PostgresHandler {
+/// Creates a `PostgreSQL`-backed [`Server`] from `DB_HOST` and `DB_PORT` environment variables.
+fn server(read_only: bool) -> Server {
     let config = DatabaseConfig {
         backend: DatabaseBackend::Postgres,
         host: std::env::var("DB_HOST").expect("DB_HOST must be set"),
@@ -21,12 +22,12 @@ fn adapter(read_only: bool) -> PostgresHandler {
         read_only,
         ..DatabaseConfig::default()
     };
-    PostgresHandler::new(&config)
+    PostgresHandler::new(&config).into()
 }
 
 #[tokio::test]
 async fn test_server_info() {
-    common::run_with_client(adapter(false), |peer| async move {
+    common::run_with_client(server(false), |peer| async move {
         let info = peer.peer_info().expect("missing peer_info");
         insta::assert_json_snapshot!("server_info", info, {
             ".serverInfo.version" => "[version]"
@@ -37,7 +38,7 @@ async fn test_server_info() {
 
 #[tokio::test]
 async fn test_list_tools() {
-    common::run_with_client(adapter(false), |peer| async move {
+    common::run_with_client(server(false), |peer| async move {
         let tools = peer.list_all_tools().await.expect("list_all_tools failed");
         insta::assert_json_snapshot!("list_tools", tools);
     })
@@ -46,7 +47,7 @@ async fn test_list_tools() {
 
 #[tokio::test]
 async fn test_list_tools_read_only() {
-    common::run_with_client(adapter(true), |peer| async move {
+    common::run_with_client(server(true), |peer| async move {
         let tools = peer.list_all_tools().await.expect("list_all_tools failed");
         insta::assert_json_snapshot!("list_tools_read_only", tools);
     })

--- a/tests/approval/sqlite.rs
+++ b/tests/approval/sqlite.rs
@@ -5,22 +5,23 @@
 mod common;
 
 use database_mcp_config::{DatabaseBackend, DatabaseConfig};
+use database_mcp_server::Server;
 use database_mcp_sqlite::SqliteHandler;
 
-/// Creates a `SQLite` handler from the `DB_PATH` environment variable.
-fn handler(read_only: bool) -> SqliteHandler {
+/// Creates a `SQLite`-backed [`Server`] from the `DB_PATH` environment variable.
+fn server(read_only: bool) -> Server {
     let config = DatabaseConfig {
         backend: DatabaseBackend::Sqlite,
         name: Some(std::env::var("DB_PATH").expect("DB_PATH must be set")),
         read_only,
         ..DatabaseConfig::default()
     };
-    SqliteHandler::new(&config)
+    SqliteHandler::new(&config).into()
 }
 
 #[tokio::test]
 async fn test_server_info() {
-    common::run_with_client(handler(false), |peer| async move {
+    common::run_with_client(server(false), |peer| async move {
         let info = peer.peer_info().expect("missing peer_info");
         insta::assert_json_snapshot!("server_info", info, {
             ".serverInfo.version" => "[version]"
@@ -31,7 +32,7 @@ async fn test_server_info() {
 
 #[tokio::test]
 async fn test_list_tools() {
-    common::run_with_client(handler(false), |peer| async move {
+    common::run_with_client(server(false), |peer| async move {
         let tools = peer.list_all_tools().await.expect("list_all_tools failed");
         insta::assert_json_snapshot!("list_tools", tools);
     })
@@ -40,7 +41,7 @@ async fn test_list_tools() {
 
 #[tokio::test]
 async fn test_list_tools_read_only() {
-    common::run_with_client(handler(true), |peer| async move {
+    common::run_with_client(server(true), |peer| async move {
         let tools = peer.list_all_tools().await.expect("list_all_tools failed");
         insta::assert_json_snapshot!("list_tools_read_only", tools);
     })


### PR DESCRIPTION
## Summary

- Move the cloneable, type-erased MCP server wrapper from `src/server.rs` into `database-mcp-server`, renamed from `ServerHandler` to `Server` to drop the long-standing name clash with the `rmcp::ServerHandler` trait.
- The root binary keeps only `create_server`, the backend-selection factory; transports (`stdio`, `http`) consume the shared `database_mcp_server::Server` type directly.
- Each backend crate regains a `From<XHandler> for Server` impl (the inverse of 2860656), so call sites read as `XHandler::new(&config).into()` in both `create_server` and the approval tests.
- Approval tests (`tests/approval/{sqlite,postgres,mysql}.rs`) now build a `Server` via `.into()` and the shared `common::run_with_client` helper is no longer generic — it takes a concrete `Server`, matching the production transport path.

## Test plan

- [x] `cargo fmt --check`
- [x] `cargo clippy --workspace --tests -- -D warnings`
- [x] `cargo test --workspace --lib --bins`
- [x] `./tests/run.sh` — 100/100 integration + approval tests pass across SQLite, MySQL, MariaDB, PostgreSQL
- [x] `cargo tree -p database-mcp-server --edges=normal` has no edge into the `mysql`/`postgres`/`sqlite` backend crates (cycle-free)