### PR TITLE
refactor(sql): unify connection management and add comprehensive tests

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -501,6 +501,7 @@ dependencies = [
  "database-mcp-config",
  "database-mcp-server",
  "database-mcp-sql",
+ "moka",
  "rmcp",
  "serde",
  "serde_json",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -547,6 +547,8 @@ dependencies = [
  "database-mcp-server",
  "serde_json",
  "sqlparser",
+ "sqlx",
+ "sqlx_to_json",
  "tokio",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -544,8 +544,8 @@ name = "database-mcp-sql"
 version = "0.6.1"
 dependencies = [
  "database-mcp-server",
+ "serde_json",
  "sqlparser",
- "sqlx",
  "tokio",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -545,6 +545,7 @@ version = "0.6.1"
 dependencies = [
  "database-mcp-server",
  "sqlparser",
+ "sqlx",
  "tokio",
 ]
 

--- a/crates/mysql/Cargo.toml
+++ b/crates/mysql/Cargo.toml
@@ -11,16 +11,15 @@ repository.workspace = true
 database-mcp-config = { workspace = true }
 database-mcp-server = { workspace = true }
 database-mcp-sql = { workspace = true }
+moka = { workspace = true }
 rmcp = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
 sqlparser = { workspace = true }
 sqlx = { workspace = true, features = ["mysql"] }
 sqlx_to_json = { workspace = true }
-tracing = { workspace = true }
-
-[dev-dependencies]
 tokio = { workspace = true }
+tracing = { workspace = true }
 
 [lints]
 workspace = true

--- a/crates/mysql/src/connection.rs
+++ b/crates/mysql/src/connection.rs
@@ -11,7 +11,7 @@ use database_mcp_server::AppError;
 use database_mcp_sql::Connection;
 use database_mcp_sql::identifier::validate_identifier;
 use moka::future::Cache;
-use sqlx::mysql::{MySqlConnectOptions, MySqlPool, MySqlPoolOptions, MySqlSslMode};
+use sqlx::mysql::{MySqlConnectOptions, MySqlPool, MySqlSslMode};
 use tracing::info;
 
 /// Maximum number of cached per-database connection pools.
@@ -106,7 +106,7 @@ impl MysqlConnection {
             .get_with(key, async {
                 let mut cfg = config;
                 cfg.name = Some(db_key.to_owned());
-                pool_options(&cfg).connect_lazy_with(connect_options(&cfg))
+                create_lazy_pool(&cfg)
             })
             .await;
 
@@ -127,23 +127,12 @@ impl Connection for MysqlConnection {
     }
 }
 
-/// Builds [`MySqlPoolOptions`] with lifecycle defaults from a [`DatabaseConfig`].
-fn pool_options(config: &DatabaseConfig) -> MySqlPoolOptions {
-    let mut opts = MySqlPoolOptions::new()
-        .max_connections(config.max_pool_size)
-        .min_connections(DatabaseConfig::DEFAULT_MIN_CONNECTIONS)
-        .idle_timeout(Duration::from_secs(DatabaseConfig::DEFAULT_IDLE_TIMEOUT_SECS))
-        .max_lifetime(Duration::from_secs(DatabaseConfig::DEFAULT_MAX_LIFETIME_SECS));
-
-    if let Some(timeout) = config.connection_timeout {
-        opts = opts.acquire_timeout(Duration::from_secs(timeout));
-    }
-
-    opts
-}
-
-/// Builds [`MySqlConnectOptions`] from a [`DatabaseConfig`].
-fn connect_options(config: &DatabaseConfig) -> MySqlConnectOptions {
+/// Creates a lazy `MySQL` pool from a [`DatabaseConfig`].
+///
+/// Combines pool lifecycle options with backend-specific connect
+/// options into a single lazy pool that establishes connections on
+/// first use.
+fn create_lazy_pool(config: &DatabaseConfig) -> MySqlPool {
     let mut opts = MySqlConnectOptions::new()
         .host(&config.host)
         .port(config.port)
@@ -178,7 +167,17 @@ fn connect_options(config: &DatabaseConfig) -> MySqlConnectOptions {
         }
     }
 
-    opts
+    let mut pool_opts = sqlx::pool::PoolOptions::new()
+        .max_connections(config.max_pool_size)
+        .min_connections(DatabaseConfig::DEFAULT_MIN_CONNECTIONS)
+        .idle_timeout(Duration::from_secs(DatabaseConfig::DEFAULT_IDLE_TIMEOUT_SECS))
+        .max_lifetime(Duration::from_secs(DatabaseConfig::DEFAULT_MAX_LIFETIME_SECS));
+
+    if let Some(timeout) = config.connection_timeout {
+        pool_opts = pool_opts.acquire_timeout(Duration::from_secs(timeout));
+    }
+
+    pool_opts.connect_lazy_with(opts)
 }
 
 #[cfg(test)]
@@ -198,108 +197,28 @@ mod tests {
         }
     }
 
-    #[test]
-    fn pool_options_applies_defaults() {
-        let config = base_config();
-        let opts = pool_options(&config);
-
-        assert_eq!(opts.get_max_connections(), config.max_pool_size);
-        assert_eq!(opts.get_min_connections(), DatabaseConfig::DEFAULT_MIN_CONNECTIONS);
-        assert_eq!(
-            opts.get_idle_timeout(),
-            Some(Duration::from_secs(DatabaseConfig::DEFAULT_IDLE_TIMEOUT_SECS))
-        );
-        assert_eq!(
-            opts.get_max_lifetime(),
-            Some(Duration::from_secs(DatabaseConfig::DEFAULT_MAX_LIFETIME_SECS))
-        );
+    #[tokio::test]
+    async fn create_lazy_pool_returns_idle_pool() {
+        let pool = create_lazy_pool(&base_config());
+        assert_eq!(pool.size(), 0, "pool should be lazy (no connections yet)");
     }
 
-    #[test]
-    fn pool_options_applies_connection_timeout() {
-        let config = DatabaseConfig {
-            connection_timeout: Some(7),
-            ..base_config()
-        };
-        let opts = pool_options(&config);
-
-        assert_eq!(opts.get_acquire_timeout(), Duration::from_secs(7));
-    }
-
-    #[test]
-    fn pool_options_without_connection_timeout_uses_sqlx_default() {
-        let config = base_config();
-        let opts = pool_options(&config);
-
-        assert_eq!(opts.get_acquire_timeout(), Duration::from_secs(30));
-    }
-
-    #[test]
-    fn try_from_basic_config() {
-        let config = base_config();
-        let opts = connect_options(&config);
-
-        assert_eq!(opts.get_host(), "db.example.com");
-        assert_eq!(opts.get_port(), 3307);
-        assert_eq!(opts.get_username(), "admin");
-        assert_eq!(opts.get_database(), Some("mydb"));
-    }
-
-    #[test]
-    fn try_from_with_charset() {
-        let config = DatabaseConfig {
-            charset: Some("utf8mb4".into()),
-            ..base_config()
-        };
-        let opts = connect_options(&config);
-
-        assert_eq!(opts.get_charset(), "utf8mb4");
-    }
-
-    #[test]
-    fn try_from_with_ssl_required() {
-        let config = DatabaseConfig {
-            ssl: true,
-            ssl_verify_cert: false,
-            ..base_config()
-        };
-        let opts = connect_options(&config);
-
-        assert!(matches!(opts.get_ssl_mode(), MySqlSslMode::Required));
-    }
-
-    #[test]
-    fn try_from_with_ssl_verify_ca() {
-        let config = DatabaseConfig {
-            ssl: true,
-            ssl_verify_cert: true,
-            ..base_config()
-        };
-        let opts = connect_options(&config);
-
-        assert!(matches!(opts.get_ssl_mode(), MySqlSslMode::VerifyCa));
-    }
-
-    #[test]
-    fn try_from_without_password() {
-        let config = DatabaseConfig {
+    #[tokio::test]
+    async fn create_lazy_pool_without_password() {
+        let pool = create_lazy_pool(&DatabaseConfig {
             password: None,
             ..base_config()
-        };
-        let opts = connect_options(&config);
-
-        assert_eq!(opts.get_host(), "db.example.com");
+        });
+        assert_eq!(pool.size(), 0);
     }
 
-    #[test]
-    fn try_from_without_database_name() {
-        let config = DatabaseConfig {
+    #[tokio::test]
+    async fn create_lazy_pool_without_database_name() {
+        let pool = create_lazy_pool(&DatabaseConfig {
             name: None,
             ..base_config()
-        };
-        let opts = connect_options(&config);
-
-        assert_eq!(opts.get_database(), None);
+        });
+        assert_eq!(pool.size(), 0);
     }
 
     #[tokio::test]

--- a/crates/mysql/src/connection.rs
+++ b/crates/mysql/src/connection.rs
@@ -1,4 +1,4 @@
-//! `MySQL`/`MariaDB` connection: pool cache, pool initialization, and [`Connection`] impl.
+//! `MySQL`/`MariaDB` connection: pool cache, pool initialization, and [`PoolProvider`] impl.
 //!
 //! Owns the lazy default pool and the moka cache of per-database pools.
 //! Hides every backend pool concern from [`MysqlHandler`](crate::MysqlHandler),
@@ -8,14 +8,10 @@ use std::time::Duration;
 
 use database_mcp_config::DatabaseConfig;
 use database_mcp_server::AppError;
-use database_mcp_sql::connection::Connection;
+use database_mcp_sql::PoolProvider;
 use database_mcp_sql::identifier::{quote_identifier, validate_identifier};
-use database_mcp_sql::timeout::execute_with_timeout;
 use moka::future::Cache;
-use serde_json::Value;
-use sqlx::Executor;
 use sqlx::mysql::{MySqlConnectOptions, MySqlPool, MySqlPoolOptions, MySqlSslMode};
-use sqlx_to_json::RowExt;
 use tracing::info;
 
 /// Maximum number of cached per-database connection pools.
@@ -142,38 +138,15 @@ impl MysqlConnection {
     }
 }
 
-impl Connection for MysqlConnection {
-    async fn execute(&self, query: &str, database: Option<&str>) -> Result<u64, AppError> {
-        let pool = self.pool(database).await?;
-        let sql = query.to_owned();
-        execute_with_timeout(self.config.query_timeout, query, async move {
-            let mut conn = pool.acquire().await?;
-            let result = (&mut *conn).execute(sql.as_str()).await?;
-            Ok::<_, sqlx::Error>(result.rows_affected())
-        })
-        .await
+impl PoolProvider for MysqlConnection {
+    type DB = sqlx::MySql;
+
+    async fn pool(&self, target: Option<&str>) -> Result<sqlx::Pool<Self::DB>, AppError> {
+        self.pool(target).await
     }
 
-    async fn fetch(&self, query: &str, database: Option<&str>) -> Result<Vec<Value>, AppError> {
-        let pool = self.pool(database).await?;
-        let sql = query.to_owned();
-        execute_with_timeout(self.config.query_timeout, query, async move {
-            let mut conn = pool.acquire().await?;
-            let rows = (&mut *conn).fetch_all(sql.as_str()).await?;
-            Ok::<_, sqlx::Error>(rows.iter().map(RowExt::to_json).collect())
-        })
-        .await
-    }
-
-    async fn fetch_optional(&self, query: &str, database: Option<&str>) -> Result<Option<Value>, AppError> {
-        let pool = self.pool(database).await?;
-        let sql = query.to_owned();
-        execute_with_timeout(self.config.query_timeout, query, async move {
-            let mut conn = pool.acquire().await?;
-            let row = (&mut *conn).fetch_optional(sql.as_str()).await?;
-            Ok::<_, sqlx::Error>(row.as_ref().map(RowExt::to_json))
-        })
-        .await
+    fn query_timeout(&self) -> Option<u64> {
+        self.config.query_timeout
     }
 }
 

--- a/crates/mysql/src/connection.rs
+++ b/crates/mysql/src/connection.rs
@@ -1,6 +1,6 @@
 //! `MySQL`/`MariaDB` connection: pool cache, pool initialization, and [`Connection`] impl.
 //!
-//! Owns the lazy default pool and the moka cache of per-database pools.
+//! Owns a moka cache of lazily-created per-database pools (including the default).
 //! Hides every backend pool concern from [`MysqlHandler`](crate::MysqlHandler),
 //! which composes one [`MysqlConnection`] as a field.
 
@@ -21,34 +21,23 @@ pub(crate) const POOL_CACHE_CAPACITY: u64 = 16;
 #[derive(Clone)]
 pub(crate) struct MysqlConnection {
     config: DatabaseConfig,
-    default_db: String,
-    default_pool: MySqlPool,
     pools: Cache<String, MySqlPool>,
 }
 
 impl std::fmt::Debug for MysqlConnection {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.debug_struct("MysqlConnection")
-            .field("default_db", &self.default_db)
+            .field("default_db", &self.default_db())
             .finish_non_exhaustive()
     }
 }
 
 impl MysqlConnection {
-    /// Builds the connection and its lazy default pool.
+    /// Builds the connection with an empty pool cache.
     ///
-    /// Does **not** establish a database connection. The default pool
-    /// connects on demand when the first query is executed. Non-default
-    /// database pools are created lazily on first request.
+    /// Does **not** establish a database connection. All pools — including
+    /// the default — are created lazily on first request via [`pool`](Self::pool).
     pub(crate) fn new(config: &DatabaseConfig) -> Self {
-        let default_db = config
-            .name
-            .as_deref()
-            .filter(|n| !n.is_empty())
-            .map_or_else(String::new, String::from);
-
-        let default_pool = pool_options(config).connect_lazy_with(connect_options(config));
-
         info!(
             "MySQL lazy connection pool created (max size: {})",
             config.max_pool_size
@@ -65,15 +54,19 @@ impl MysqlConnection {
 
         Self {
             config: config.clone(),
-            default_db,
-            default_pool,
             pools,
         }
     }
 
-    /// Returns the name of the database resolved at startup.
+    /// Returns the configured default database name, or `""` if none.
     pub(crate) fn default_db(&self) -> &str {
-        &self.default_db
+        self.config.name.as_deref().filter(|n| !n.is_empty()).unwrap_or("")
+    }
+
+    /// Returns `true` if `name` matches the default database (case-insensitive).
+    fn is_default_db(&self, name: &str) -> bool {
+        let default = self.default_db();
+        !default.is_empty() && default.eq_ignore_ascii_case(name)
     }
 
     /// Evicts the cached pool for `name`, closing its connections.
@@ -94,25 +87,23 @@ impl MysqlConnection {
     pub(crate) async fn pool(&self, target: Option<&str>) -> Result<MySqlPool, AppError> {
         let db_key = match target {
             Some(name) if !name.is_empty() => name,
-            _ => return Ok(self.default_pool.clone()),
+            _ => self.default_db(),
         };
-
-        if !self.default_db.is_empty() && db_key == self.default_db {
-            return Ok(self.default_pool.clone());
-        }
 
         if let Some(pool) = self.pools.get(db_key).await {
             return Ok(pool);
         }
 
-        validate_identifier(db_key)?;
+        if !self.is_default_db(db_key) {
+            validate_identifier(db_key)?;
+        }
 
         let config = self.config.clone();
-        let db_key_owned = db_key.to_owned();
+        let key = db_key.to_owned();
 
         let pool = self
             .pools
-            .get_with(db_key_owned, async {
+            .get_with(key, async {
                 let mut cfg = config;
                 cfg.name = Some(db_key.to_owned());
                 pool_options(&cfg).connect_lazy_with(connect_options(&cfg))
@@ -312,10 +303,9 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn new_creates_lazy_default_pool() {
+    async fn default_db_derived_from_config() {
         let connection = MysqlConnection::new(&base_config());
         assert_eq!(connection.default_db(), "mydb");
-        assert_eq!(connection.default_pool.size(), 0, "default pool should be lazy");
     }
 
     #[tokio::test]

--- a/crates/mysql/src/connection.rs
+++ b/crates/mysql/src/connection.rs
@@ -1,8 +1,8 @@
-//! `MySQL`/`MariaDB` connection: pool ownership + initialization.
+//! `MySQL`/`MariaDB` connection: pool cache, pool initialization, and [`Connection`] impl.
 //!
-//! Owns the single lazy [`MySqlPool`] used by [`MysqlHandler`](crate::MysqlHandler).
-//! Cross-database access is performed at the query layer via per-call
-//! `USE` statements on the same acquired pool connection.
+//! Owns the lazy default pool and the moka cache of per-database pools.
+//! Hides every backend pool concern from [`MysqlHandler`](crate::MysqlHandler),
+//! which composes one [`MysqlConnection`] as a field.
 
 use std::time::Duration;
 
@@ -11,40 +11,73 @@ use database_mcp_server::AppError;
 use database_mcp_sql::connection::Connection;
 use database_mcp_sql::identifier::{quote_identifier, validate_identifier};
 use database_mcp_sql::timeout::execute_with_timeout;
+use moka::future::Cache;
 use serde_json::Value;
 use sqlx::Executor;
 use sqlx::mysql::{MySqlConnectOptions, MySqlPool, MySqlPoolOptions, MySqlSslMode};
 use sqlx_to_json::RowExt;
 use tracing::info;
 
-/// Owns the lazy `MySQL` pool and the logic that builds it.
+/// Maximum number of cached per-database connection pools.
+pub(crate) const POOL_CACHE_CAPACITY: u64 = 16;
+
+/// Owns every `MySqlPool` the handler uses and the logic that builds them.
 #[derive(Clone)]
 pub(crate) struct MysqlConnection {
     config: DatabaseConfig,
-    pool: MySqlPool,
+    default_db: String,
+    default_pool: MySqlPool,
+    pools: Cache<String, MySqlPool>,
 }
 
 impl std::fmt::Debug for MysqlConnection {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        f.debug_struct("MysqlConnection").finish_non_exhaustive()
+        f.debug_struct("MysqlConnection")
+            .field("default_db", &self.default_db)
+            .finish_non_exhaustive()
     }
 }
 
 impl MysqlConnection {
-    /// Builds the connection and its lazy pool.
+    /// Builds the connection and its lazy default pool.
     ///
-    /// Does **not** establish a database connection; the pool connects
-    /// on demand when the first query is executed.
+    /// Does **not** establish a database connection. The default pool
+    /// connects on demand when the first query is executed. Non-default
+    /// database pools are created lazily on first request.
     pub(crate) fn new(config: &DatabaseConfig) -> Self {
-        let pool = pool_options(config).connect_lazy_with(connect_options(config));
+        let default_db = config
+            .name
+            .as_deref()
+            .filter(|n| !n.is_empty())
+            .map_or_else(String::new, String::from);
+
+        let default_pool = pool_options(config).connect_lazy_with(connect_options(config));
+
         info!(
             "MySQL lazy connection pool created (max size: {})",
             config.max_pool_size
         );
+
+        let pools = Cache::builder()
+            .max_capacity(POOL_CACHE_CAPACITY)
+            .eviction_listener(|_key, pool: MySqlPool, _cause| {
+                tokio::spawn(async move {
+                    pool.close().await;
+                });
+            })
+            .build();
+
         Self {
             config: config.clone(),
-            pool,
+            default_db,
+            default_pool,
+            pools,
         }
+    }
+
+    /// Returns the name of the database resolved at startup.
+    pub(crate) fn default_db(&self) -> &str {
+        &self.default_db
     }
 
     /// Wraps `name` in backticks for safe use in `MySQL` SQL statements.
@@ -62,30 +95,59 @@ impl MysqlConnection {
         format!("'{escaped}'")
     }
 
-    /// Returns the single pool. Target is ignored (single-pool backend).
+    /// Evicts the cached pool for `name`, closing its connections.
     ///
-    /// Crate-private so every tool path goes through the unified
+    /// Idempotent — does nothing if the pool was not cached.
+    pub(crate) async fn invalidate(&self, name: &str) {
+        self.pools.invalidate(name).await;
+    }
+
+    /// Resolves the cached pool for `target`, creating it lazily on miss.
+    ///
+    /// Kept crate-private so every tool path goes through the unified
     /// [`Connection`] methods and cannot bypass timeout / error capture.
-    #[allow(clippy::unused_async)]
-    pub(crate) async fn pool(&self, _target: Option<&str>) -> Result<MySqlPool, AppError> {
-        Ok(self.pool.clone())
+    ///
+    /// # Errors
+    ///
+    /// - [`AppError::InvalidIdentifier`] — `target` failed identifier validation.
+    pub(crate) async fn pool(&self, target: Option<&str>) -> Result<MySqlPool, AppError> {
+        let db_key = match target {
+            Some(name) if !name.is_empty() => name,
+            _ => return Ok(self.default_pool.clone()),
+        };
+
+        if !self.default_db.is_empty() && db_key == self.default_db {
+            return Ok(self.default_pool.clone());
+        }
+
+        if let Some(pool) = self.pools.get(db_key).await {
+            return Ok(pool);
+        }
+
+        validate_identifier(db_key)?;
+
+        let config = self.config.clone();
+        let db_key_owned = db_key.to_owned();
+
+        let pool = self
+            .pools
+            .get_with(db_key_owned, async {
+                let mut cfg = config;
+                cfg.name = Some(db_key.to_owned());
+                pool_options(&cfg).connect_lazy_with(connect_options(&cfg))
+            })
+            .await;
+
+        Ok(pool)
     }
 }
 
 impl Connection for MysqlConnection {
     async fn execute(&self, query: &str, database: Option<&str>) -> Result<u64, AppError> {
-        if let Some(db) = database {
-            validate_identifier(db)?;
-        }
         let pool = self.pool(database).await?;
         let sql = query.to_owned();
-        let target_owned = database.map(str::to_owned);
         execute_with_timeout(self.config.query_timeout, query, async move {
             let mut conn = pool.acquire().await?;
-            if let Some(db) = target_owned.as_deref() {
-                let use_sql = format!("USE {}", quote_identifier(db, '`'));
-                (&mut *conn).execute(use_sql.as_str()).await?;
-            }
             let result = (&mut *conn).execute(sql.as_str()).await?;
             Ok::<_, sqlx::Error>(result.rows_affected())
         })
@@ -93,18 +155,10 @@ impl Connection for MysqlConnection {
     }
 
     async fn fetch(&self, query: &str, database: Option<&str>) -> Result<Vec<Value>, AppError> {
-        if let Some(db) = database {
-            validate_identifier(db)?;
-        }
         let pool = self.pool(database).await?;
         let sql = query.to_owned();
-        let target_owned = database.map(str::to_owned);
         execute_with_timeout(self.config.query_timeout, query, async move {
             let mut conn = pool.acquire().await?;
-            if let Some(db) = target_owned.as_deref() {
-                let use_sql = format!("USE {}", quote_identifier(db, '`'));
-                (&mut *conn).execute(use_sql.as_str()).await?;
-            }
             let rows = (&mut *conn).fetch_all(sql.as_str()).await?;
             Ok::<_, sqlx::Error>(rows.iter().map(RowExt::to_json).collect())
         })
@@ -112,18 +166,10 @@ impl Connection for MysqlConnection {
     }
 
     async fn fetch_optional(&self, query: &str, database: Option<&str>) -> Result<Option<Value>, AppError> {
-        if let Some(db) = database {
-            validate_identifier(db)?;
-        }
         let pool = self.pool(database).await?;
         let sql = query.to_owned();
-        let target_owned = database.map(str::to_owned);
         execute_with_timeout(self.config.query_timeout, query, async move {
             let mut conn = pool.acquire().await?;
-            if let Some(db) = target_owned.as_deref() {
-                let use_sql = format!("USE {}", quote_identifier(db, '`'));
-                (&mut *conn).execute(use_sql.as_str()).await?;
-            }
             let row = (&mut *conn).fetch_optional(sql.as_str()).await?;
             Ok::<_, sqlx::Error>(row.as_ref().map(RowExt::to_json))
         })
@@ -307,18 +353,59 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn new_creates_lazy_pool() {
+    async fn new_creates_lazy_default_pool() {
         let connection = MysqlConnection::new(&base_config());
-        assert_eq!(connection.pool.size(), 0, "pool should be lazy");
+        assert_eq!(connection.default_db(), "mydb");
+        assert_eq!(connection.default_pool.size(), 0, "default pool should be lazy");
     }
 
     #[tokio::test]
-    async fn pool_returns_single_pool() {
+    async fn defaults_db_to_empty_when_name_missing() {
+        let connection = MysqlConnection::new(&DatabaseConfig {
+            name: None,
+            ..base_config()
+        });
+        assert_eq!(connection.default_db(), "");
+    }
+
+    #[tokio::test]
+    async fn none_target_returns_default_pool() {
         let connection = MysqlConnection::new(&base_config());
         connection.pool(None).await.expect("None target should succeed");
+    }
+
+    #[tokio::test]
+    async fn default_db_target_returns_default_pool() {
+        let connection = MysqlConnection::new(&base_config());
         connection
-            .pool(Some("anything"))
+            .pool(Some("mydb"))
             .await
-            .expect("any target should return the same single pool");
+            .expect("default db target should return default pool");
+    }
+
+    #[tokio::test]
+    async fn arbitrary_target_database_is_permitted() {
+        let connection = MysqlConnection::new(&base_config());
+        connection
+            .pool(Some("any_db"))
+            .await
+            .expect("any database should be permitted");
+    }
+
+    #[tokio::test]
+    async fn pool_cache_respects_capacity_const() {
+        let connection = MysqlConnection::new(&base_config());
+
+        for i in 0..=POOL_CACHE_CAPACITY {
+            let name = format!("db_{i}");
+            connection.pool(Some(&name)).await.expect("pool should succeed");
+        }
+        connection.pools.run_pending_tasks().await;
+
+        assert!(
+            connection.pools.entry_count() <= POOL_CACHE_CAPACITY,
+            "cached pools exceeded cap: {} > {POOL_CACHE_CAPACITY}",
+            connection.pools.entry_count()
+        );
     }
 }

--- a/crates/mysql/src/connection.rs
+++ b/crates/mysql/src/connection.rs
@@ -27,7 +27,7 @@ pub(crate) struct MysqlConnection {
 impl std::fmt::Debug for MysqlConnection {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.debug_struct("MysqlConnection")
-            .field("default_db", &self.default_db())
+            .field("default_db", &self.default_database_name())
             .finish_non_exhaustive()
     }
 }
@@ -59,7 +59,7 @@ impl MysqlConnection {
     }
 
     /// Returns the configured default database name, or `""` if none.
-    pub(crate) fn default_db(&self) -> &str {
+    pub(crate) fn default_database_name(&self) -> &str {
         self.config.name.as_deref().filter(|n| !n.is_empty()).unwrap_or("")
     }
 
@@ -79,30 +79,23 @@ impl MysqlConnection {
     ///
     /// - [`AppError::InvalidIdentifier`] — `target` failed identifier validation.
     pub(crate) async fn pool(&self, target: Option<&str>) -> Result<MySqlPool, AppError> {
-        let db_key = match target {
+        let database = match target {
             Some(name) if !name.is_empty() => name,
-            _ => self.default_db(),
+            _ => self.default_database_name(),
         };
 
-        if let Some(pool) = self.pools.get(db_key).await {
+        if let Some(pool) = self.pools.get(database).await {
             return Ok(pool);
         }
 
-        let default = self.default_db();
-        if default.is_empty() || !default.eq_ignore_ascii_case(db_key) {
-            validate_identifier(db_key)?;
+        let default = self.default_database_name();
+        if default.is_empty() || !default.eq_ignore_ascii_case(database) {
+            validate_identifier(database)?;
         }
-
-        let config = self.config.clone();
-        let key = db_key.to_owned();
 
         let pool = self
             .pools
-            .get_with(key, async {
-                let mut cfg = config;
-                cfg.name = Some(db_key.to_owned());
-                create_lazy_pool(&cfg)
-            })
+            .get_with(database.to_owned(), async { create_lazy_pool(&self.config, database) })
             .await;
 
         Ok(pool)
@@ -122,43 +115,41 @@ impl Connection for MysqlConnection {
     }
 }
 
-/// Creates a lazy `MySQL` pool from a [`DatabaseConfig`].
+/// Creates a lazy `MySQL` pool for `db_name`.
 ///
 /// Combines pool lifecycle options with backend-specific connect
 /// options into a single lazy pool that establishes connections on
 /// first use.
-fn create_lazy_pool(config: &DatabaseConfig) -> MySqlPool {
-    let mut opts = MySqlConnectOptions::new()
+fn create_lazy_pool(config: &DatabaseConfig, database: &str) -> MySqlPool {
+    let mut conn_ops = MySqlConnectOptions::new()
         .host(&config.host)
         .port(config.port)
         .username(&config.user);
 
     if let Some(ref password) = config.password {
-        opts = opts.password(password);
+        conn_ops = conn_ops.password(password);
     }
-    if let Some(ref name) = config.name
-        && !name.is_empty()
-    {
-        opts = opts.database(name);
+    if !database.is_empty() {
+        conn_ops = conn_ops.database(database);
     }
     if let Some(ref charset) = config.charset {
-        opts = opts.charset(charset);
+        conn_ops = conn_ops.charset(charset);
     }
 
     if config.ssl {
-        opts = if config.ssl_verify_cert {
-            opts.ssl_mode(MySqlSslMode::VerifyCa)
+        conn_ops = if config.ssl_verify_cert {
+            conn_ops.ssl_mode(MySqlSslMode::VerifyCa)
         } else {
-            opts.ssl_mode(MySqlSslMode::Required)
+            conn_ops.ssl_mode(MySqlSslMode::Required)
         };
         if let Some(ref ca) = config.ssl_ca {
-            opts = opts.ssl_ca(ca);
+            conn_ops = conn_ops.ssl_ca(ca);
         }
         if let Some(ref cert) = config.ssl_cert {
-            opts = opts.ssl_client_cert(cert);
+            conn_ops = conn_ops.ssl_client_cert(cert);
         }
         if let Some(ref key) = config.ssl_key {
-            opts = opts.ssl_client_key(key);
+            conn_ops = conn_ops.ssl_client_key(key);
         }
     }
 
@@ -172,7 +163,7 @@ fn create_lazy_pool(config: &DatabaseConfig) -> MySqlPool {
         pool_opts = pool_opts.acquire_timeout(Duration::from_secs(timeout));
     }
 
-    pool_opts.connect_lazy_with(opts)
+    pool_opts.connect_lazy_with(conn_ops)
 }
 
 #[cfg(test)]
@@ -194,32 +185,38 @@ mod tests {
 
     #[tokio::test]
     async fn create_lazy_pool_returns_idle_pool() {
-        let pool = create_lazy_pool(&base_config());
+        let pool = create_lazy_pool(&base_config(), "mydb");
         assert_eq!(pool.size(), 0, "pool should be lazy (no connections yet)");
     }
 
     #[tokio::test]
     async fn create_lazy_pool_without_password() {
-        let pool = create_lazy_pool(&DatabaseConfig {
-            password: None,
-            ..base_config()
-        });
+        let pool = create_lazy_pool(
+            &DatabaseConfig {
+                password: None,
+                ..base_config()
+            },
+            "mydb",
+        );
         assert_eq!(pool.size(), 0);
     }
 
     #[tokio::test]
     async fn create_lazy_pool_without_database_name() {
-        let pool = create_lazy_pool(&DatabaseConfig {
-            name: None,
-            ..base_config()
-        });
+        let pool = create_lazy_pool(
+            &DatabaseConfig {
+                name: None,
+                ..base_config()
+            },
+            "",
+        );
         assert_eq!(pool.size(), 0);
     }
 
     #[tokio::test]
     async fn default_db_derived_from_config() {
         let connection = MysqlConnection::new(&base_config());
-        assert_eq!(connection.default_db(), "mydb");
+        assert_eq!(connection.default_database_name(), "mydb");
     }
 
     #[tokio::test]
@@ -228,7 +225,7 @@ mod tests {
             name: None,
             ..base_config()
         });
-        assert_eq!(connection.default_db(), "");
+        assert_eq!(connection.default_database_name(), "");
     }
 
     #[tokio::test]

--- a/crates/mysql/src/connection.rs
+++ b/crates/mysql/src/connection.rs
@@ -1,0 +1,331 @@
+//! `MySQL`/`MariaDB` connection: pool ownership + initialization.
+//!
+//! Owns the single lazy [`MySqlPool`] used by [`MysqlHandler`](crate::MysqlHandler).
+//! Cross-database access is performed at the query layer via per-call
+//! `USE` statements on the same acquired pool connection.
+
+use std::time::Duration;
+
+use database_mcp_config::DatabaseConfig;
+use database_mcp_server::AppError;
+use database_mcp_sql::connection::{Connection, Executable, Query};
+use database_mcp_sql::identifier::{quote_identifier, validate_identifier};
+use database_mcp_sql::timeout::execute_with_timeout;
+use sqlx::Executor;
+use sqlx::MySql;
+use sqlx::mysql::{MySqlConnectOptions, MySqlPool, MySqlPoolOptions, MySqlQueryResult, MySqlSslMode};
+use tracing::info;
+
+/// Owns the lazy `MySQL` pool and the logic that builds it.
+#[derive(Clone)]
+pub(crate) struct MysqlConnection {
+    config: DatabaseConfig,
+    pool: MySqlPool,
+}
+
+impl std::fmt::Debug for MysqlConnection {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("MysqlConnection").finish_non_exhaustive()
+    }
+}
+
+impl MysqlConnection {
+    /// Builds the connection and its lazy pool.
+    ///
+    /// Does **not** establish a database connection; the pool connects
+    /// on demand when the first query is executed.
+    pub(crate) fn new(config: &DatabaseConfig) -> Self {
+        let pool = pool_options(config).connect_lazy_with(connect_options(config));
+        info!(
+            "MySQL lazy connection pool created (max size: {})",
+            config.max_pool_size
+        );
+        Self {
+            config: config.clone(),
+            pool,
+        }
+    }
+
+    /// Wraps `name` in backticks for safe use in `MySQL` SQL statements.
+    #[allow(clippy::unused_self)]
+    pub(crate) fn quote_identifier(&self, name: &str) -> String {
+        quote_identifier(name, '`')
+    }
+
+    /// Wraps a value in single quotes for use as a SQL string literal.
+    ///
+    /// Escapes internal single quotes by doubling them.
+    #[allow(clippy::unused_self)]
+    pub(crate) fn quote_string(&self, value: &str) -> String {
+        let escaped = value.replace('\'', "''");
+        format!("'{escaped}'")
+    }
+
+    /// Returns the single pool. Target is ignored (single-pool backend).
+    ///
+    /// Crate-private so every tool path goes through the unified
+    /// [`Connection`] methods and cannot bypass timeout / error capture.
+    #[allow(clippy::unused_async)]
+    pub(crate) async fn pool(&self, _target: Option<&str>) -> Result<MySqlPool, AppError> {
+        Ok(self.pool.clone())
+    }
+}
+
+impl Connection for MysqlConnection {
+    type Database = MySql;
+
+    async fn execute<Q>(&self, query: Q, target: Option<&str>) -> Result<MySqlQueryResult, AppError>
+    where
+        Q: Executable<MySql>,
+    {
+        if let Some(db) = target {
+            validate_identifier(db)?;
+        }
+        let pool = self.pool(target).await?;
+        let sql = query.sql().to_owned();
+        let target_owned = target.map(str::to_owned);
+        execute_with_timeout(self.config.query_timeout, &sql, async move {
+            let mut conn = pool.acquire().await?;
+            if let Some(db) = target_owned.as_deref() {
+                let use_sql = format!("USE {}", quote_identifier(db, '`'));
+                (&mut *conn).execute(use_sql.as_str()).await?;
+            }
+            query.run_execute(&mut conn).await
+        })
+        .await
+    }
+
+    async fn fetch<Q>(&self, query: Q, target: Option<&str>) -> Result<Vec<Q::Output>, AppError>
+    where
+        Q: Query<MySql>,
+    {
+        if let Some(db) = target {
+            validate_identifier(db)?;
+        }
+        let pool = self.pool(target).await?;
+        let sql = query.sql().to_owned();
+        let target_owned = target.map(str::to_owned);
+        execute_with_timeout(self.config.query_timeout, &sql, async move {
+            let mut conn = pool.acquire().await?;
+            if let Some(db) = target_owned.as_deref() {
+                let use_sql = format!("USE {}", quote_identifier(db, '`'));
+                (&mut *conn).execute(use_sql.as_str()).await?;
+            }
+            query.run_fetch_all(&mut conn).await
+        })
+        .await
+    }
+
+    async fn fetch_optional<Q>(&self, query: Q, target: Option<&str>) -> Result<Option<Q::Output>, AppError>
+    where
+        Q: Query<MySql>,
+    {
+        if let Some(db) = target {
+            validate_identifier(db)?;
+        }
+        let pool = self.pool(target).await?;
+        let sql = query.sql().to_owned();
+        let target_owned = target.map(str::to_owned);
+        execute_with_timeout(self.config.query_timeout, &sql, async move {
+            let mut conn = pool.acquire().await?;
+            if let Some(db) = target_owned.as_deref() {
+                let use_sql = format!("USE {}", quote_identifier(db, '`'));
+                (&mut *conn).execute(use_sql.as_str()).await?;
+            }
+            query.run_fetch_optional(&mut conn).await
+        })
+        .await
+    }
+}
+
+/// Builds [`MySqlPoolOptions`] with lifecycle defaults from a [`DatabaseConfig`].
+fn pool_options(config: &DatabaseConfig) -> MySqlPoolOptions {
+    let mut opts = MySqlPoolOptions::new()
+        .max_connections(config.max_pool_size)
+        .min_connections(DatabaseConfig::DEFAULT_MIN_CONNECTIONS)
+        .idle_timeout(Duration::from_secs(DatabaseConfig::DEFAULT_IDLE_TIMEOUT_SECS))
+        .max_lifetime(Duration::from_secs(DatabaseConfig::DEFAULT_MAX_LIFETIME_SECS));
+
+    if let Some(timeout) = config.connection_timeout {
+        opts = opts.acquire_timeout(Duration::from_secs(timeout));
+    }
+
+    opts
+}
+
+/// Builds [`MySqlConnectOptions`] from a [`DatabaseConfig`].
+fn connect_options(config: &DatabaseConfig) -> MySqlConnectOptions {
+    let mut opts = MySqlConnectOptions::new()
+        .host(&config.host)
+        .port(config.port)
+        .username(&config.user);
+
+    if let Some(ref password) = config.password {
+        opts = opts.password(password);
+    }
+    if let Some(ref name) = config.name
+        && !name.is_empty()
+    {
+        opts = opts.database(name);
+    }
+    if let Some(ref charset) = config.charset {
+        opts = opts.charset(charset);
+    }
+
+    if config.ssl {
+        opts = if config.ssl_verify_cert {
+            opts.ssl_mode(MySqlSslMode::VerifyCa)
+        } else {
+            opts.ssl_mode(MySqlSslMode::Required)
+        };
+        if let Some(ref ca) = config.ssl_ca {
+            opts = opts.ssl_ca(ca);
+        }
+        if let Some(ref cert) = config.ssl_cert {
+            opts = opts.ssl_client_cert(cert);
+        }
+        if let Some(ref key) = config.ssl_key {
+            opts = opts.ssl_client_key(key);
+        }
+    }
+
+    opts
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use database_mcp_config::DatabaseBackend;
+
+    fn base_config() -> DatabaseConfig {
+        DatabaseConfig {
+            backend: DatabaseBackend::Mysql,
+            host: "db.example.com".into(),
+            port: 3307,
+            user: "admin".into(),
+            password: Some("s3cret".into()),
+            name: Some("mydb".into()),
+            ..DatabaseConfig::default()
+        }
+    }
+
+    #[test]
+    fn pool_options_applies_defaults() {
+        let config = base_config();
+        let opts = pool_options(&config);
+
+        assert_eq!(opts.get_max_connections(), config.max_pool_size);
+        assert_eq!(opts.get_min_connections(), DatabaseConfig::DEFAULT_MIN_CONNECTIONS);
+        assert_eq!(
+            opts.get_idle_timeout(),
+            Some(Duration::from_secs(DatabaseConfig::DEFAULT_IDLE_TIMEOUT_SECS))
+        );
+        assert_eq!(
+            opts.get_max_lifetime(),
+            Some(Duration::from_secs(DatabaseConfig::DEFAULT_MAX_LIFETIME_SECS))
+        );
+    }
+
+    #[test]
+    fn pool_options_applies_connection_timeout() {
+        let config = DatabaseConfig {
+            connection_timeout: Some(7),
+            ..base_config()
+        };
+        let opts = pool_options(&config);
+
+        assert_eq!(opts.get_acquire_timeout(), Duration::from_secs(7));
+    }
+
+    #[test]
+    fn pool_options_without_connection_timeout_uses_sqlx_default() {
+        let config = base_config();
+        let opts = pool_options(&config);
+
+        assert_eq!(opts.get_acquire_timeout(), Duration::from_secs(30));
+    }
+
+    #[test]
+    fn try_from_basic_config() {
+        let config = base_config();
+        let opts = connect_options(&config);
+
+        assert_eq!(opts.get_host(), "db.example.com");
+        assert_eq!(opts.get_port(), 3307);
+        assert_eq!(opts.get_username(), "admin");
+        assert_eq!(opts.get_database(), Some("mydb"));
+    }
+
+    #[test]
+    fn try_from_with_charset() {
+        let config = DatabaseConfig {
+            charset: Some("utf8mb4".into()),
+            ..base_config()
+        };
+        let opts = connect_options(&config);
+
+        assert_eq!(opts.get_charset(), "utf8mb4");
+    }
+
+    #[test]
+    fn try_from_with_ssl_required() {
+        let config = DatabaseConfig {
+            ssl: true,
+            ssl_verify_cert: false,
+            ..base_config()
+        };
+        let opts = connect_options(&config);
+
+        assert!(matches!(opts.get_ssl_mode(), MySqlSslMode::Required));
+    }
+
+    #[test]
+    fn try_from_with_ssl_verify_ca() {
+        let config = DatabaseConfig {
+            ssl: true,
+            ssl_verify_cert: true,
+            ..base_config()
+        };
+        let opts = connect_options(&config);
+
+        assert!(matches!(opts.get_ssl_mode(), MySqlSslMode::VerifyCa));
+    }
+
+    #[test]
+    fn try_from_without_password() {
+        let config = DatabaseConfig {
+            password: None,
+            ..base_config()
+        };
+        let opts = connect_options(&config);
+
+        assert_eq!(opts.get_host(), "db.example.com");
+    }
+
+    #[test]
+    fn try_from_without_database_name() {
+        let config = DatabaseConfig {
+            name: None,
+            ..base_config()
+        };
+        let opts = connect_options(&config);
+
+        assert_eq!(opts.get_database(), None);
+    }
+
+    #[tokio::test]
+    async fn new_creates_lazy_pool() {
+        let connection = MysqlConnection::new(&base_config());
+        assert_eq!(connection.pool.size(), 0, "pool should be lazy");
+    }
+
+    #[tokio::test]
+    async fn pool_returns_single_pool() {
+        let connection = MysqlConnection::new(&base_config());
+        connection.pool(None).await.expect("None target should succeed");
+        connection
+            .pool(Some("anything"))
+            .await
+            .expect("any target should return the same single pool");
+    }
+}

--- a/crates/mysql/src/connection.rs
+++ b/crates/mysql/src/connection.rs
@@ -1,4 +1,4 @@
-//! `MySQL`/`MariaDB` connection: pool cache, pool initialization, and [`PoolProvider`] impl.
+//! `MySQL`/`MariaDB` connection: pool cache, pool initialization, and [`Connection`] impl.
 //!
 //! Owns the lazy default pool and the moka cache of per-database pools.
 //! Hides every backend pool concern from [`MysqlHandler`](crate::MysqlHandler),
@@ -8,8 +8,8 @@ use std::time::Duration;
 
 use database_mcp_config::DatabaseConfig;
 use database_mcp_server::AppError;
-use database_mcp_sql::PoolProvider;
-use database_mcp_sql::identifier::{quote_identifier, validate_identifier};
+use database_mcp_sql::Connection;
+use database_mcp_sql::identifier::validate_identifier;
 use moka::future::Cache;
 use sqlx::mysql::{MySqlConnectOptions, MySqlPool, MySqlPoolOptions, MySqlSslMode};
 use tracing::info;
@@ -76,21 +76,6 @@ impl MysqlConnection {
         &self.default_db
     }
 
-    /// Wraps `name` in backticks for safe use in `MySQL` SQL statements.
-    #[allow(clippy::unused_self)]
-    pub(crate) fn quote_identifier(&self, name: &str) -> String {
-        quote_identifier(name, '`')
-    }
-
-    /// Wraps a value in single quotes for use as a SQL string literal.
-    ///
-    /// Escapes internal single quotes by doubling them.
-    #[allow(clippy::unused_self)]
-    pub(crate) fn quote_string(&self, value: &str) -> String {
-        let escaped = value.replace('\'', "''");
-        format!("'{escaped}'")
-    }
-
     /// Evicts the cached pool for `name`, closing its connections.
     ///
     /// Idempotent — does nothing if the pool was not cached.
@@ -138,8 +123,9 @@ impl MysqlConnection {
     }
 }
 
-impl PoolProvider for MysqlConnection {
+impl Connection for MysqlConnection {
     type DB = sqlx::MySql;
+    const IDENTIFIER_QUOTE: char = '`';
 
     async fn pool(&self, target: Option<&str>) -> Result<sqlx::Pool<Self::DB>, AppError> {
         self.pool(target).await

--- a/crates/mysql/src/connection.rs
+++ b/crates/mysql/src/connection.rs
@@ -8,12 +8,13 @@ use std::time::Duration;
 
 use database_mcp_config::DatabaseConfig;
 use database_mcp_server::AppError;
-use database_mcp_sql::connection::{Connection, Executable, Query};
+use database_mcp_sql::connection::Connection;
 use database_mcp_sql::identifier::{quote_identifier, validate_identifier};
 use database_mcp_sql::timeout::execute_with_timeout;
+use serde_json::Value;
 use sqlx::Executor;
-use sqlx::MySql;
-use sqlx::mysql::{MySqlConnectOptions, MySqlPool, MySqlPoolOptions, MySqlQueryResult, MySqlSslMode};
+use sqlx::mysql::{MySqlConnectOptions, MySqlPool, MySqlPoolOptions, MySqlSslMode};
+use sqlx_to_json::RowExt;
 use tracing::info;
 
 /// Owns the lazy `MySQL` pool and the logic that builds it.
@@ -72,67 +73,59 @@ impl MysqlConnection {
 }
 
 impl Connection for MysqlConnection {
-    type Database = MySql;
-
-    async fn execute<Q>(&self, query: Q, target: Option<&str>) -> Result<MySqlQueryResult, AppError>
-    where
-        Q: Executable<MySql>,
-    {
-        if let Some(db) = target {
+    async fn execute(&self, query: &str, database: Option<&str>) -> Result<u64, AppError> {
+        if let Some(db) = database {
             validate_identifier(db)?;
         }
-        let pool = self.pool(target).await?;
-        let sql = query.sql().to_owned();
-        let target_owned = target.map(str::to_owned);
-        execute_with_timeout(self.config.query_timeout, &sql, async move {
+        let pool = self.pool(database).await?;
+        let sql = query.to_owned();
+        let target_owned = database.map(str::to_owned);
+        execute_with_timeout(self.config.query_timeout, query, async move {
             let mut conn = pool.acquire().await?;
             if let Some(db) = target_owned.as_deref() {
                 let use_sql = format!("USE {}", quote_identifier(db, '`'));
                 (&mut *conn).execute(use_sql.as_str()).await?;
             }
-            query.run_execute(&mut conn).await
+            let result = (&mut *conn).execute(sql.as_str()).await?;
+            Ok::<_, sqlx::Error>(result.rows_affected())
         })
         .await
     }
 
-    async fn fetch<Q>(&self, query: Q, target: Option<&str>) -> Result<Vec<Q::Output>, AppError>
-    where
-        Q: Query<MySql>,
-    {
-        if let Some(db) = target {
+    async fn fetch(&self, query: &str, database: Option<&str>) -> Result<Vec<Value>, AppError> {
+        if let Some(db) = database {
             validate_identifier(db)?;
         }
-        let pool = self.pool(target).await?;
-        let sql = query.sql().to_owned();
-        let target_owned = target.map(str::to_owned);
-        execute_with_timeout(self.config.query_timeout, &sql, async move {
+        let pool = self.pool(database).await?;
+        let sql = query.to_owned();
+        let target_owned = database.map(str::to_owned);
+        execute_with_timeout(self.config.query_timeout, query, async move {
             let mut conn = pool.acquire().await?;
             if let Some(db) = target_owned.as_deref() {
                 let use_sql = format!("USE {}", quote_identifier(db, '`'));
                 (&mut *conn).execute(use_sql.as_str()).await?;
             }
-            query.run_fetch_all(&mut conn).await
+            let rows = (&mut *conn).fetch_all(sql.as_str()).await?;
+            Ok::<_, sqlx::Error>(rows.iter().map(RowExt::to_json).collect())
         })
         .await
     }
 
-    async fn fetch_optional<Q>(&self, query: Q, target: Option<&str>) -> Result<Option<Q::Output>, AppError>
-    where
-        Q: Query<MySql>,
-    {
-        if let Some(db) = target {
+    async fn fetch_optional(&self, query: &str, database: Option<&str>) -> Result<Option<Value>, AppError> {
+        if let Some(db) = database {
             validate_identifier(db)?;
         }
-        let pool = self.pool(target).await?;
-        let sql = query.sql().to_owned();
-        let target_owned = target.map(str::to_owned);
-        execute_with_timeout(self.config.query_timeout, &sql, async move {
+        let pool = self.pool(database).await?;
+        let sql = query.to_owned();
+        let target_owned = database.map(str::to_owned);
+        execute_with_timeout(self.config.query_timeout, query, async move {
             let mut conn = pool.acquire().await?;
             if let Some(db) = target_owned.as_deref() {
                 let use_sql = format!("USE {}", quote_identifier(db, '`'));
                 (&mut *conn).execute(use_sql.as_str()).await?;
             }
-            query.run_fetch_optional(&mut conn).await
+            let row = (&mut *conn).fetch_optional(sql.as_str()).await?;
+            Ok::<_, sqlx::Error>(row.as_ref().map(RowExt::to_json))
         })
         .await
     }

--- a/crates/mysql/src/connection.rs
+++ b/crates/mysql/src/connection.rs
@@ -63,12 +63,6 @@ impl MysqlConnection {
         self.config.name.as_deref().filter(|n| !n.is_empty()).unwrap_or("")
     }
 
-    /// Returns `true` if `name` matches the default database (case-insensitive).
-    fn is_default_db(&self, name: &str) -> bool {
-        let default = self.default_db();
-        !default.is_empty() && default.eq_ignore_ascii_case(name)
-    }
-
     /// Evicts the cached pool for `name`, closing its connections.
     ///
     /// Idempotent — does nothing if the pool was not cached.
@@ -94,7 +88,8 @@ impl MysqlConnection {
             return Ok(pool);
         }
 
-        if !self.is_default_db(db_key) {
+        let default = self.default_db();
+        if default.is_empty() || !default.eq_ignore_ascii_case(db_key) {
             validate_identifier(db_key)?;
         }
 

--- a/crates/mysql/src/handler.rs
+++ b/crates/mysql/src/handler.rs
@@ -1,28 +1,20 @@
-//! MySQL/MariaDB handler: connection pool, MCP tool router, and `ServerHandler` impl.
+//! MySQL/MariaDB handler: composes a [`MysqlConnection`] with the MCP tool router.
 //!
-//! Builds [`MySqlConnectOptions`] from a [`DatabaseConfig`] and creates
-//! a lazy connection pool via [`MySqlPoolOptions::connect_lazy_with`].
-//! No network I/O happens until the first tool invocation.
-
-use std::time::Duration;
+//! All pool ownership and pool initialization logic lives in the
+//! [`MysqlConnection`]. This module exposes the MCP `ServerHandler`
+//! surface and a small set of thin delegators that per-tool
+//! implementations call.
 
 use database_mcp_config::DatabaseConfig;
-use database_mcp_server::{AppError, Server, server_info};
-use database_mcp_sql::identifier::validate_identifier;
-use database_mcp_sql::timeout::execute_with_timeout;
+use database_mcp_server::{Server, server_info};
 use rmcp::RoleServer;
 use rmcp::handler::server::router::tool::ToolRouter;
 use rmcp::handler::server::tool::ToolCallContext;
 use rmcp::model::{CallToolRequestParams, CallToolResult, ListToolsResult, PaginatedRequestParams, ServerInfo, Tool};
 use rmcp::service::RequestContext;
 use rmcp::{ErrorData, ServerHandler};
-use serde_json::Value;
-use sqlx::Executor;
-use sqlx::MySqlPool;
-use sqlx::mysql::{MySqlConnectOptions, MySqlPoolOptions, MySqlRow, MySqlSslMode};
-use sqlx_to_json::RowExt;
-use tracing::info;
 
+use crate::connection::MysqlConnection;
 use crate::tools::{
     CreateDatabaseTool, DropDatabaseTool, DropTableTool, ExplainQueryTool, GetTableSchemaTool, ListDatabasesTool,
     ListTablesTool, ReadQueryTool, WriteQueryTool,
@@ -49,13 +41,12 @@ const INSTRUCTIONS: &str = r"## Workflow
 
 /// MySQL/MariaDB database handler.
 ///
-/// The connection pool is created with [`MySqlPoolOptions::connect_lazy_with`],
-/// which defers all network I/O until the first query. Connection errors
-/// surface as tool-level errors returned to the MCP client.
+/// Composes one [`MysqlConnection`] (which owns the pool and
+/// the pool initialization logic) with the per-backend MCP tool router.
 #[derive(Clone)]
 pub struct MysqlHandler {
     pub(crate) config: DatabaseConfig,
-    pub(crate) pool: MySqlPool,
+    pub(crate) connection: MysqlConnection,
     tool_router: ToolRouter<Self>,
 }
 
@@ -63,77 +54,23 @@ impl std::fmt::Debug for MysqlHandler {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.debug_struct("MysqlHandler")
             .field("read_only", &self.config.read_only)
+            .field("connection", &self.connection)
             .finish_non_exhaustive()
     }
 }
 
 impl MysqlHandler {
-    /// Creates a new `MySQL` handler with a lazy connection pool.
+    /// Creates a new `MySQL` handler.
     ///
-    /// Does **not** establish a database connection. The pool connects
-    /// on-demand when the first query is executed. The MCP tool router
-    /// is built once here and reused for every request.
+    /// Constructs the [`MysqlConnection`] (which builds the
+    /// lazy pool) and the MCP tool router. No network I/O happens here.
     #[must_use]
     pub fn new(config: &DatabaseConfig) -> Self {
-        let pool = pool_options(config).connect_lazy_with(connect_options(config));
-        info!(
-            "MySQL lazy connection pool created (max size: {})",
-            config.max_pool_size
-        );
         Self {
             config: config.clone(),
-            pool,
+            connection: MysqlConnection::new(config),
             tool_router: build_tool_router(config.read_only),
         }
-    }
-
-    /// Wraps `name` in backticks for safe use in `MySQL` SQL statements.
-    pub(crate) fn quote_identifier(name: &str) -> String {
-        database_mcp_sql::identifier::quote_identifier(name, '`')
-    }
-
-    /// Wraps a value in single quotes for use as a SQL string literal.
-    ///
-    /// Escapes internal single quotes by doubling them.
-    pub(crate) fn quote_string(value: &str) -> String {
-        let escaped = value.replace('\'', "''");
-        format!("'{escaped}'")
-    }
-
-    /// Executes raw SQL and converts rows to JSON maps.
-    ///
-    /// Uses the text protocol via `Executor::fetch_all(&str)` instead of prepared
-    /// statements, because `MySQL` 9+ doesn't support SHOW commands as prepared
-    /// statements, and the text protocol returns all values as strings.
-    ///
-    /// # Errors
-    ///
-    /// Returns [`AppError`] if the identifier is invalid or the query fails.
-    pub(crate) async fn query_to_json(&self, sql: &str, database: Option<&str>) -> Result<Value, AppError> {
-        // Validate before entering the timeout scope so validation errors
-        // are not confused with timeouts.
-        if let Some(db) = database {
-            validate_identifier(db)?;
-        }
-
-        let pool = self.pool.clone();
-        let db = database.map(String::from);
-        let sql_owned = sql.to_string();
-
-        // The timeout wraps the entire acquire → USE → fetch sequence
-        // because from the caller's perspective, this is one operation.
-        execute_with_timeout(self.config.query_timeout, sql, async move {
-            let mut conn = pool.acquire().await?;
-
-            if let Some(db) = &db {
-                let use_sql = format!("USE {}", Self::quote_identifier(db));
-                conn.execute(use_sql.as_str()).await?;
-            }
-
-            let rows: Vec<MySqlRow> = conn.fetch_all(sql_owned.as_str()).await?;
-            Ok::<_, sqlx::Error>(Value::Array(rows.iter().map(RowExt::to_json).collect()))
-        })
-        .await
     }
 }
 
@@ -142,60 +79,6 @@ impl From<MysqlHandler> for Server {
     fn from(handler: MysqlHandler) -> Self {
         Self::new(handler)
     }
-}
-
-/// Builds [`MySqlPoolOptions`] with lifecycle defaults from a [`DatabaseConfig`].
-fn pool_options(config: &DatabaseConfig) -> MySqlPoolOptions {
-    let mut opts = MySqlPoolOptions::new()
-        .max_connections(config.max_pool_size)
-        .min_connections(DatabaseConfig::DEFAULT_MIN_CONNECTIONS)
-        .idle_timeout(Duration::from_secs(DatabaseConfig::DEFAULT_IDLE_TIMEOUT_SECS))
-        .max_lifetime(Duration::from_secs(DatabaseConfig::DEFAULT_MAX_LIFETIME_SECS));
-
-    if let Some(timeout) = config.connection_timeout {
-        opts = opts.acquire_timeout(Duration::from_secs(timeout));
-    }
-
-    opts
-}
-
-/// Builds [`MySqlConnectOptions`] from a [`DatabaseConfig`].
-fn connect_options(config: &DatabaseConfig) -> MySqlConnectOptions {
-    let mut opts = MySqlConnectOptions::new()
-        .host(&config.host)
-        .port(config.port)
-        .username(&config.user);
-
-    if let Some(ref password) = config.password {
-        opts = opts.password(password);
-    }
-    if let Some(ref name) = config.name
-        && !name.is_empty()
-    {
-        opts = opts.database(name);
-    }
-    if let Some(ref charset) = config.charset {
-        opts = opts.charset(charset);
-    }
-
-    if config.ssl {
-        opts = if config.ssl_verify_cert {
-            opts.ssl_mode(MySqlSslMode::VerifyCa)
-        } else {
-            opts.ssl_mode(MySqlSslMode::Required)
-        };
-        if let Some(ref ca) = config.ssl_ca {
-            opts = opts.ssl_ca(ca);
-        }
-        if let Some(ref cert) = config.ssl_cert {
-            opts = opts.ssl_client_cert(cert);
-        }
-        if let Some(ref key) = config.ssl_key {
-            opts = opts.ssl_client_key(key);
-        }
-    }
-
-    opts
 }
 
 /// Builds the tool router, including write tools only when not in read-only mode.
@@ -273,129 +156,6 @@ mod tests {
             read_only,
             ..base_config()
         })
-    }
-
-    #[test]
-    fn pool_options_applies_defaults() {
-        let config = base_config();
-        let opts = pool_options(&config);
-
-        assert_eq!(opts.get_max_connections(), config.max_pool_size);
-        assert_eq!(opts.get_min_connections(), DatabaseConfig::DEFAULT_MIN_CONNECTIONS);
-        assert_eq!(
-            opts.get_idle_timeout(),
-            Some(Duration::from_secs(DatabaseConfig::DEFAULT_IDLE_TIMEOUT_SECS))
-        );
-        assert_eq!(
-            opts.get_max_lifetime(),
-            Some(Duration::from_secs(DatabaseConfig::DEFAULT_MAX_LIFETIME_SECS))
-        );
-    }
-
-    #[test]
-    fn pool_options_applies_connection_timeout() {
-        let config = DatabaseConfig {
-            connection_timeout: Some(7),
-            ..base_config()
-        };
-        let opts = pool_options(&config);
-
-        assert_eq!(opts.get_acquire_timeout(), Duration::from_secs(7));
-    }
-
-    #[test]
-    fn pool_options_without_connection_timeout_uses_sqlx_default() {
-        let config = base_config();
-        let opts = pool_options(&config);
-
-        // sqlx defaults acquire_timeout to 30s when not overridden
-        assert_eq!(opts.get_acquire_timeout(), Duration::from_secs(30));
-    }
-
-    #[test]
-    fn try_from_basic_config() {
-        let config = base_config();
-        let opts = connect_options(&config);
-
-        assert_eq!(opts.get_host(), "db.example.com");
-        assert_eq!(opts.get_port(), 3307);
-        assert_eq!(opts.get_username(), "admin");
-        assert_eq!(opts.get_database(), Some("mydb"));
-    }
-
-    #[test]
-    fn try_from_with_charset() {
-        let config = DatabaseConfig {
-            charset: Some("utf8mb4".into()),
-            ..base_config()
-        };
-        let opts = connect_options(&config);
-
-        assert_eq!(opts.get_charset(), "utf8mb4");
-    }
-
-    #[test]
-    fn try_from_with_ssl_required() {
-        let config = DatabaseConfig {
-            ssl: true,
-            ssl_verify_cert: false,
-            ..base_config()
-        };
-        let opts = connect_options(&config);
-
-        assert!(
-            matches!(opts.get_ssl_mode(), MySqlSslMode::Required),
-            "expected Required, got {:?}",
-            opts.get_ssl_mode()
-        );
-    }
-
-    #[test]
-    fn try_from_with_ssl_verify_ca() {
-        let config = DatabaseConfig {
-            ssl: true,
-            ssl_verify_cert: true,
-            ..base_config()
-        };
-        let opts = connect_options(&config);
-
-        assert!(
-            matches!(opts.get_ssl_mode(), MySqlSslMode::VerifyCa),
-            "expected VerifyCa, got {:?}",
-            opts.get_ssl_mode()
-        );
-    }
-
-    #[test]
-    fn try_from_without_password() {
-        let config = DatabaseConfig {
-            password: None,
-            ..base_config()
-        };
-        let opts = connect_options(&config);
-
-        // Should not panic — password is simply omitted
-        assert_eq!(opts.get_host(), "db.example.com");
-    }
-
-    #[test]
-    fn try_from_without_database_name() {
-        let config = DatabaseConfig {
-            name: None,
-            ..base_config()
-        };
-        let opts = connect_options(&config);
-
-        assert_eq!(opts.get_database(), None);
-    }
-
-    #[tokio::test]
-    async fn new_creates_lazy_pool() {
-        let config = base_config();
-        let handler = MysqlHandler::new(&config);
-        assert!(handler.config.read_only);
-        // Pool exists but has no active connections (lazy).
-        assert_eq!(handler.pool.size(), 0);
     }
 
     #[tokio::test]

--- a/crates/mysql/src/lib.rs
+++ b/crates/mysql/src/lib.rs
@@ -3,6 +3,7 @@
 //! Provides [`MysqlHandler`] for database operations with MCP
 //! tool registration via [`ServerHandler`](rmcp::ServerHandler).
 
+mod connection;
 mod handler;
 mod tools;
 pub mod types;

--- a/crates/mysql/src/tools/create_database.rs
+++ b/crates/mysql/src/tools/create_database.rs
@@ -4,7 +4,7 @@ use std::borrow::Cow;
 
 use database_mcp_server::AppError;
 use database_mcp_server::types::{CreateDatabaseRequest, MessageResponse};
-use database_mcp_sql::connection::Connection;
+use database_mcp_sql::Connection as _;
 use database_mcp_sql::identifier::validate_identifier;
 use rmcp::handler::server::router::tool::{AsyncTool, ToolBase};
 use rmcp::model::{ErrorData, ToolAnnotations};

--- a/crates/mysql/src/tools/create_database.rs
+++ b/crates/mysql/src/tools/create_database.rs
@@ -4,7 +4,7 @@ use std::borrow::Cow;
 
 use database_mcp_server::AppError;
 use database_mcp_server::types::{CreateDatabaseRequest, MessageResponse};
-use database_mcp_sql::connection::Connection as _;
+use database_mcp_sql::connection::Connection;
 use database_mcp_sql::identifier::validate_identifier;
 use rmcp::handler::server::router::tool::{AsyncTool, ToolBase};
 use rmcp::model::{ErrorData, ToolAnnotations};
@@ -62,12 +62,11 @@ impl MysqlHandler {
         let name = &request.database_name;
         validate_identifier(name)?;
 
-        // Check existence — use Vec<u8> because MySQL 9 returns BINARY columns
-        let check_sql = "SELECT SCHEMA_NAME FROM information_schema.SCHEMATA WHERE SCHEMA_NAME = ?";
-        let exists: Option<Vec<u8>> = self
-            .connection
-            .fetch_optional(sqlx::query_scalar(check_sql).bind(name), None)
-            .await?;
+        let check_sql = format!(
+            "SELECT SCHEMA_NAME FROM information_schema.SCHEMATA WHERE SCHEMA_NAME = {}",
+            self.connection.quote_string(name),
+        );
+        let exists = self.connection.fetch_optional(check_sql.as_str(), None).await?;
 
         if exists.is_some() {
             return Ok(MessageResponse {

--- a/crates/mysql/src/tools/create_database.rs
+++ b/crates/mysql/src/tools/create_database.rs
@@ -4,8 +4,8 @@ use std::borrow::Cow;
 
 use database_mcp_server::AppError;
 use database_mcp_server::types::{CreateDatabaseRequest, MessageResponse};
+use database_mcp_sql::connection::Connection as _;
 use database_mcp_sql::identifier::validate_identifier;
-use database_mcp_sql::timeout::execute_with_timeout;
 use rmcp::handler::server::router::tool::{AsyncTool, ToolBase};
 use rmcp::model::{ErrorData, ToolAnnotations};
 
@@ -62,16 +62,12 @@ impl MysqlHandler {
         let name = &request.database_name;
         validate_identifier(name)?;
 
-        let pool = self.pool.clone();
-
         // Check existence — use Vec<u8> because MySQL 9 returns BINARY columns
         let check_sql = "SELECT SCHEMA_NAME FROM information_schema.SCHEMATA WHERE SCHEMA_NAME = ?";
-        let exists: Option<Vec<u8>> = execute_with_timeout(
-            self.config.query_timeout,
-            check_sql,
-            sqlx::query_scalar(check_sql).bind(name).fetch_optional(&pool),
-        )
-        .await?;
+        let exists: Option<Vec<u8>> = self
+            .connection
+            .fetch_optional(sqlx::query_scalar(check_sql).bind(name), None)
+            .await?;
 
         if exists.is_some() {
             return Ok(MessageResponse {
@@ -79,13 +75,11 @@ impl MysqlHandler {
             });
         }
 
-        let create_sql = format!("CREATE DATABASE IF NOT EXISTS {}", Self::quote_identifier(name));
-        execute_with_timeout(
-            self.config.query_timeout,
-            &create_sql,
-            sqlx::query(&create_sql).execute(&pool),
-        )
-        .await?;
+        let create_sql = format!(
+            "CREATE DATABASE IF NOT EXISTS {}",
+            self.connection.quote_identifier(name)
+        );
+        self.connection.execute(create_sql.as_str(), None).await?;
 
         Ok(MessageResponse {
             message: format!("Database '{name}' created successfully."),

--- a/crates/mysql/src/tools/drop_database.rs
+++ b/crates/mysql/src/tools/drop_database.rs
@@ -4,7 +4,7 @@ use std::borrow::Cow;
 
 use database_mcp_server::AppError;
 use database_mcp_server::types::{DropDatabaseRequest, MessageResponse};
-use database_mcp_sql::connection::Connection;
+use database_mcp_sql::Connection as _;
 use database_mcp_sql::identifier::validate_identifier;
 use rmcp::handler::server::router::tool::{AsyncTool, ToolBase};
 use rmcp::model::{ErrorData, ToolAnnotations};

--- a/crates/mysql/src/tools/drop_database.rs
+++ b/crates/mysql/src/tools/drop_database.rs
@@ -68,7 +68,7 @@ impl MysqlHandler {
         validate_identifier(name)?;
 
         // Guard: prevent dropping the currently connected database.
-        if self.connection.default_db().eq_ignore_ascii_case(name) {
+        if self.connection.default_database_name().eq_ignore_ascii_case(name) {
             return Err(AppError::Query(format!(
                 "Cannot drop the currently connected database '{name}'."
             )));

--- a/crates/mysql/src/tools/drop_database.rs
+++ b/crates/mysql/src/tools/drop_database.rs
@@ -68,9 +68,7 @@ impl MysqlHandler {
         validate_identifier(name)?;
 
         // Guard: prevent dropping the currently connected database.
-        if let Some(ref active) = self.config.name
-            && active.eq_ignore_ascii_case(name)
-        {
+        if self.connection.default_db().eq_ignore_ascii_case(name) {
             return Err(AppError::Query(format!(
                 "Cannot drop the currently connected database '{name}'."
             )));
@@ -78,6 +76,10 @@ impl MysqlHandler {
 
         let drop_sql = format!("DROP DATABASE {}", self.connection.quote_identifier(name));
         self.connection.execute(drop_sql.as_str(), None).await?;
+
+        // Evict the pool for the dropped database so stale connections
+        // are not reused.
+        self.connection.invalidate(name).await;
 
         Ok(MessageResponse {
             message: format!("Database '{name}' dropped successfully."),

--- a/crates/mysql/src/tools/drop_database.rs
+++ b/crates/mysql/src/tools/drop_database.rs
@@ -4,8 +4,8 @@ use std::borrow::Cow;
 
 use database_mcp_server::AppError;
 use database_mcp_server::types::{DropDatabaseRequest, MessageResponse};
+use database_mcp_sql::connection::Connection as _;
 use database_mcp_sql::identifier::validate_identifier;
-use database_mcp_sql::timeout::execute_with_timeout;
 use rmcp::handler::server::router::tool::{AsyncTool, ToolBase};
 use rmcp::model::{ErrorData, ToolAnnotations};
 
@@ -76,14 +76,8 @@ impl MysqlHandler {
             )));
         }
 
-        let pool = self.pool.clone();
-        let drop_sql = format!("DROP DATABASE {}", Self::quote_identifier(name));
-        execute_with_timeout(
-            self.config.query_timeout,
-            &drop_sql,
-            sqlx::query(&drop_sql).execute(&pool),
-        )
-        .await?;
+        let drop_sql = format!("DROP DATABASE {}", self.connection.quote_identifier(name));
+        self.connection.execute(drop_sql.as_str(), None).await?;
 
         Ok(MessageResponse {
             message: format!("Database '{name}' dropped successfully."),

--- a/crates/mysql/src/tools/drop_database.rs
+++ b/crates/mysql/src/tools/drop_database.rs
@@ -4,7 +4,7 @@ use std::borrow::Cow;
 
 use database_mcp_server::AppError;
 use database_mcp_server::types::{DropDatabaseRequest, MessageResponse};
-use database_mcp_sql::connection::Connection as _;
+use database_mcp_sql::connection::Connection;
 use database_mcp_sql::identifier::validate_identifier;
 use rmcp::handler::server::router::tool::{AsyncTool, ToolBase};
 use rmcp::model::{ErrorData, ToolAnnotations};

--- a/crates/mysql/src/tools/drop_table.rs
+++ b/crates/mysql/src/tools/drop_table.rs
@@ -4,7 +4,7 @@ use std::borrow::Cow;
 
 use database_mcp_server::AppError;
 use database_mcp_server::types::MessageResponse;
-use database_mcp_sql::connection::Connection;
+use database_mcp_sql::Connection as _;
 use database_mcp_sql::identifier::validate_identifier;
 use rmcp::handler::server::router::tool::{AsyncTool, ToolBase};
 use rmcp::model::{ErrorData, ToolAnnotations};

--- a/crates/mysql/src/tools/drop_table.rs
+++ b/crates/mysql/src/tools/drop_table.rs
@@ -4,11 +4,10 @@ use std::borrow::Cow;
 
 use database_mcp_server::AppError;
 use database_mcp_server::types::MessageResponse;
+use database_mcp_sql::connection::Connection as _;
 use database_mcp_sql::identifier::validate_identifier;
-use database_mcp_sql::timeout::execute_with_timeout;
 use rmcp::handler::server::router::tool::{AsyncTool, ToolBase};
 use rmcp::model::{ErrorData, ToolAnnotations};
-use sqlx::Executor;
 
 use crate::MysqlHandler;
 use crate::types::DropTableRequest;
@@ -71,21 +70,8 @@ impl MysqlHandler {
         validate_identifier(database)?;
         validate_identifier(table)?;
 
-        let pool = self.pool.clone();
-        let db = database.clone();
-        let drop_sql = format!("DROP TABLE {}", Self::quote_identifier(table));
-        let drop_sql_label = drop_sql.clone();
-
-        execute_with_timeout(self.config.query_timeout, &drop_sql_label, async move {
-            let mut conn = pool.acquire().await?;
-
-            let use_sql = format!("USE {}", Self::quote_identifier(&db));
-            conn.execute(use_sql.as_str()).await?;
-
-            conn.execute(drop_sql.as_str()).await?;
-            Ok::<_, sqlx::Error>(())
-        })
-        .await?;
+        let drop_sql = format!("DROP TABLE {}", self.connection.quote_identifier(table));
+        self.connection.execute(drop_sql.as_str(), Some(database)).await?;
 
         Ok(MessageResponse {
             message: format!("Table '{table}' dropped successfully."),

--- a/crates/mysql/src/tools/drop_table.rs
+++ b/crates/mysql/src/tools/drop_table.rs
@@ -4,7 +4,7 @@ use std::borrow::Cow;
 
 use database_mcp_server::AppError;
 use database_mcp_server::types::MessageResponse;
-use database_mcp_sql::connection::Connection as _;
+use database_mcp_sql::connection::Connection;
 use database_mcp_sql::identifier::validate_identifier;
 use rmcp::handler::server::router::tool::{AsyncTool, ToolBase};
 use rmcp::model::{ErrorData, ToolAnnotations};

--- a/crates/mysql/src/tools/explain_query.rs
+++ b/crates/mysql/src/tools/explain_query.rs
@@ -4,7 +4,7 @@ use std::borrow::Cow;
 
 use database_mcp_server::AppError;
 use database_mcp_server::types::{ExplainQueryRequest, QueryResponse};
-use database_mcp_sql::connection::Connection;
+use database_mcp_sql::Connection as _;
 use database_mcp_sql::validation::validate_read_only_with_dialect;
 use rmcp::handler::server::router::tool::{AsyncTool, ToolBase};
 use rmcp::model::{ErrorData, ToolAnnotations};

--- a/crates/mysql/src/tools/explain_query.rs
+++ b/crates/mysql/src/tools/explain_query.rs
@@ -4,9 +4,12 @@ use std::borrow::Cow;
 
 use database_mcp_server::AppError;
 use database_mcp_server::types::{ExplainQueryRequest, QueryResponse};
+use database_mcp_sql::connection::Connection as _;
 use database_mcp_sql::validation::validate_read_only_with_dialect;
 use rmcp::handler::server::router::tool::{AsyncTool, ToolBase};
 use rmcp::model::{ErrorData, ToolAnnotations};
+use serde_json::Value;
+use sqlx_to_json::RowExt;
 
 use crate::MysqlHandler;
 
@@ -70,7 +73,12 @@ impl MysqlHandler {
             format!("EXPLAIN FORMAT=JSON {}", request.query)
         };
 
-        let rows = self.query_to_json(&explain_sql, Some(&request.database_name)).await?;
-        Ok(QueryResponse { rows })
+        let rows = self
+            .connection
+            .fetch(explain_sql.as_str(), Some(request.database_name.as_str()))
+            .await?;
+        Ok(QueryResponse {
+            rows: Value::Array(rows.iter().map(RowExt::to_json).collect()),
+        })
     }
 }

--- a/crates/mysql/src/tools/explain_query.rs
+++ b/crates/mysql/src/tools/explain_query.rs
@@ -4,12 +4,11 @@ use std::borrow::Cow;
 
 use database_mcp_server::AppError;
 use database_mcp_server::types::{ExplainQueryRequest, QueryResponse};
-use database_mcp_sql::connection::Connection as _;
+use database_mcp_sql::connection::Connection;
 use database_mcp_sql::validation::validate_read_only_with_dialect;
 use rmcp::handler::server::router::tool::{AsyncTool, ToolBase};
 use rmcp::model::{ErrorData, ToolAnnotations};
 use serde_json::Value;
-use sqlx_to_json::RowExt;
 
 use crate::MysqlHandler;
 
@@ -78,7 +77,7 @@ impl MysqlHandler {
             .fetch(explain_sql.as_str(), Some(request.database_name.as_str()))
             .await?;
         Ok(QueryResponse {
-            rows: Value::Array(rows.iter().map(RowExt::to_json).collect()),
+            rows: Value::Array(rows),
         })
     }
 }

--- a/crates/mysql/src/tools/get_table_schema.rs
+++ b/crates/mysql/src/tools/get_table_schema.rs
@@ -5,7 +5,7 @@ use std::collections::HashMap;
 
 use database_mcp_server::AppError;
 use database_mcp_server::types::{GetTableSchemaRequest, TableSchemaResponse};
-use database_mcp_sql::connection::Connection;
+use database_mcp_sql::Connection as _;
 use database_mcp_sql::identifier::validate_identifier;
 use rmcp::handler::server::router::tool::{AsyncTool, ToolBase};
 use rmcp::model::{ErrorData, ToolAnnotations};

--- a/crates/mysql/src/tools/get_table_schema.rs
+++ b/crates/mysql/src/tools/get_table_schema.rs
@@ -5,13 +5,13 @@ use std::collections::HashMap;
 
 use database_mcp_server::AppError;
 use database_mcp_server::types::{GetTableSchemaRequest, TableSchemaResponse};
+use database_mcp_sql::connection::Connection as _;
 use database_mcp_sql::identifier::validate_identifier;
-use database_mcp_sql::timeout::execute_with_timeout;
 use rmcp::handler::server::router::tool::{AsyncTool, ToolBase};
 use rmcp::model::{ErrorData, ToolAnnotations};
 use serde_json::{Value, json};
 use sqlx::Row;
-use sqlx::mysql::MySqlRow;
+use sqlx_to_json::RowExt;
 
 use crate::MysqlHandler;
 
@@ -68,27 +68,27 @@ impl MysqlHandler {
         // 1. Get basic schema
         let describe_sql = format!(
             "DESCRIBE {}.{}",
-            Self::quote_identifier(database),
-            Self::quote_identifier(table)
+            self.connection.quote_identifier(database),
+            self.connection.quote_identifier(table)
         );
-        let schema_results = self.query_to_json(&describe_sql, None).await?;
-        let schema_rows = schema_results.as_array().map_or([].as_slice(), Vec::as_slice);
+        let schema_rows = self.connection.fetch(describe_sql.as_str(), None).await?;
 
         if schema_rows.is_empty() {
             return Err(AppError::TableNotFound(format!("{database}.{table}")));
         }
 
         let mut columns: HashMap<String, Value> = HashMap::new();
-        for row in schema_rows {
-            if let Some(col_name) = row.get("Field").and_then(|v| v.as_str()) {
+        for row in &schema_rows {
+            let row_json = RowExt::to_json(row);
+            if let Some(col_name) = row_json.get("Field").and_then(|v| v.as_str()) {
                 columns.insert(
                     col_name.to_string(),
                     json!({
-                        "type": row.get("Type").unwrap_or(&Value::Null),
-                        "nullable": row.get("Null").and_then(|v| v.as_str()).is_some_and(|s| s.to_uppercase() == "YES"),
-                        "key": row.get("Key").unwrap_or(&Value::Null),
-                        "default": row.get("Default").unwrap_or(&Value::Null),
-                        "extra": row.get("Extra").unwrap_or(&Value::Null),
+                        "type": row_json.get("Type").unwrap_or(&Value::Null),
+                        "nullable": row_json.get("Null").and_then(|v| v.as_str()).is_some_and(|s| s.to_uppercase() == "YES"),
+                        "key": row_json.get("Key").unwrap_or(&Value::Null),
+                        "default": row_json.get("Default").unwrap_or(&Value::Null),
+                        "extra": row_json.get("Extra").unwrap_or(&Value::Null),
                         "foreign_key": Value::Null,
                     }),
                 );
@@ -114,12 +114,10 @@ impl MysqlHandler {
             ORDER BY kcu.CONSTRAINT_NAME, kcu.ORDINAL_POSITION
         ";
 
-        let fk_rows: Vec<MySqlRow> = execute_with_timeout(
-            self.config.query_timeout,
-            fk_sql,
-            sqlx::query(fk_sql).bind(database).bind(table).fetch_all(&self.pool),
-        )
-        .await?;
+        let fk_rows = self
+            .connection
+            .fetch(sqlx::query(fk_sql).bind(database).bind(table), None)
+            .await?;
 
         for fk_row in &fk_rows {
             let col_name: Option<String> = fk_row.try_get("column_name").ok();

--- a/crates/mysql/src/tools/get_table_schema.rs
+++ b/crates/mysql/src/tools/get_table_schema.rs
@@ -5,13 +5,11 @@ use std::collections::HashMap;
 
 use database_mcp_server::AppError;
 use database_mcp_server::types::{GetTableSchemaRequest, TableSchemaResponse};
-use database_mcp_sql::connection::Connection as _;
+use database_mcp_sql::connection::Connection;
 use database_mcp_sql::identifier::validate_identifier;
 use rmcp::handler::server::router::tool::{AsyncTool, ToolBase};
 use rmcp::model::{ErrorData, ToolAnnotations};
 use serde_json::{Value, json};
-use sqlx::Row;
-use sqlx_to_json::RowExt;
 
 use crate::MysqlHandler;
 
@@ -79,16 +77,15 @@ impl MysqlHandler {
 
         let mut columns: HashMap<String, Value> = HashMap::new();
         for row in &schema_rows {
-            let row_json = RowExt::to_json(row);
-            if let Some(col_name) = row_json.get("Field").and_then(|v| v.as_str()) {
+            if let Some(col_name) = row.get("Field").and_then(|v| v.as_str()) {
                 columns.insert(
                     col_name.to_string(),
                     json!({
-                        "type": row_json.get("Type").unwrap_or(&Value::Null),
-                        "nullable": row_json.get("Null").and_then(|v| v.as_str()).is_some_and(|s| s.to_uppercase() == "YES"),
-                        "key": row_json.get("Key").unwrap_or(&Value::Null),
-                        "default": row_json.get("Default").unwrap_or(&Value::Null),
-                        "extra": row_json.get("Extra").unwrap_or(&Value::Null),
+                        "type": row.get("Type").unwrap_or(&Value::Null),
+                        "nullable": row.get("Null").and_then(|v| v.as_str()).is_some_and(|s| s.to_uppercase() == "YES"),
+                        "key": row.get("Key").unwrap_or(&Value::Null),
+                        "default": row.get("Default").unwrap_or(&Value::Null),
+                        "extra": row.get("Extra").unwrap_or(&Value::Null),
                         "foreign_key": Value::Null,
                     }),
                 );
@@ -96,8 +93,8 @@ impl MysqlHandler {
         }
 
         // 2. Get FK relationships
-        let fk_sql = r"
-            SELECT
+        let fk_sql = format!(
+            "SELECT
                 kcu.COLUMN_NAME as column_name,
                 kcu.CONSTRAINT_NAME as constraint_name,
                 kcu.REFERENCED_TABLE_NAME as referenced_table,
@@ -108,36 +105,29 @@ impl MysqlHandler {
             INNER JOIN information_schema.REFERENTIAL_CONSTRAINTS rc
                 ON kcu.CONSTRAINT_NAME = rc.CONSTRAINT_NAME
                 AND kcu.CONSTRAINT_SCHEMA = rc.CONSTRAINT_SCHEMA
-            WHERE kcu.TABLE_SCHEMA = ?
-              AND kcu.TABLE_NAME = ?
+            WHERE kcu.TABLE_SCHEMA = {}
+              AND kcu.TABLE_NAME = {}
               AND kcu.REFERENCED_TABLE_NAME IS NOT NULL
-            ORDER BY kcu.CONSTRAINT_NAME, kcu.ORDINAL_POSITION
-        ";
+            ORDER BY kcu.CONSTRAINT_NAME, kcu.ORDINAL_POSITION",
+            self.connection.quote_string(database),
+            self.connection.quote_string(table),
+        );
 
-        let fk_rows = self
-            .connection
-            .fetch(sqlx::query(fk_sql).bind(database).bind(table), None)
-            .await?;
+        let fk_rows = self.connection.fetch(fk_sql.as_str(), None).await?;
 
         for fk_row in &fk_rows {
-            let col_name: Option<String> = fk_row.try_get("column_name").ok();
-            if let Some(col_name) = col_name
-                && let Some(col_info) = columns.get_mut(&col_name)
+            if let Some(col_name) = fk_row.get("column_name").and_then(|v| v.as_str())
+                && let Some(col_info) = columns.get_mut(col_name)
                 && let Some(obj) = col_info.as_object_mut()
             {
-                let constraint_name: Option<String> = fk_row.try_get("constraint_name").ok();
-                let referenced_table: Option<String> = fk_row.try_get("referenced_table").ok();
-                let referenced_column: Option<String> = fk_row.try_get("referenced_column").ok();
-                let on_update: Option<String> = fk_row.try_get("on_update").ok();
-                let on_delete: Option<String> = fk_row.try_get("on_delete").ok();
                 obj.insert(
                     "foreign_key".to_string(),
                     json!({
-                        "constraint_name": constraint_name,
-                        "referenced_table": referenced_table,
-                        "referenced_column": referenced_column,
-                        "on_update": on_update,
-                        "on_delete": on_delete,
+                        "constraint_name": fk_row.get("constraint_name"),
+                        "referenced_table": fk_row.get("referenced_table"),
+                        "referenced_column": fk_row.get("referenced_column"),
+                        "on_update": fk_row.get("on_update"),
+                        "on_delete": fk_row.get("on_delete"),
                     }),
                 );
             }

--- a/crates/mysql/src/tools/list_databases.rs
+++ b/crates/mysql/src/tools/list_databases.rs
@@ -5,7 +5,7 @@ use std::sync::Arc;
 
 use database_mcp_server::AppError;
 use database_mcp_server::types::ListDatabasesResponse;
-use database_mcp_sql::connection::Connection;
+use database_mcp_sql::Connection as _;
 use rmcp::handler::server::common::schema_for_empty_input;
 use rmcp::handler::server::router::tool::{AsyncTool, ToolBase};
 use rmcp::model::{ErrorData, JsonObject, ToolAnnotations};

--- a/crates/mysql/src/tools/list_databases.rs
+++ b/crates/mysql/src/tools/list_databases.rs
@@ -5,9 +5,11 @@ use std::sync::Arc;
 
 use database_mcp_server::AppError;
 use database_mcp_server::types::ListDatabasesResponse;
+use database_mcp_sql::connection::Connection as _;
 use rmcp::handler::server::common::schema_for_empty_input;
 use rmcp::handler::server::router::tool::{AsyncTool, ToolBase};
 use rmcp::model::{ErrorData, JsonObject, ToolAnnotations};
+use sqlx_to_json::RowExt;
 
 use crate::MysqlHandler;
 
@@ -60,17 +62,16 @@ impl MysqlHandler {
     ///
     /// Returns [`AppError`] if the query fails.
     pub async fn list_databases(&self) -> Result<ListDatabasesResponse, AppError> {
-        let results = self
-            .query_to_json(
-                "SELECT SCHEMA_NAME AS name FROM information_schema.SCHEMATA ORDER BY SCHEMA_NAME",
-                None,
-            )
-            .await?;
-        let rows = results.as_array().map_or([].as_slice(), Vec::as_slice);
+        let sql = "SELECT SCHEMA_NAME AS name FROM information_schema.SCHEMATA ORDER BY SCHEMA_NAME";
+        let rows = self.connection.fetch(sql, None).await?;
         Ok(ListDatabasesResponse {
             databases: rows
                 .iter()
-                .filter_map(|row| row.get("name").and_then(|v| v.as_str().map(String::from)))
+                .filter_map(|row| {
+                    RowExt::to_json(row)
+                        .get("name")
+                        .and_then(|v| v.as_str().map(String::from))
+                })
                 .collect(),
         })
     }

--- a/crates/mysql/src/tools/list_databases.rs
+++ b/crates/mysql/src/tools/list_databases.rs
@@ -5,11 +5,10 @@ use std::sync::Arc;
 
 use database_mcp_server::AppError;
 use database_mcp_server::types::ListDatabasesResponse;
-use database_mcp_sql::connection::Connection as _;
+use database_mcp_sql::connection::Connection;
 use rmcp::handler::server::common::schema_for_empty_input;
 use rmcp::handler::server::router::tool::{AsyncTool, ToolBase};
 use rmcp::model::{ErrorData, JsonObject, ToolAnnotations};
-use sqlx_to_json::RowExt;
 
 use crate::MysqlHandler;
 
@@ -67,11 +66,7 @@ impl MysqlHandler {
         Ok(ListDatabasesResponse {
             databases: rows
                 .iter()
-                .filter_map(|row| {
-                    RowExt::to_json(row)
-                        .get("name")
-                        .and_then(|v| v.as_str().map(String::from))
-                })
+                .filter_map(|row| row.get("name").and_then(|v| v.as_str().map(String::from)))
                 .collect(),
         })
     }

--- a/crates/mysql/src/tools/list_tables.rs
+++ b/crates/mysql/src/tools/list_tables.rs
@@ -4,7 +4,7 @@ use std::borrow::Cow;
 
 use database_mcp_server::AppError;
 use database_mcp_server::types::{ListTablesRequest, ListTablesResponse};
-use database_mcp_sql::connection::Connection;
+use database_mcp_sql::Connection as _;
 use database_mcp_sql::identifier::validate_identifier;
 use rmcp::handler::server::router::tool::{AsyncTool, ToolBase};
 use rmcp::model::{ErrorData, ToolAnnotations};

--- a/crates/mysql/src/tools/list_tables.rs
+++ b/crates/mysql/src/tools/list_tables.rs
@@ -4,11 +4,10 @@ use std::borrow::Cow;
 
 use database_mcp_server::AppError;
 use database_mcp_server::types::{ListTablesRequest, ListTablesResponse};
-use database_mcp_sql::connection::Connection as _;
+use database_mcp_sql::connection::Connection;
 use database_mcp_sql::identifier::validate_identifier;
 use rmcp::handler::server::router::tool::{AsyncTool, ToolBase};
 use rmcp::model::{ErrorData, ToolAnnotations};
-use sqlx_to_json::RowExt;
 
 use crate::MysqlHandler;
 
@@ -67,11 +66,7 @@ impl MysqlHandler {
         Ok(ListTablesResponse {
             tables: rows
                 .iter()
-                .filter_map(|row| {
-                    RowExt::to_json(row)
-                        .get("name")
-                        .and_then(|v| v.as_str().map(String::from))
-                })
+                .filter_map(|row| row.get("name").and_then(|v| v.as_str().map(String::from)))
                 .collect(),
         })
     }

--- a/crates/mysql/src/tools/list_tables.rs
+++ b/crates/mysql/src/tools/list_tables.rs
@@ -4,9 +4,11 @@ use std::borrow::Cow;
 
 use database_mcp_server::AppError;
 use database_mcp_server::types::{ListTablesRequest, ListTablesResponse};
+use database_mcp_sql::connection::Connection as _;
 use database_mcp_sql::identifier::validate_identifier;
 use rmcp::handler::server::router::tool::{AsyncTool, ToolBase};
 use rmcp::model::{ErrorData, ToolAnnotations};
+use sqlx_to_json::RowExt;
 
 use crate::MysqlHandler;
 
@@ -59,14 +61,17 @@ impl MysqlHandler {
         validate_identifier(&request.database_name)?;
         let sql = format!(
             "SELECT TABLE_NAME AS name FROM information_schema.TABLES WHERE TABLE_SCHEMA = {} ORDER BY TABLE_NAME",
-            Self::quote_string(&request.database_name)
+            self.connection.quote_string(&request.database_name)
         );
-        let results = self.query_to_json(&sql, None).await?;
-        let rows = results.as_array().map_or([].as_slice(), Vec::as_slice);
+        let rows = self.connection.fetch(sql.as_str(), None).await?;
         Ok(ListTablesResponse {
             tables: rows
                 .iter()
-                .filter_map(|row| row.get("name").and_then(|v| v.as_str().map(String::from)))
+                .filter_map(|row| {
+                    RowExt::to_json(row)
+                        .get("name")
+                        .and_then(|v| v.as_str().map(String::from))
+                })
                 .collect(),
         })
     }

--- a/crates/mysql/src/tools/read_query.rs
+++ b/crates/mysql/src/tools/read_query.rs
@@ -4,7 +4,7 @@ use std::borrow::Cow;
 
 use database_mcp_server::AppError;
 use database_mcp_server::types::{QueryRequest, QueryResponse};
-use database_mcp_sql::connection::Connection;
+use database_mcp_sql::Connection as _;
 use database_mcp_sql::validation::validate_read_only_with_dialect;
 use rmcp::handler::server::router::tool::{AsyncTool, ToolBase};
 use rmcp::model::{ErrorData, ToolAnnotations};

--- a/crates/mysql/src/tools/read_query.rs
+++ b/crates/mysql/src/tools/read_query.rs
@@ -4,9 +4,12 @@ use std::borrow::Cow;
 
 use database_mcp_server::AppError;
 use database_mcp_server::types::{QueryRequest, QueryResponse};
+use database_mcp_sql::connection::Connection as _;
 use database_mcp_sql::validation::validate_read_only_with_dialect;
 use rmcp::handler::server::router::tool::{AsyncTool, ToolBase};
 use rmcp::model::{ErrorData, ToolAnnotations};
+use serde_json::Value;
+use sqlx_to_json::RowExt;
 
 use crate::MysqlHandler;
 
@@ -60,7 +63,9 @@ impl MysqlHandler {
     pub async fn read_query(&self, request: &QueryRequest) -> Result<QueryResponse, AppError> {
         validate_read_only_with_dialect(&request.query, &sqlparser::dialect::MySqlDialect {})?;
         let db = Some(request.database_name.trim()).filter(|s| !s.is_empty());
-        let rows = self.query_to_json(&request.query, db).await?;
-        Ok(QueryResponse { rows })
+        let rows = self.connection.fetch(request.query.as_str(), db).await?;
+        Ok(QueryResponse {
+            rows: Value::Array(rows.iter().map(RowExt::to_json).collect()),
+        })
     }
 }

--- a/crates/mysql/src/tools/read_query.rs
+++ b/crates/mysql/src/tools/read_query.rs
@@ -4,12 +4,11 @@ use std::borrow::Cow;
 
 use database_mcp_server::AppError;
 use database_mcp_server::types::{QueryRequest, QueryResponse};
-use database_mcp_sql::connection::Connection as _;
+use database_mcp_sql::connection::Connection;
 use database_mcp_sql::validation::validate_read_only_with_dialect;
 use rmcp::handler::server::router::tool::{AsyncTool, ToolBase};
 use rmcp::model::{ErrorData, ToolAnnotations};
 use serde_json::Value;
-use sqlx_to_json::RowExt;
 
 use crate::MysqlHandler;
 
@@ -65,7 +64,7 @@ impl MysqlHandler {
         let db = Some(request.database_name.trim()).filter(|s| !s.is_empty());
         let rows = self.connection.fetch(request.query.as_str(), db).await?;
         Ok(QueryResponse {
-            rows: Value::Array(rows.iter().map(RowExt::to_json).collect()),
+            rows: Value::Array(rows),
         })
     }
 }

--- a/crates/mysql/src/tools/write_query.rs
+++ b/crates/mysql/src/tools/write_query.rs
@@ -4,7 +4,7 @@ use std::borrow::Cow;
 
 use database_mcp_server::AppError;
 use database_mcp_server::types::{QueryRequest, QueryResponse};
-use database_mcp_sql::connection::Connection;
+use database_mcp_sql::Connection as _;
 use rmcp::handler::server::router::tool::{AsyncTool, ToolBase};
 use rmcp::model::{ErrorData, ToolAnnotations};
 use serde_json::Value;

--- a/crates/mysql/src/tools/write_query.rs
+++ b/crates/mysql/src/tools/write_query.rs
@@ -4,8 +4,11 @@ use std::borrow::Cow;
 
 use database_mcp_server::AppError;
 use database_mcp_server::types::{QueryRequest, QueryResponse};
+use database_mcp_sql::connection::Connection as _;
 use rmcp::handler::server::router::tool::{AsyncTool, ToolBase};
 use rmcp::model::{ErrorData, ToolAnnotations};
+use serde_json::Value;
+use sqlx_to_json::RowExt;
 
 use crate::MysqlHandler;
 
@@ -55,7 +58,9 @@ impl MysqlHandler {
     /// Returns [`AppError`] if the query fails.
     pub async fn write_query(&self, request: &QueryRequest) -> Result<QueryResponse, AppError> {
         let db = Some(request.database_name.trim()).filter(|s| !s.is_empty());
-        let rows = self.query_to_json(&request.query, db).await?;
-        Ok(QueryResponse { rows })
+        let rows = self.connection.fetch(request.query.as_str(), db).await?;
+        Ok(QueryResponse {
+            rows: Value::Array(rows.iter().map(RowExt::to_json).collect()),
+        })
     }
 }

--- a/crates/mysql/src/tools/write_query.rs
+++ b/crates/mysql/src/tools/write_query.rs
@@ -4,11 +4,10 @@ use std::borrow::Cow;
 
 use database_mcp_server::AppError;
 use database_mcp_server::types::{QueryRequest, QueryResponse};
-use database_mcp_sql::connection::Connection as _;
+use database_mcp_sql::connection::Connection;
 use rmcp::handler::server::router::tool::{AsyncTool, ToolBase};
 use rmcp::model::{ErrorData, ToolAnnotations};
 use serde_json::Value;
-use sqlx_to_json::RowExt;
 
 use crate::MysqlHandler;
 
@@ -60,7 +59,7 @@ impl MysqlHandler {
         let db = Some(request.database_name.trim()).filter(|s| !s.is_empty());
         let rows = self.connection.fetch(request.query.as_str(), db).await?;
         Ok(QueryResponse {
-            rows: Value::Array(rows.iter().map(RowExt::to_json).collect()),
+            rows: Value::Array(rows),
         })
     }
 }

--- a/crates/postgres/src/connection.rs
+++ b/crates/postgres/src/connection.rs
@@ -11,7 +11,7 @@ use database_mcp_server::AppError;
 use database_mcp_sql::Connection;
 use database_mcp_sql::identifier::validate_identifier;
 use moka::future::Cache;
-use sqlx::postgres::{PgConnectOptions, PgPool, PgPoolOptions, PgSslMode};
+use sqlx::postgres::{PgConnectOptions, PgPool, PgSslMode};
 use tracing::info;
 
 /// Maximum number of cached per-database connection pools.
@@ -109,7 +109,7 @@ impl PostgresConnection {
             .get_with(key, async {
                 let mut cfg = config;
                 cfg.name = Some(db_key.to_owned());
-                pool_options(&cfg).connect_lazy_with(connect_options(&cfg))
+                create_lazy_pool(&cfg)
             })
             .await;
 
@@ -130,27 +130,12 @@ impl Connection for PostgresConnection {
     }
 }
 
-/// Builds [`PgPoolOptions`] with lifecycle defaults from a [`DatabaseConfig`].
-fn pool_options(config: &DatabaseConfig) -> PgPoolOptions {
-    let mut opts = PgPoolOptions::new()
-        .max_connections(config.max_pool_size)
-        .min_connections(DatabaseConfig::DEFAULT_MIN_CONNECTIONS)
-        .idle_timeout(Duration::from_secs(DatabaseConfig::DEFAULT_IDLE_TIMEOUT_SECS))
-        .max_lifetime(Duration::from_secs(DatabaseConfig::DEFAULT_MAX_LIFETIME_SECS));
-
-    if let Some(timeout) = config.connection_timeout {
-        opts = opts.acquire_timeout(Duration::from_secs(timeout));
-    }
-
-    opts
-}
-
-/// Builds [`PgConnectOptions`] from a [`DatabaseConfig`].
+/// Creates a lazy `PostgreSQL` pool from a [`DatabaseConfig`].
 ///
 /// Uses [`PgConnectOptions::new_without_pgpass`] to avoid unintended
 /// `PG*` environment variable influence, since our config already
 /// resolves values from CLI/env.
-fn connect_options(config: &DatabaseConfig) -> PgConnectOptions {
+fn create_lazy_pool(config: &DatabaseConfig) -> PgPool {
     let mut opts = PgConnectOptions::new_without_pgpass()
         .host(&config.host)
         .port(config.port)
@@ -182,7 +167,17 @@ fn connect_options(config: &DatabaseConfig) -> PgConnectOptions {
         }
     }
 
-    opts
+    let mut pool_opts = sqlx::pool::PoolOptions::new()
+        .max_connections(config.max_pool_size)
+        .min_connections(DatabaseConfig::DEFAULT_MIN_CONNECTIONS)
+        .idle_timeout(Duration::from_secs(DatabaseConfig::DEFAULT_IDLE_TIMEOUT_SECS))
+        .max_lifetime(Duration::from_secs(DatabaseConfig::DEFAULT_MAX_LIFETIME_SECS));
+
+    if let Some(timeout) = config.connection_timeout {
+        pool_opts = pool_opts.acquire_timeout(Duration::from_secs(timeout));
+    }
+
+    pool_opts.connect_lazy_with(opts)
 }
 
 #[cfg(test)]
@@ -202,97 +197,28 @@ mod tests {
         }
     }
 
-    #[test]
-    fn pool_options_applies_defaults() {
-        let config = base_config();
-        let opts = pool_options(&config);
-
-        assert_eq!(opts.get_max_connections(), config.max_pool_size);
-        assert_eq!(opts.get_min_connections(), DatabaseConfig::DEFAULT_MIN_CONNECTIONS);
-        assert_eq!(
-            opts.get_idle_timeout(),
-            Some(Duration::from_secs(DatabaseConfig::DEFAULT_IDLE_TIMEOUT_SECS))
-        );
-        assert_eq!(
-            opts.get_max_lifetime(),
-            Some(Duration::from_secs(DatabaseConfig::DEFAULT_MAX_LIFETIME_SECS))
-        );
+    #[tokio::test]
+    async fn create_lazy_pool_returns_idle_pool() {
+        let pool = create_lazy_pool(&base_config());
+        assert_eq!(pool.size(), 0, "pool should be lazy (no connections yet)");
     }
 
-    #[test]
-    fn pool_options_applies_connection_timeout() {
-        let config = DatabaseConfig {
-            connection_timeout: Some(7),
-            ..base_config()
-        };
-        let opts = pool_options(&config);
-
-        assert_eq!(opts.get_acquire_timeout(), Duration::from_secs(7));
-    }
-
-    #[test]
-    fn pool_options_without_connection_timeout_uses_sqlx_default() {
-        let config = base_config();
-        let opts = pool_options(&config);
-
-        assert_eq!(opts.get_acquire_timeout(), Duration::from_secs(30));
-    }
-
-    #[test]
-    fn try_from_basic_config() {
-        let config = base_config();
-        let opts = connect_options(&config);
-
-        assert_eq!(opts.get_host(), "pg.example.com");
-        assert_eq!(opts.get_port(), 5433);
-        assert_eq!(opts.get_username(), "pgadmin");
-        assert_eq!(opts.get_database(), Some("mydb"));
-    }
-
-    #[test]
-    fn try_from_with_ssl_require() {
-        let config = DatabaseConfig {
-            ssl: true,
-            ssl_verify_cert: false,
-            ..base_config()
-        };
-        let opts = connect_options(&config);
-
-        assert!(matches!(opts.get_ssl_mode(), PgSslMode::Require));
-    }
-
-    #[test]
-    fn try_from_with_ssl_verify_ca() {
-        let config = DatabaseConfig {
-            ssl: true,
-            ssl_verify_cert: true,
-            ..base_config()
-        };
-        let opts = connect_options(&config);
-
-        assert!(matches!(opts.get_ssl_mode(), PgSslMode::VerifyCa));
-    }
-
-    #[test]
-    fn try_from_without_database_name() {
-        let config = DatabaseConfig {
-            name: None,
-            ..base_config()
-        };
-        let opts = connect_options(&config);
-
-        assert_eq!(opts.get_database(), None);
-    }
-
-    #[test]
-    fn try_from_without_password() {
-        let config = DatabaseConfig {
+    #[tokio::test]
+    async fn create_lazy_pool_without_password() {
+        let pool = create_lazy_pool(&DatabaseConfig {
             password: None,
             ..base_config()
-        };
-        let opts = connect_options(&config);
+        });
+        assert_eq!(pool.size(), 0);
+    }
 
-        assert_eq!(opts.get_host(), "pg.example.com");
+    #[tokio::test]
+    async fn create_lazy_pool_without_database_name() {
+        let pool = create_lazy_pool(&DatabaseConfig {
+            name: None,
+            ..base_config()
+        });
+        assert_eq!(pool.size(), 0);
     }
 
     #[tokio::test]

--- a/crates/postgres/src/connection.rs
+++ b/crates/postgres/src/connection.rs
@@ -1,6 +1,6 @@
 //! `PostgreSQL` connection: pool cache, pool initialization, and [`Connection`] impl.
 //!
-//! Owns the lazy default pool and the moka cache of per-database pools.
+//! Owns a moka cache of lazily-created per-database pools (including the default).
 //! Hides every backend pool concern from [`PostgresHandler`](crate::PostgresHandler),
 //! which composes one [`PostgresConnection`] as a field.
 
@@ -21,35 +21,23 @@ pub(crate) const POOL_CACHE_CAPACITY: u64 = 16;
 #[derive(Clone)]
 pub(crate) struct PostgresConnection {
     config: DatabaseConfig,
-    default_db: String,
-    default_pool: PgPool,
     pools: Cache<String, PgPool>,
 }
 
 impl std::fmt::Debug for PostgresConnection {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.debug_struct("PostgresConnection")
-            .field("default_db", &self.default_db)
+            .field("default_db", &self.default_db())
             .finish_non_exhaustive()
     }
 }
 
 impl PostgresConnection {
-    /// Builds the connection and its lazy default pool.
+    /// Builds the connection with an empty pool cache.
     ///
-    /// Does **not** establish a database connection. The default pool
-    /// connects on demand when the first query is executed. Non-default
-    /// database pools are created lazily on first request.
+    /// Does **not** establish a database connection. All pools — including
+    /// the default — are created lazily on first request via [`pool`](Self::pool).
     pub(crate) fn new(config: &DatabaseConfig) -> Self {
-        // PostgreSQL defaults to a database named after the connecting user.
-        let default_db = config
-            .name
-            .as_deref()
-            .filter(|n| !n.is_empty())
-            .map_or_else(|| config.user.clone(), String::from);
-
-        let default_pool = pool_options(config).connect_lazy_with(connect_options(config));
-
         info!(
             "PostgreSQL lazy connection pool created (max size: {})",
             config.max_pool_size
@@ -66,15 +54,22 @@ impl PostgresConnection {
 
         Self {
             config: config.clone(),
-            default_db,
-            default_pool,
             pools,
         }
     }
 
-    /// Returns the name of the database resolved at startup.
+    /// Returns the configured default database name, or the username as fallback.
     pub(crate) fn default_db(&self) -> &str {
-        &self.default_db
+        self.config
+            .name
+            .as_deref()
+            .filter(|n| !n.is_empty())
+            .unwrap_or(&self.config.user)
+    }
+
+    /// Returns `true` if `name` matches the default database (case-sensitive).
+    fn is_default_db(&self, name: &str) -> bool {
+        name == self.default_db()
     }
 
     /// Evicts the cached pool for `name`, closing its connections.
@@ -95,25 +90,23 @@ impl PostgresConnection {
     pub(crate) async fn pool(&self, target: Option<&str>) -> Result<PgPool, AppError> {
         let db_key = match target {
             Some(name) if !name.is_empty() => name,
-            _ => return Ok(self.default_pool.clone()),
+            _ => self.default_db(),
         };
-
-        if db_key == self.default_db {
-            return Ok(self.default_pool.clone());
-        }
 
         if let Some(pool) = self.pools.get(db_key).await {
             return Ok(pool);
         }
 
-        validate_identifier(db_key)?;
+        if !self.is_default_db(db_key) {
+            validate_identifier(db_key)?;
+        }
 
         let config = self.config.clone();
-        let db_key_owned = db_key.to_owned();
+        let key = db_key.to_owned();
 
         let pool = self
             .pools
-            .get_with(db_key_owned, async {
+            .get_with(key, async {
                 let mut cfg = config;
                 cfg.name = Some(db_key.to_owned());
                 pool_options(&cfg).connect_lazy_with(connect_options(&cfg))
@@ -303,10 +296,9 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn new_creates_lazy_default_pool() {
+    async fn default_db_derived_from_config() {
         let connection = PostgresConnection::new(&base_config());
         assert_eq!(connection.default_db(), "mydb");
-        assert_eq!(connection.default_pool.size(), 0, "default pool should be lazy");
     }
 
     #[tokio::test]

--- a/crates/postgres/src/connection.rs
+++ b/crates/postgres/src/connection.rs
@@ -27,7 +27,7 @@ pub(crate) struct PostgresConnection {
 impl std::fmt::Debug for PostgresConnection {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.debug_struct("PostgresConnection")
-            .field("default_db", &self.default_db())
+            .field("default_database_name", &self.default_database_name())
             .finish_non_exhaustive()
     }
 }
@@ -59,7 +59,7 @@ impl PostgresConnection {
     }
 
     /// Returns the configured default database name, or the username as fallback.
-    pub(crate) fn default_db(&self) -> &str {
+    pub(crate) fn default_database_name(&self) -> &str {
         self.config
             .name
             .as_deref()
@@ -83,29 +83,22 @@ impl PostgresConnection {
     ///
     /// - [`AppError::InvalidIdentifier`] — `target` failed identifier validation.
     pub(crate) async fn pool(&self, target: Option<&str>) -> Result<PgPool, AppError> {
-        let db_key = match target {
+        let database = match target {
             Some(name) if !name.is_empty() => name,
-            _ => self.default_db(),
+            _ => self.default_database_name(),
         };
 
-        if let Some(pool) = self.pools.get(db_key).await {
+        if let Some(pool) = self.pools.get(database).await {
             return Ok(pool);
         }
 
-        if db_key != self.default_db() {
-            validate_identifier(db_key)?;
+        if database != self.default_database_name() {
+            validate_identifier(database)?;
         }
-
-        let config = self.config.clone();
-        let key = db_key.to_owned();
 
         let pool = self
             .pools
-            .get_with(key, async {
-                let mut cfg = config;
-                cfg.name = Some(db_key.to_owned());
-                create_lazy_pool(&cfg)
-            })
+            .get_with(database.to_owned(), async { create_lazy_pool(&self.config, database) })
             .await;
 
         Ok(pool)
@@ -125,40 +118,38 @@ impl Connection for PostgresConnection {
     }
 }
 
-/// Creates a lazy `PostgreSQL` pool from a [`DatabaseConfig`].
+/// Creates a lazy `PostgreSQL` pool for `db_name`.
 ///
 /// Uses [`PgConnectOptions::new_without_pgpass`] to avoid unintended
 /// `PG*` environment variable influence, since our config already
 /// resolves values from CLI/env.
-fn create_lazy_pool(config: &DatabaseConfig) -> PgPool {
-    let mut opts = PgConnectOptions::new_without_pgpass()
+fn create_lazy_pool(config: &DatabaseConfig, database: &str) -> PgPool {
+    let mut conn_ops = PgConnectOptions::new_without_pgpass()
         .host(&config.host)
         .port(config.port)
         .username(&config.user);
 
     if let Some(ref password) = config.password {
-        opts = opts.password(password);
+        conn_ops = conn_ops.password(password);
     }
-    if let Some(ref name) = config.name
-        && !name.is_empty()
-    {
-        opts = opts.database(name);
+    if !database.is_empty() {
+        conn_ops = conn_ops.database(database);
     }
 
     if config.ssl {
-        opts = if config.ssl_verify_cert {
-            opts.ssl_mode(PgSslMode::VerifyCa)
+        conn_ops = if config.ssl_verify_cert {
+            conn_ops.ssl_mode(PgSslMode::VerifyCa)
         } else {
-            opts.ssl_mode(PgSslMode::Require)
+            conn_ops.ssl_mode(PgSslMode::Require)
         };
         if let Some(ref ca) = config.ssl_ca {
-            opts = opts.ssl_root_cert(ca);
+            conn_ops = conn_ops.ssl_root_cert(ca);
         }
         if let Some(ref cert) = config.ssl_cert {
-            opts = opts.ssl_client_cert(cert);
+            conn_ops = conn_ops.ssl_client_cert(cert);
         }
         if let Some(ref key) = config.ssl_key {
-            opts = opts.ssl_client_key(key);
+            conn_ops = conn_ops.ssl_client_key(key);
         }
     }
 
@@ -172,7 +163,7 @@ fn create_lazy_pool(config: &DatabaseConfig) -> PgPool {
         pool_opts = pool_opts.acquire_timeout(Duration::from_secs(timeout));
     }
 
-    pool_opts.connect_lazy_with(opts)
+    pool_opts.connect_lazy_with(conn_ops)
 }
 
 #[cfg(test)]
@@ -194,32 +185,38 @@ mod tests {
 
     #[tokio::test]
     async fn create_lazy_pool_returns_idle_pool() {
-        let pool = create_lazy_pool(&base_config());
+        let pool = create_lazy_pool(&base_config(), "mydb");
         assert_eq!(pool.size(), 0, "pool should be lazy (no connections yet)");
     }
 
     #[tokio::test]
     async fn create_lazy_pool_without_password() {
-        let pool = create_lazy_pool(&DatabaseConfig {
-            password: None,
-            ..base_config()
-        });
+        let pool = create_lazy_pool(
+            &DatabaseConfig {
+                password: None,
+                ..base_config()
+            },
+            "mydb",
+        );
         assert_eq!(pool.size(), 0);
     }
 
     #[tokio::test]
     async fn create_lazy_pool_without_database_name() {
-        let pool = create_lazy_pool(&DatabaseConfig {
-            name: None,
-            ..base_config()
-        });
+        let pool = create_lazy_pool(
+            &DatabaseConfig {
+                name: None,
+                ..base_config()
+            },
+            "",
+        );
         assert_eq!(pool.size(), 0);
     }
 
     #[tokio::test]
-    async fn default_db_derived_from_config() {
+    async fn default_database_name_derived_from_config() {
         let connection = PostgresConnection::new(&base_config());
-        assert_eq!(connection.default_db(), "mydb");
+        assert_eq!(connection.default_database_name(), "mydb");
     }
 
     #[tokio::test]
@@ -228,7 +225,7 @@ mod tests {
             name: None,
             ..base_config()
         });
-        assert_eq!(connection.default_db(), "pgadmin");
+        assert_eq!(connection.default_database_name(), "pgadmin");
     }
 
     #[tokio::test]

--- a/crates/postgres/src/connection.rs
+++ b/crates/postgres/src/connection.rs
@@ -1,4 +1,4 @@
-//! `PostgreSQL` connection: pool cache, pool initialization, and [`Connection`] impl.
+//! `PostgreSQL` connection: pool cache, pool initialization, and [`PoolProvider`] impl.
 //!
 //! Owns the lazy default pool and the moka cache of per-database pools.
 //! Hides every backend pool concern from [`PostgresHandler`](crate::PostgresHandler),
@@ -8,14 +8,10 @@ use std::time::Duration;
 
 use database_mcp_config::DatabaseConfig;
 use database_mcp_server::AppError;
-use database_mcp_sql::connection::Connection;
+use database_mcp_sql::PoolProvider;
 use database_mcp_sql::identifier::validate_identifier;
-use database_mcp_sql::timeout::execute_with_timeout;
 use moka::future::Cache;
-use serde_json::Value;
-use sqlx::Executor;
 use sqlx::postgres::{PgConnectOptions, PgPool, PgPoolOptions, PgSslMode};
-use sqlx_to_json::RowExt;
 use tracing::info;
 
 /// Maximum number of cached per-database connection pools.
@@ -134,38 +130,15 @@ impl PostgresConnection {
     }
 }
 
-impl Connection for PostgresConnection {
-    async fn execute(&self, query: &str, database: Option<&str>) -> Result<u64, AppError> {
-        let pool = self.pool(database).await?;
-        let sql = query.to_owned();
-        execute_with_timeout(self.config.query_timeout, query, async move {
-            let mut conn = pool.acquire().await?;
-            let result = (&mut *conn).execute(sql.as_str()).await?;
-            Ok::<_, sqlx::Error>(result.rows_affected())
-        })
-        .await
+impl PoolProvider for PostgresConnection {
+    type DB = sqlx::Postgres;
+
+    async fn pool(&self, target: Option<&str>) -> Result<sqlx::Pool<Self::DB>, AppError> {
+        self.pool(target).await
     }
 
-    async fn fetch(&self, query: &str, database: Option<&str>) -> Result<Vec<Value>, AppError> {
-        let pool = self.pool(database).await?;
-        let sql = query.to_owned();
-        execute_with_timeout(self.config.query_timeout, query, async move {
-            let mut conn = pool.acquire().await?;
-            let rows = (&mut *conn).fetch_all(sql.as_str()).await?;
-            Ok::<_, sqlx::Error>(rows.iter().map(RowExt::to_json).collect())
-        })
-        .await
-    }
-
-    async fn fetch_optional(&self, query: &str, database: Option<&str>) -> Result<Option<Value>, AppError> {
-        let pool = self.pool(database).await?;
-        let sql = query.to_owned();
-        execute_with_timeout(self.config.query_timeout, query, async move {
-            let mut conn = pool.acquire().await?;
-            let row = (&mut *conn).fetch_optional(sql.as_str()).await?;
-            Ok::<_, sqlx::Error>(row.as_ref().map(RowExt::to_json))
-        })
-        .await
+    fn query_timeout(&self) -> Option<u64> {
+        self.config.query_timeout
     }
 }
 

--- a/crates/postgres/src/connection.rs
+++ b/crates/postgres/src/connection.rs
@@ -8,12 +8,14 @@ use std::time::Duration;
 
 use database_mcp_config::DatabaseConfig;
 use database_mcp_server::AppError;
-use database_mcp_sql::connection::{Connection, Executable, Query};
+use database_mcp_sql::connection::Connection;
 use database_mcp_sql::identifier::validate_identifier;
 use database_mcp_sql::timeout::execute_with_timeout;
 use moka::future::Cache;
-use sqlx::Postgres;
-use sqlx::postgres::{PgConnectOptions, PgPool, PgPoolOptions, PgQueryResult, PgSslMode};
+use serde_json::Value;
+use sqlx::Executor;
+use sqlx::postgres::{PgConnectOptions, PgPool, PgPoolOptions, PgSslMode};
+use sqlx_to_json::RowExt;
 use tracing::info;
 
 /// Maximum number of cached per-database connection pools.
@@ -133,43 +135,35 @@ impl PostgresConnection {
 }
 
 impl Connection for PostgresConnection {
-    type Database = Postgres;
-
-    async fn execute<Q>(&self, query: Q, target: Option<&str>) -> Result<PgQueryResult, AppError>
-    where
-        Q: Executable<Postgres>,
-    {
-        let pool = self.pool(target).await?;
-        let sql = query.sql().to_owned();
-        execute_with_timeout(self.config.query_timeout, &sql, async move {
+    async fn execute(&self, query: &str, database: Option<&str>) -> Result<u64, AppError> {
+        let pool = self.pool(database).await?;
+        let sql = query.to_owned();
+        execute_with_timeout(self.config.query_timeout, query, async move {
             let mut conn = pool.acquire().await?;
-            query.run_execute(&mut conn).await
+            let result = (&mut *conn).execute(sql.as_str()).await?;
+            Ok::<_, sqlx::Error>(result.rows_affected())
         })
         .await
     }
 
-    async fn fetch<Q>(&self, query: Q, target: Option<&str>) -> Result<Vec<Q::Output>, AppError>
-    where
-        Q: Query<Postgres>,
-    {
-        let pool = self.pool(target).await?;
-        let sql = query.sql().to_owned();
-        execute_with_timeout(self.config.query_timeout, &sql, async move {
+    async fn fetch(&self, query: &str, database: Option<&str>) -> Result<Vec<Value>, AppError> {
+        let pool = self.pool(database).await?;
+        let sql = query.to_owned();
+        execute_with_timeout(self.config.query_timeout, query, async move {
             let mut conn = pool.acquire().await?;
-            query.run_fetch_all(&mut conn).await
+            let rows = (&mut *conn).fetch_all(sql.as_str()).await?;
+            Ok::<_, sqlx::Error>(rows.iter().map(RowExt::to_json).collect())
         })
         .await
     }
 
-    async fn fetch_optional<Q>(&self, query: Q, target: Option<&str>) -> Result<Option<Q::Output>, AppError>
-    where
-        Q: Query<Postgres>,
-    {
-        let pool = self.pool(target).await?;
-        let sql = query.sql().to_owned();
-        execute_with_timeout(self.config.query_timeout, &sql, async move {
+    async fn fetch_optional(&self, query: &str, database: Option<&str>) -> Result<Option<Value>, AppError> {
+        let pool = self.pool(database).await?;
+        let sql = query.to_owned();
+        execute_with_timeout(self.config.query_timeout, query, async move {
             let mut conn = pool.acquire().await?;
-            query.run_fetch_optional(&mut conn).await
+            let row = (&mut *conn).fetch_optional(sql.as_str()).await?;
+            Ok::<_, sqlx::Error>(row.as_ref().map(RowExt::to_json))
         })
         .await
     }

--- a/crates/postgres/src/connection.rs
+++ b/crates/postgres/src/connection.rs
@@ -1,4 +1,4 @@
-//! `PostgreSQL` connection: pool cache, pool initialization, and [`PoolProvider`] impl.
+//! `PostgreSQL` connection: pool cache, pool initialization, and [`Connection`] impl.
 //!
 //! Owns the lazy default pool and the moka cache of per-database pools.
 //! Hides every backend pool concern from [`PostgresHandler`](crate::PostgresHandler),
@@ -8,7 +8,7 @@ use std::time::Duration;
 
 use database_mcp_config::DatabaseConfig;
 use database_mcp_server::AppError;
-use database_mcp_sql::PoolProvider;
+use database_mcp_sql::Connection;
 use database_mcp_sql::identifier::validate_identifier;
 use moka::future::Cache;
 use sqlx::postgres::{PgConnectOptions, PgPool, PgPoolOptions, PgSslMode};
@@ -77,12 +77,6 @@ impl PostgresConnection {
         &self.default_db
     }
 
-    /// Wraps `name` in double quotes for safe use in `PostgreSQL` SQL statements.
-    #[allow(clippy::unused_self)]
-    pub(crate) fn quote_identifier(&self, name: &str) -> String {
-        database_mcp_sql::identifier::quote_identifier(name, '"')
-    }
-
     /// Evicts the cached pool for `name`, closing its connections.
     ///
     /// Idempotent — does nothing if the pool was not cached.
@@ -130,8 +124,9 @@ impl PostgresConnection {
     }
 }
 
-impl PoolProvider for PostgresConnection {
+impl Connection for PostgresConnection {
     type DB = sqlx::Postgres;
+    const IDENTIFIER_QUOTE: char = '"';
 
     async fn pool(&self, target: Option<&str>) -> Result<sqlx::Pool<Self::DB>, AppError> {
         self.pool(target).await

--- a/crates/postgres/src/connection.rs
+++ b/crates/postgres/src/connection.rs
@@ -67,11 +67,6 @@ impl PostgresConnection {
             .unwrap_or(&self.config.user)
     }
 
-    /// Returns `true` if `name` matches the default database (case-sensitive).
-    fn is_default_db(&self, name: &str) -> bool {
-        name == self.default_db()
-    }
-
     /// Evicts the cached pool for `name`, closing its connections.
     ///
     /// Idempotent — does nothing if the pool was not cached.
@@ -97,7 +92,7 @@ impl PostgresConnection {
             return Ok(pool);
         }
 
-        if !self.is_default_db(db_key) {
+        if db_key != self.default_db() {
             validate_identifier(db_key)?;
         }
 

--- a/crates/postgres/src/connection.rs
+++ b/crates/postgres/src/connection.rs
@@ -1,0 +1,392 @@
+//! `PostgreSQL` connection: pool cache, pool initialization, and [`Connection`] impl.
+//!
+//! Owns the lazy default pool and the moka cache of per-database pools.
+//! Hides every backend pool concern from [`PostgresHandler`](crate::PostgresHandler),
+//! which composes one [`PostgresConnection`] as a field.
+
+use std::time::Duration;
+
+use database_mcp_config::DatabaseConfig;
+use database_mcp_server::AppError;
+use database_mcp_sql::connection::{Connection, Executable, Query};
+use database_mcp_sql::identifier::validate_identifier;
+use database_mcp_sql::timeout::execute_with_timeout;
+use moka::future::Cache;
+use sqlx::Postgres;
+use sqlx::postgres::{PgConnectOptions, PgPool, PgPoolOptions, PgQueryResult, PgSslMode};
+use tracing::info;
+
+/// Maximum number of cached per-database connection pools.
+pub(crate) const POOL_CACHE_CAPACITY: u64 = 16;
+
+/// Owns every `PgPool` the handler uses and the logic that builds them.
+#[derive(Clone)]
+pub(crate) struct PostgresConnection {
+    config: DatabaseConfig,
+    default_db: String,
+    default_pool: PgPool,
+    pools: Cache<String, PgPool>,
+}
+
+impl std::fmt::Debug for PostgresConnection {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("PostgresConnection")
+            .field("default_db", &self.default_db)
+            .finish_non_exhaustive()
+    }
+}
+
+impl PostgresConnection {
+    /// Builds the connection and its lazy default pool.
+    ///
+    /// Does **not** establish a database connection. The default pool
+    /// connects on demand when the first query is executed. Non-default
+    /// database pools are created lazily on first request.
+    pub(crate) fn new(config: &DatabaseConfig) -> Self {
+        // PostgreSQL defaults to a database named after the connecting user.
+        let default_db = config
+            .name
+            .as_deref()
+            .filter(|n| !n.is_empty())
+            .map_or_else(|| config.user.clone(), String::from);
+
+        let default_pool = pool_options(config).connect_lazy_with(connect_options(config));
+
+        info!(
+            "PostgreSQL lazy connection pool created (max size: {})",
+            config.max_pool_size
+        );
+
+        let pools = Cache::builder()
+            .max_capacity(POOL_CACHE_CAPACITY)
+            .eviction_listener(|_key, pool: PgPool, _cause| {
+                tokio::spawn(async move {
+                    pool.close().await;
+                });
+            })
+            .build();
+
+        Self {
+            config: config.clone(),
+            default_db,
+            default_pool,
+            pools,
+        }
+    }
+
+    /// Returns the name of the database resolved at startup.
+    pub(crate) fn default_db(&self) -> &str {
+        &self.default_db
+    }
+
+    /// Wraps `name` in double quotes for safe use in `PostgreSQL` SQL statements.
+    #[allow(clippy::unused_self)]
+    pub(crate) fn quote_identifier(&self, name: &str) -> String {
+        database_mcp_sql::identifier::quote_identifier(name, '"')
+    }
+
+    /// Evicts the cached pool for `name`, closing its connections.
+    ///
+    /// Idempotent — does nothing if the pool was not cached.
+    pub(crate) async fn invalidate(&self, name: &str) {
+        self.pools.invalidate(name).await;
+    }
+
+    /// Resolves the cached pool for `target`, creating it lazily on miss.
+    ///
+    /// Kept crate-private so every tool path goes through the unified
+    /// [`Connection`] methods and cannot bypass timeout / error capture.
+    ///
+    /// # Errors
+    ///
+    /// - [`AppError::InvalidIdentifier`] — `target` failed identifier validation.
+    pub(crate) async fn pool(&self, target: Option<&str>) -> Result<PgPool, AppError> {
+        let db_key = match target {
+            Some(name) if !name.is_empty() => name,
+            _ => return Ok(self.default_pool.clone()),
+        };
+
+        if db_key == self.default_db {
+            return Ok(self.default_pool.clone());
+        }
+
+        if let Some(pool) = self.pools.get(db_key).await {
+            return Ok(pool);
+        }
+
+        validate_identifier(db_key)?;
+
+        let config = self.config.clone();
+        let db_key_owned = db_key.to_owned();
+
+        let pool = self
+            .pools
+            .get_with(db_key_owned, async {
+                let mut cfg = config;
+                cfg.name = Some(db_key.to_owned());
+                pool_options(&cfg).connect_lazy_with(connect_options(&cfg))
+            })
+            .await;
+
+        Ok(pool)
+    }
+}
+
+impl Connection for PostgresConnection {
+    type Database = Postgres;
+
+    async fn execute<Q>(&self, query: Q, target: Option<&str>) -> Result<PgQueryResult, AppError>
+    where
+        Q: Executable<Postgres>,
+    {
+        let pool = self.pool(target).await?;
+        let sql = query.sql().to_owned();
+        execute_with_timeout(self.config.query_timeout, &sql, async move {
+            let mut conn = pool.acquire().await?;
+            query.run_execute(&mut conn).await
+        })
+        .await
+    }
+
+    async fn fetch<Q>(&self, query: Q, target: Option<&str>) -> Result<Vec<Q::Output>, AppError>
+    where
+        Q: Query<Postgres>,
+    {
+        let pool = self.pool(target).await?;
+        let sql = query.sql().to_owned();
+        execute_with_timeout(self.config.query_timeout, &sql, async move {
+            let mut conn = pool.acquire().await?;
+            query.run_fetch_all(&mut conn).await
+        })
+        .await
+    }
+
+    async fn fetch_optional<Q>(&self, query: Q, target: Option<&str>) -> Result<Option<Q::Output>, AppError>
+    where
+        Q: Query<Postgres>,
+    {
+        let pool = self.pool(target).await?;
+        let sql = query.sql().to_owned();
+        execute_with_timeout(self.config.query_timeout, &sql, async move {
+            let mut conn = pool.acquire().await?;
+            query.run_fetch_optional(&mut conn).await
+        })
+        .await
+    }
+}
+
+/// Builds [`PgPoolOptions`] with lifecycle defaults from a [`DatabaseConfig`].
+fn pool_options(config: &DatabaseConfig) -> PgPoolOptions {
+    let mut opts = PgPoolOptions::new()
+        .max_connections(config.max_pool_size)
+        .min_connections(DatabaseConfig::DEFAULT_MIN_CONNECTIONS)
+        .idle_timeout(Duration::from_secs(DatabaseConfig::DEFAULT_IDLE_TIMEOUT_SECS))
+        .max_lifetime(Duration::from_secs(DatabaseConfig::DEFAULT_MAX_LIFETIME_SECS));
+
+    if let Some(timeout) = config.connection_timeout {
+        opts = opts.acquire_timeout(Duration::from_secs(timeout));
+    }
+
+    opts
+}
+
+/// Builds [`PgConnectOptions`] from a [`DatabaseConfig`].
+///
+/// Uses [`PgConnectOptions::new_without_pgpass`] to avoid unintended
+/// `PG*` environment variable influence, since our config already
+/// resolves values from CLI/env.
+fn connect_options(config: &DatabaseConfig) -> PgConnectOptions {
+    let mut opts = PgConnectOptions::new_without_pgpass()
+        .host(&config.host)
+        .port(config.port)
+        .username(&config.user);
+
+    if let Some(ref password) = config.password {
+        opts = opts.password(password);
+    }
+    if let Some(ref name) = config.name
+        && !name.is_empty()
+    {
+        opts = opts.database(name);
+    }
+
+    if config.ssl {
+        opts = if config.ssl_verify_cert {
+            opts.ssl_mode(PgSslMode::VerifyCa)
+        } else {
+            opts.ssl_mode(PgSslMode::Require)
+        };
+        if let Some(ref ca) = config.ssl_ca {
+            opts = opts.ssl_root_cert(ca);
+        }
+        if let Some(ref cert) = config.ssl_cert {
+            opts = opts.ssl_client_cert(cert);
+        }
+        if let Some(ref key) = config.ssl_key {
+            opts = opts.ssl_client_key(key);
+        }
+    }
+
+    opts
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use database_mcp_config::DatabaseBackend;
+
+    fn base_config() -> DatabaseConfig {
+        DatabaseConfig {
+            backend: DatabaseBackend::Postgres,
+            host: "pg.example.com".into(),
+            port: 5433,
+            user: "pgadmin".into(),
+            password: Some("pgpass".into()),
+            name: Some("mydb".into()),
+            ..DatabaseConfig::default()
+        }
+    }
+
+    #[test]
+    fn pool_options_applies_defaults() {
+        let config = base_config();
+        let opts = pool_options(&config);
+
+        assert_eq!(opts.get_max_connections(), config.max_pool_size);
+        assert_eq!(opts.get_min_connections(), DatabaseConfig::DEFAULT_MIN_CONNECTIONS);
+        assert_eq!(
+            opts.get_idle_timeout(),
+            Some(Duration::from_secs(DatabaseConfig::DEFAULT_IDLE_TIMEOUT_SECS))
+        );
+        assert_eq!(
+            opts.get_max_lifetime(),
+            Some(Duration::from_secs(DatabaseConfig::DEFAULT_MAX_LIFETIME_SECS))
+        );
+    }
+
+    #[test]
+    fn pool_options_applies_connection_timeout() {
+        let config = DatabaseConfig {
+            connection_timeout: Some(7),
+            ..base_config()
+        };
+        let opts = pool_options(&config);
+
+        assert_eq!(opts.get_acquire_timeout(), Duration::from_secs(7));
+    }
+
+    #[test]
+    fn pool_options_without_connection_timeout_uses_sqlx_default() {
+        let config = base_config();
+        let opts = pool_options(&config);
+
+        assert_eq!(opts.get_acquire_timeout(), Duration::from_secs(30));
+    }
+
+    #[test]
+    fn try_from_basic_config() {
+        let config = base_config();
+        let opts = connect_options(&config);
+
+        assert_eq!(opts.get_host(), "pg.example.com");
+        assert_eq!(opts.get_port(), 5433);
+        assert_eq!(opts.get_username(), "pgadmin");
+        assert_eq!(opts.get_database(), Some("mydb"));
+    }
+
+    #[test]
+    fn try_from_with_ssl_require() {
+        let config = DatabaseConfig {
+            ssl: true,
+            ssl_verify_cert: false,
+            ..base_config()
+        };
+        let opts = connect_options(&config);
+
+        assert!(matches!(opts.get_ssl_mode(), PgSslMode::Require));
+    }
+
+    #[test]
+    fn try_from_with_ssl_verify_ca() {
+        let config = DatabaseConfig {
+            ssl: true,
+            ssl_verify_cert: true,
+            ..base_config()
+        };
+        let opts = connect_options(&config);
+
+        assert!(matches!(opts.get_ssl_mode(), PgSslMode::VerifyCa));
+    }
+
+    #[test]
+    fn try_from_without_database_name() {
+        let config = DatabaseConfig {
+            name: None,
+            ..base_config()
+        };
+        let opts = connect_options(&config);
+
+        assert_eq!(opts.get_database(), None);
+    }
+
+    #[test]
+    fn try_from_without_password() {
+        let config = DatabaseConfig {
+            password: None,
+            ..base_config()
+        };
+        let opts = connect_options(&config);
+
+        assert_eq!(opts.get_host(), "pg.example.com");
+    }
+
+    #[tokio::test]
+    async fn new_creates_lazy_default_pool() {
+        let connection = PostgresConnection::new(&base_config());
+        assert_eq!(connection.default_db(), "mydb");
+        assert_eq!(connection.default_pool.size(), 0, "default pool should be lazy");
+    }
+
+    #[tokio::test]
+    async fn defaults_db_to_username_when_name_missing() {
+        let connection = PostgresConnection::new(&DatabaseConfig {
+            name: None,
+            ..base_config()
+        });
+        assert_eq!(connection.default_db(), "pgadmin");
+    }
+
+    #[tokio::test]
+    async fn none_target_returns_default_pool() {
+        let connection = PostgresConnection::new(&base_config());
+        connection.pool(None).await.expect("None target should succeed");
+    }
+
+    #[tokio::test]
+    async fn arbitrary_target_database_is_permitted() {
+        let connection = PostgresConnection::new(&base_config());
+        connection
+            .pool(Some("any_db"))
+            .await
+            .expect("any database should be permitted");
+    }
+
+    #[tokio::test]
+    async fn pool_cache_respects_capacity_const() {
+        let connection = PostgresConnection::new(&base_config());
+
+        // Insert one more pool than the cap; moka should evict the
+        // oldest so the cached count stays at or below POOL_CACHE_CAPACITY.
+        for i in 0..=POOL_CACHE_CAPACITY {
+            let name = format!("db_{i}");
+            connection.pool(Some(&name)).await.expect("pool should succeed");
+        }
+        connection.pools.run_pending_tasks().await;
+
+        assert!(
+            connection.pools.entry_count() <= POOL_CACHE_CAPACITY,
+            "cached pools exceeded cap: {} > {POOL_CACHE_CAPACITY}",
+            connection.pools.entry_count()
+        );
+    }
+}

--- a/crates/postgres/src/handler.rs
+++ b/crates/postgres/src/handler.rs
@@ -166,7 +166,7 @@ mod tests {
     #[tokio::test]
     async fn handler_exposes_connection_default_db() {
         let handler = PostgresHandler::new(&base_config());
-        assert_eq!(handler.connection.default_db(), "mydb");
+        assert_eq!(handler.connection.default_database_name(), "mydb");
     }
 
     #[tokio::test]

--- a/crates/postgres/src/handler.rs
+++ b/crates/postgres/src/handler.rs
@@ -1,32 +1,25 @@
-//! `PostgreSQL` handler: connection pool cache, MCP tool router, and `ServerHandler` impl.
+//! `PostgreSQL` handler: composes a [`PostgresConnection`] with the MCP tool router.
 //!
-//! Creates a lazy default pool via [`PgPoolOptions::connect_lazy_with`].
-//! Non-default database pools are created on demand and cached in a
-//! moka [`Cache`].
-
-use std::time::Duration;
+//! All pool ownership and pool initialization logic lives in the
+//! [`PostgresConnection`]. This module wires the connection into
+//! the MCP `ServerHandler` surface and exposes a small set of thin
+//! delegator methods that the per-tool implementations call.
 
 use database_mcp_config::DatabaseConfig;
-use database_mcp_server::{AppError, Server, server_info};
-use database_mcp_sql::identifier::validate_identifier;
-use moka::future::Cache;
+use database_mcp_server::{Server, server_info};
 use rmcp::RoleServer;
 use rmcp::handler::server::router::tool::ToolRouter;
 use rmcp::handler::server::tool::ToolCallContext;
 use rmcp::model::{CallToolRequestParams, CallToolResult, ListToolsResult, PaginatedRequestParams, ServerInfo, Tool};
 use rmcp::service::RequestContext;
 use rmcp::{ErrorData, ServerHandler};
-use sqlx::PgPool;
-use sqlx::postgres::{PgConnectOptions, PgPoolOptions, PgSslMode};
-use tracing::info;
+
+use crate::connection::PostgresConnection;
 
 use crate::tools::{
     CreateDatabaseTool, DropDatabaseTool, DropTableTool, ExplainQueryTool, GetTableSchemaTool, ListDatabasesTool,
     ListTablesTool, ReadQueryTool, WriteQueryTool,
 };
-
-/// Maximum number of database connection pools to cache (including the default).
-const POOL_CACHE_CAPACITY: u64 = 6;
 
 /// Backend-specific description for `PostgreSQL`.
 const DESCRIPTION: &str = "Database MCP Server for PostgreSQL";
@@ -51,16 +44,13 @@ Tools accept an optional `database_name` parameter to query across databases wit
 
 /// `PostgreSQL` database handler.
 ///
-/// The default connection pool is created with
-/// [`PgPoolOptions::connect_lazy_with`], which defers all network I/O
-/// until the first query. Non-default database pools are created on
-/// demand via the moka [`Cache`].
+/// Composes one [`PostgresConnection`] (which owns every pool
+/// and the pool initialization logic) with the per-backend MCP tool
+/// router.
 #[derive(Clone)]
 pub struct PostgresHandler {
     pub(crate) config: DatabaseConfig,
-    pub(crate) default_db: String,
-    default_pool: PgPool,
-    pub(crate) pools: Cache<String, PgPool>,
+    pub(crate) connection: PostgresConnection,
     tool_router: ToolRouter<Self>,
 }
 
@@ -68,99 +58,24 @@ impl std::fmt::Debug for PostgresHandler {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.debug_struct("PostgresHandler")
             .field("read_only", &self.config.read_only)
-            .field("default_db", &self.default_db)
+            .field("connection", &self.connection)
             .finish_non_exhaustive()
     }
 }
 
 impl PostgresHandler {
-    /// Creates a new `PostgreSQL` handler with a lazy connection pool.
+    /// Creates a new `PostgreSQL` handler.
     ///
-    /// Does **not** establish a database connection. The default pool
-    /// connects on-demand when the first query is executed. The MCP tool
-    /// router is built once here and reused for every request.
+    /// Constructs the [`PostgresConnection`] (which builds the
+    /// lazy default pool and the per-database pool cache) and the MCP
+    /// tool router. No network I/O happens here.
     #[must_use]
     pub fn new(config: &DatabaseConfig) -> Self {
-        // PostgreSQL defaults to a database named after the connecting user.
-        let default_db = config
-            .name
-            .as_deref()
-            .filter(|n| !n.is_empty())
-            .map_or_else(|| config.user.clone(), String::from);
-
-        let default_pool = pool_options(config).connect_lazy_with(connect_options(config));
-
-        info!(
-            "PostgreSQL lazy connection pool created (max size: {})",
-            config.max_pool_size
-        );
-
-        let pools = Cache::builder()
-            .max_capacity(POOL_CACHE_CAPACITY)
-            .eviction_listener(|_key, pool: PgPool, _cause| {
-                tokio::spawn(async move {
-                    pool.close().await;
-                });
-            })
-            .build();
-
         Self {
             config: config.clone(),
-            default_db,
-            default_pool,
-            pools,
+            connection: PostgresConnection::new(config),
             tool_router: build_tool_router(config.read_only),
         }
-    }
-
-    /// Wraps `name` in double quotes for safe use in `PostgreSQL` SQL statements.
-    pub(crate) fn quote_identifier(name: &str) -> String {
-        database_mcp_sql::identifier::quote_identifier(name, '"')
-    }
-
-    /// Returns a connection pool for the requested database.
-    ///
-    /// Resolves `None` or empty names to the default lazy pool. On a
-    /// cache miss for a non-default database, a new lazy pool is created
-    /// and cached. Evicted pools are closed via the cache's eviction
-    /// listener.
-    ///
-    /// # Errors
-    ///
-    /// Returns [`AppError::InvalidIdentifier`] if the database name fails
-    /// validation.
-    pub(crate) async fn get_pool(&self, database: Option<&str>) -> Result<PgPool, AppError> {
-        let db_key = match database {
-            Some(name) if !name.is_empty() => name,
-            _ => return Ok(self.default_pool.clone()),
-        };
-
-        // Check if it's the default database by name.
-        if db_key == self.default_db {
-            return Ok(self.default_pool.clone());
-        }
-
-        // Non-default database: check cache first.
-        if let Some(pool) = self.pools.get(db_key).await {
-            return Ok(pool);
-        }
-
-        // Cache miss — validate then create a new lazy pool.
-        validate_identifier(db_key)?;
-
-        let config = self.config.clone();
-        let db_key_owned = db_key.to_owned();
-
-        let pool = self
-            .pools
-            .get_with(db_key_owned, async {
-                let mut cfg = config;
-                cfg.name = Some(db_key.to_owned());
-                pool_options(&cfg).connect_lazy_with(connect_options(&cfg))
-            })
-            .await;
-
-        Ok(pool)
     }
 }
 
@@ -169,61 +84,6 @@ impl From<PostgresHandler> for Server {
     fn from(handler: PostgresHandler) -> Self {
         Self::new(handler)
     }
-}
-
-/// Builds [`PgPoolOptions`] with lifecycle defaults from a [`DatabaseConfig`].
-fn pool_options(config: &DatabaseConfig) -> PgPoolOptions {
-    let mut opts = PgPoolOptions::new()
-        .max_connections(config.max_pool_size)
-        .min_connections(DatabaseConfig::DEFAULT_MIN_CONNECTIONS)
-        .idle_timeout(Duration::from_secs(DatabaseConfig::DEFAULT_IDLE_TIMEOUT_SECS))
-        .max_lifetime(Duration::from_secs(DatabaseConfig::DEFAULT_MAX_LIFETIME_SECS));
-
-    if let Some(timeout) = config.connection_timeout {
-        opts = opts.acquire_timeout(Duration::from_secs(timeout));
-    }
-
-    opts
-}
-
-/// Builds [`PgConnectOptions`] from a [`DatabaseConfig`].
-///
-/// Uses [`PgConnectOptions::new_without_pgpass`] to avoid unintended
-/// `PG*` environment variable influence, since our config already
-/// resolves values from CLI/env.
-fn connect_options(config: &DatabaseConfig) -> PgConnectOptions {
-    let mut opts = PgConnectOptions::new_without_pgpass()
-        .host(&config.host)
-        .port(config.port)
-        .username(&config.user);
-
-    if let Some(ref password) = config.password {
-        opts = opts.password(password);
-    }
-    if let Some(ref name) = config.name
-        && !name.is_empty()
-    {
-        opts = opts.database(name);
-    }
-
-    if config.ssl {
-        opts = if config.ssl_verify_cert {
-            opts.ssl_mode(PgSslMode::VerifyCa)
-        } else {
-            opts.ssl_mode(PgSslMode::Require)
-        };
-        if let Some(ref ca) = config.ssl_ca {
-            opts = opts.ssl_root_cert(ca);
-        }
-        if let Some(ref cert) = config.ssl_cert {
-            opts = opts.ssl_client_cert(cert);
-        }
-        if let Some(ref key) = config.ssl_key {
-            opts = opts.ssl_client_key(key);
-        }
-    }
-
-    opts
 }
 
 /// Builds the tool router, including write tools only when not in read-only mode.
@@ -303,124 +163,10 @@ mod tests {
         })
     }
 
-    #[test]
-    fn pool_options_applies_defaults() {
-        let config = base_config();
-        let opts = pool_options(&config);
-
-        assert_eq!(opts.get_max_connections(), config.max_pool_size);
-        assert_eq!(opts.get_min_connections(), DatabaseConfig::DEFAULT_MIN_CONNECTIONS);
-        assert_eq!(
-            opts.get_idle_timeout(),
-            Some(Duration::from_secs(DatabaseConfig::DEFAULT_IDLE_TIMEOUT_SECS))
-        );
-        assert_eq!(
-            opts.get_max_lifetime(),
-            Some(Duration::from_secs(DatabaseConfig::DEFAULT_MAX_LIFETIME_SECS))
-        );
-    }
-
-    #[test]
-    fn pool_options_applies_connection_timeout() {
-        let config = DatabaseConfig {
-            connection_timeout: Some(7),
-            ..base_config()
-        };
-        let opts = pool_options(&config);
-
-        assert_eq!(opts.get_acquire_timeout(), Duration::from_secs(7));
-    }
-
-    #[test]
-    fn pool_options_without_connection_timeout_uses_sqlx_default() {
-        let config = base_config();
-        let opts = pool_options(&config);
-
-        assert_eq!(opts.get_acquire_timeout(), Duration::from_secs(30));
-    }
-
-    #[test]
-    fn try_from_basic_config() {
-        let config = base_config();
-        let opts = connect_options(&config);
-
-        assert_eq!(opts.get_host(), "pg.example.com");
-        assert_eq!(opts.get_port(), 5433);
-        assert_eq!(opts.get_username(), "pgadmin");
-        assert_eq!(opts.get_database(), Some("mydb"));
-    }
-
-    #[test]
-    fn try_from_with_ssl_require() {
-        let config = DatabaseConfig {
-            ssl: true,
-            ssl_verify_cert: false,
-            ..base_config()
-        };
-        let opts = connect_options(&config);
-
-        assert!(
-            matches!(opts.get_ssl_mode(), PgSslMode::Require),
-            "expected Require, got {:?}",
-            opts.get_ssl_mode()
-        );
-    }
-
-    #[test]
-    fn try_from_with_ssl_verify_ca() {
-        let config = DatabaseConfig {
-            ssl: true,
-            ssl_verify_cert: true,
-            ..base_config()
-        };
-        let opts = connect_options(&config);
-
-        assert!(
-            matches!(opts.get_ssl_mode(), PgSslMode::VerifyCa),
-            "expected VerifyCa, got {:?}",
-            opts.get_ssl_mode()
-        );
-    }
-
-    #[test]
-    fn try_from_without_database_name() {
-        let config = DatabaseConfig {
-            name: None,
-            ..base_config()
-        };
-        let opts = connect_options(&config);
-
-        assert_eq!(opts.get_database(), None);
-    }
-
-    #[test]
-    fn try_from_without_password() {
-        let config = DatabaseConfig {
-            password: None,
-            ..base_config()
-        };
-        let opts = connect_options(&config);
-
-        assert_eq!(opts.get_host(), "pg.example.com");
-    }
-
     #[tokio::test]
-    async fn new_creates_lazy_pool() {
-        let config = base_config();
-        let handler = PostgresHandler::new(&config);
-        assert_eq!(handler.default_db, "mydb");
-        // Pool exists but has no active connections (lazy).
-        assert_eq!(handler.default_pool.size(), 0);
-    }
-
-    #[tokio::test]
-    async fn new_defaults_db_to_username() {
-        let config = DatabaseConfig {
-            name: None,
-            ..base_config()
-        };
-        let handler = PostgresHandler::new(&config);
-        assert_eq!(handler.default_db, "pgadmin");
+    async fn handler_exposes_connection_default_db() {
+        let handler = PostgresHandler::new(&base_config());
+        assert_eq!(handler.connection.default_db(), "mydb");
     }
 
     #[tokio::test]

--- a/crates/postgres/src/lib.rs
+++ b/crates/postgres/src/lib.rs
@@ -3,6 +3,7 @@
 //! Provides [`PostgresHandler`] for database operations with MCP
 //! tool registration via [`ServerHandler`](rmcp::ServerHandler).
 
+mod connection;
 mod handler;
 mod tools;
 pub mod types;

--- a/crates/postgres/src/tools/create_database.rs
+++ b/crates/postgres/src/tools/create_database.rs
@@ -4,8 +4,8 @@ use std::borrow::Cow;
 
 use database_mcp_server::AppError;
 use database_mcp_server::types::{CreateDatabaseRequest, MessageResponse};
+use database_mcp_sql::connection::Connection as _;
 use database_mcp_sql::identifier::validate_identifier;
-use database_mcp_sql::timeout::execute_with_timeout;
 use rmcp::handler::server::router::tool::{AsyncTool, ToolBase};
 use rmcp::model::{ErrorData, ToolAnnotations};
 
@@ -62,23 +62,18 @@ impl PostgresHandler {
         let name = &request.database_name;
         validate_identifier(name)?;
 
-        let pool = self.get_pool(None).await?;
-
         // PostgreSQL CREATE DATABASE can't use parameterized queries
-        let create_sql = format!("CREATE DATABASE {}", Self::quote_identifier(name));
-        execute_with_timeout(
-            self.config.query_timeout,
-            &create_sql,
-            sqlx::query(&create_sql).execute(&pool),
-        )
-        .await
-        .map_err(|e| {
-            let msg = e.to_string();
-            if msg.contains("already exists") {
-                return AppError::Query(format!("Database '{name}' already exists."));
-            }
-            e
-        })?;
+        let create_sql = format!("CREATE DATABASE {}", self.connection.quote_identifier(name));
+        self.connection
+            .execute(sqlx::query(&create_sql), None)
+            .await
+            .map_err(|e| {
+                let msg = e.to_string();
+                if msg.contains("already exists") {
+                    return AppError::Query(format!("Database '{name}' already exists."));
+                }
+                e
+            })?;
 
         Ok(MessageResponse {
             message: format!("Database '{name}' created successfully."),

--- a/crates/postgres/src/tools/create_database.rs
+++ b/crates/postgres/src/tools/create_database.rs
@@ -4,7 +4,7 @@ use std::borrow::Cow;
 
 use database_mcp_server::AppError;
 use database_mcp_server::types::{CreateDatabaseRequest, MessageResponse};
-use database_mcp_sql::connection::Connection as _;
+use database_mcp_sql::Connection as _;
 use database_mcp_sql::identifier::validate_identifier;
 use rmcp::handler::server::router::tool::{AsyncTool, ToolBase};
 use rmcp::model::{ErrorData, ToolAnnotations};
@@ -64,16 +64,13 @@ impl PostgresHandler {
 
         // PostgreSQL CREATE DATABASE can't use parameterized queries
         let create_sql = format!("CREATE DATABASE {}", self.connection.quote_identifier(name));
-        self.connection
-            .execute(sqlx::query(&create_sql), None)
-            .await
-            .map_err(|e| {
-                let msg = e.to_string();
-                if msg.contains("already exists") {
-                    return AppError::Query(format!("Database '{name}' already exists."));
-                }
-                e
-            })?;
+        self.connection.execute(&create_sql, None).await.map_err(|e| {
+            let msg = e.to_string();
+            if msg.contains("already exists") {
+                return AppError::Query(format!("Database '{name}' already exists."));
+            }
+            e
+        })?;
 
         Ok(MessageResponse {
             message: format!("Database '{name}' created successfully."),

--- a/crates/postgres/src/tools/drop_database.rs
+++ b/crates/postgres/src/tools/drop_database.rs
@@ -69,7 +69,7 @@ impl PostgresHandler {
         validate_identifier(name)?;
 
         // Guard: prevent dropping the currently connected database.
-        if self.connection.default_db() == name.as_str() {
+        if self.connection.default_database_name() == name.as_str() {
             return Err(AppError::Query(format!(
                 "Cannot drop the currently connected database '{name}'."
             )));

--- a/crates/postgres/src/tools/drop_database.rs
+++ b/crates/postgres/src/tools/drop_database.rs
@@ -4,7 +4,7 @@ use std::borrow::Cow;
 
 use database_mcp_server::AppError;
 use database_mcp_server::types::{DropDatabaseRequest, MessageResponse};
-use database_mcp_sql::connection::Connection as _;
+use database_mcp_sql::Connection as _;
 use database_mcp_sql::identifier::validate_identifier;
 use rmcp::handler::server::router::tool::{AsyncTool, ToolBase};
 use rmcp::model::{ErrorData, ToolAnnotations};

--- a/crates/postgres/src/tools/drop_database.rs
+++ b/crates/postgres/src/tools/drop_database.rs
@@ -4,8 +4,8 @@ use std::borrow::Cow;
 
 use database_mcp_server::AppError;
 use database_mcp_server::types::{DropDatabaseRequest, MessageResponse};
+use database_mcp_sql::connection::Connection as _;
 use database_mcp_sql::identifier::validate_identifier;
-use database_mcp_sql::timeout::execute_with_timeout;
 use rmcp::handler::server::router::tool::{AsyncTool, ToolBase};
 use rmcp::model::{ErrorData, ToolAnnotations};
 
@@ -69,25 +69,18 @@ impl PostgresHandler {
         validate_identifier(name)?;
 
         // Guard: prevent dropping the currently connected database.
-        if self.default_db == *name {
+        if self.connection.default_db() == name.as_str() {
             return Err(AppError::Query(format!(
                 "Cannot drop the currently connected database '{name}'."
             )));
         }
 
-        let pool = self.get_pool(None).await?;
-
-        let drop_sql = format!("DROP DATABASE {}", Self::quote_identifier(name));
-        execute_with_timeout(
-            self.config.query_timeout,
-            &drop_sql,
-            sqlx::query(&drop_sql).execute(&pool),
-        )
-        .await?;
+        let drop_sql = format!("DROP DATABASE {}", self.connection.quote_identifier(name));
+        self.connection.execute(drop_sql.as_str(), None).await?;
 
         // Evict the pool for the dropped database so stale connections
         // are not reused.
-        self.pools.invalidate(name).await;
+        self.connection.invalidate(name).await;
 
         Ok(MessageResponse {
             message: format!("Database '{name}' dropped successfully."),

--- a/crates/postgres/src/tools/drop_table.rs
+++ b/crates/postgres/src/tools/drop_table.rs
@@ -4,8 +4,8 @@ use std::borrow::Cow;
 
 use database_mcp_server::AppError;
 use database_mcp_server::types::MessageResponse;
+use database_mcp_sql::connection::Connection as _;
 use database_mcp_sql::identifier::validate_identifier;
-use database_mcp_sql::timeout::execute_with_timeout;
 use rmcp::handler::server::router::tool::{AsyncTool, ToolBase};
 use rmcp::model::{ErrorData, ToolAnnotations};
 
@@ -71,19 +71,12 @@ impl PostgresHandler {
         validate_identifier(database)?;
         validate_identifier(table)?;
 
-        let pool = self.get_pool(Some(database)).await?;
-
-        let mut drop_sql = format!("DROP TABLE {}", Self::quote_identifier(table));
+        let mut drop_sql = format!("DROP TABLE {}", self.connection.quote_identifier(table));
         if request.cascade {
             drop_sql.push_str(" CASCADE");
         }
 
-        execute_with_timeout(
-            self.config.query_timeout,
-            &drop_sql,
-            sqlx::query(&drop_sql).execute(&pool),
-        )
-        .await?;
+        self.connection.execute(drop_sql.as_str(), Some(database)).await?;
 
         Ok(MessageResponse {
             message: format!("Table '{table}' dropped successfully."),

--- a/crates/postgres/src/tools/drop_table.rs
+++ b/crates/postgres/src/tools/drop_table.rs
@@ -4,7 +4,7 @@ use std::borrow::Cow;
 
 use database_mcp_server::AppError;
 use database_mcp_server::types::MessageResponse;
-use database_mcp_sql::connection::Connection as _;
+use database_mcp_sql::Connection as _;
 use database_mcp_sql::identifier::validate_identifier;
 use rmcp::handler::server::router::tool::{AsyncTool, ToolBase};
 use rmcp::model::{ErrorData, ToolAnnotations};

--- a/crates/postgres/src/tools/explain_query.rs
+++ b/crates/postgres/src/tools/explain_query.rs
@@ -4,12 +4,11 @@ use std::borrow::Cow;
 
 use database_mcp_server::AppError;
 use database_mcp_server::types::{ExplainQueryRequest, QueryResponse};
-use database_mcp_sql::timeout::execute_with_timeout;
+use database_mcp_sql::connection::Connection as _;
 use database_mcp_sql::validation::validate_read_only_with_dialect;
 use rmcp::handler::server::router::tool::{AsyncTool, ToolBase};
 use rmcp::model::{ErrorData, ToolAnnotations};
 use serde_json::Value;
-use sqlx::postgres::PgRow;
 use sqlx_to_json::RowExt;
 
 use crate::PostgresHandler;
@@ -68,20 +67,16 @@ impl PostgresHandler {
             validate_read_only_with_dialect(&request.query, &sqlparser::dialect::PostgreSqlDialect {})?;
         }
 
-        let pool = self.get_pool(Some(&request.database_name)).await?;
-
         let explain_sql = if request.analyze {
             format!("EXPLAIN (ANALYZE, FORMAT JSON) {}", request.query)
         } else {
             format!("EXPLAIN (FORMAT JSON) {}", request.query)
         };
 
-        let rows: Vec<PgRow> = execute_with_timeout(
-            self.config.query_timeout,
-            &explain_sql,
-            sqlx::query(&explain_sql).fetch_all(&pool),
-        )
-        .await?;
+        let rows = self
+            .connection
+            .fetch(sqlx::query(&explain_sql), Some(&request.database_name))
+            .await?;
 
         Ok(QueryResponse {
             rows: Value::Array(rows.iter().map(RowExt::to_json).collect()),

--- a/crates/postgres/src/tools/explain_query.rs
+++ b/crates/postgres/src/tools/explain_query.rs
@@ -4,12 +4,11 @@ use std::borrow::Cow;
 
 use database_mcp_server::AppError;
 use database_mcp_server::types::{ExplainQueryRequest, QueryResponse};
-use database_mcp_sql::connection::Connection as _;
+use database_mcp_sql::Connection as _;
 use database_mcp_sql::validation::validate_read_only_with_dialect;
 use rmcp::handler::server::router::tool::{AsyncTool, ToolBase};
 use rmcp::model::{ErrorData, ToolAnnotations};
 use serde_json::Value;
-use sqlx_to_json::RowExt;
 
 use crate::PostgresHandler;
 
@@ -75,11 +74,11 @@ impl PostgresHandler {
 
         let rows = self
             .connection
-            .fetch(sqlx::query(&explain_sql), Some(&request.database_name))
+            .fetch(&explain_sql, Some(&request.database_name))
             .await?;
 
         Ok(QueryResponse {
-            rows: Value::Array(rows.iter().map(RowExt::to_json).collect()),
+            rows: Value::Array(rows),
         })
     }
 }

--- a/crates/postgres/src/tools/get_table_schema.rs
+++ b/crates/postgres/src/tools/get_table_schema.rs
@@ -5,12 +5,11 @@ use std::collections::HashMap;
 
 use database_mcp_server::AppError;
 use database_mcp_server::types::{GetTableSchemaRequest, TableSchemaResponse};
-use database_mcp_sql::connection::Connection as _;
+use database_mcp_sql::Connection as _;
 use database_mcp_sql::identifier::validate_identifier;
 use rmcp::handler::server::router::tool::{AsyncTool, ToolBase};
 use rmcp::model::{ErrorData, ToolAnnotations};
 use serde_json::{Value, json};
-use sqlx::Row;
 
 use crate::PostgresHandler;
 
@@ -68,12 +67,14 @@ impl PostgresHandler {
         };
 
         // 1. Get basic schema
-        let schema_sql = r"SELECT column_name, data_type, is_nullable, column_default,
-                      character_maximum_length
-               FROM information_schema.columns
-               WHERE table_schema = 'public' AND table_name = $1
-               ORDER BY ordinal_position";
-        let rows = self.connection.fetch(sqlx::query(schema_sql).bind(table), db).await?;
+        let schema_sql = format!(
+            "SELECT column_name, data_type, is_nullable, column_default, \
+                    character_maximum_length \
+             FROM information_schema.columns \
+             WHERE table_schema = 'public' AND table_name = '{table}' \
+             ORDER BY ordinal_position"
+        );
+        let rows = self.connection.fetch(&schema_sql, db).await?;
 
         if rows.is_empty() {
             return Err(AppError::TableNotFound(table.clone()));
@@ -81,10 +82,22 @@ impl PostgresHandler {
 
         let mut columns: HashMap<String, Value> = HashMap::new();
         for row in &rows {
-            let col_name: String = row.try_get("column_name").unwrap_or_default();
-            let data_type: String = row.try_get("data_type").unwrap_or_default();
-            let nullable: String = row.try_get("is_nullable").unwrap_or_default();
-            let default: Option<String> = row.try_get("column_default").ok();
+            let col_name = row
+                .get("column_name")
+                .and_then(Value::as_str)
+                .unwrap_or_default()
+                .to_owned();
+            let data_type = row
+                .get("data_type")
+                .and_then(Value::as_str)
+                .unwrap_or_default()
+                .to_owned();
+            let nullable = row
+                .get("is_nullable")
+                .and_then(Value::as_str)
+                .unwrap_or_default()
+                .to_owned();
+            let default = row.get("column_default").and_then(Value::as_str).map(str::to_owned);
             columns.insert(
                 col_name,
                 json!({
@@ -99,41 +112,47 @@ impl PostgresHandler {
         }
 
         // 2. Get FK relationships
-        let fk_sql = r"SELECT
-                kcu.column_name,
-                tc.constraint_name,
-                ccu.table_name AS referenced_table,
-                ccu.column_name AS referenced_column,
-                rc.update_rule AS on_update,
-                rc.delete_rule AS on_delete
-            FROM information_schema.table_constraints tc
-            JOIN information_schema.key_column_usage kcu
-                ON tc.constraint_name = kcu.constraint_name
-                AND tc.table_schema = kcu.table_schema
-            JOIN information_schema.constraint_column_usage ccu
-                ON ccu.constraint_name = tc.constraint_name
-                AND ccu.table_schema = tc.table_schema
-            JOIN information_schema.referential_constraints rc
-                ON rc.constraint_name = tc.constraint_name
-                AND rc.constraint_schema = tc.table_schema
-            WHERE tc.constraint_type = 'FOREIGN KEY'
-                AND tc.table_name = $1
-                AND tc.table_schema = 'public'";
-        let fk_rows = self.connection.fetch(sqlx::query(fk_sql).bind(table), db).await?;
+        let fk_sql = format!(
+            "SELECT \
+                kcu.column_name, \
+                tc.constraint_name, \
+                ccu.table_name AS referenced_table, \
+                ccu.column_name AS referenced_column, \
+                rc.update_rule AS on_update, \
+                rc.delete_rule AS on_delete \
+            FROM information_schema.table_constraints tc \
+            JOIN information_schema.key_column_usage kcu \
+                ON tc.constraint_name = kcu.constraint_name \
+                AND tc.table_schema = kcu.table_schema \
+            JOIN information_schema.constraint_column_usage ccu \
+                ON ccu.constraint_name = tc.constraint_name \
+                AND ccu.table_schema = tc.table_schema \
+            JOIN information_schema.referential_constraints rc \
+                ON rc.constraint_name = tc.constraint_name \
+                AND rc.constraint_schema = tc.table_schema \
+            WHERE tc.constraint_type = 'FOREIGN KEY' \
+                AND tc.table_name = '{table}' \
+                AND tc.table_schema = 'public'"
+        );
+        let fk_rows = self.connection.fetch(&fk_sql, db).await?;
 
         for fk_row in &fk_rows {
-            let col_name: String = fk_row.try_get("column_name").unwrap_or_default();
+            let col_name = fk_row
+                .get("column_name")
+                .and_then(Value::as_str)
+                .unwrap_or_default()
+                .to_owned();
             if let Some(col_info) = columns.get_mut(&col_name)
                 && let Some(obj) = col_info.as_object_mut()
             {
                 obj.insert(
                     "foreign_key".to_string(),
                     json!({
-                        "constraint_name": fk_row.try_get::<String, _>("constraint_name").ok(),
-                        "referenced_table": fk_row.try_get::<String, _>("referenced_table").ok(),
-                        "referenced_column": fk_row.try_get::<String, _>("referenced_column").ok(),
-                        "on_update": fk_row.try_get::<String, _>("on_update").ok(),
-                        "on_delete": fk_row.try_get::<String, _>("on_delete").ok(),
+                        "constraint_name": fk_row.get("constraint_name").and_then(Value::as_str),
+                        "referenced_table": fk_row.get("referenced_table").and_then(Value::as_str),
+                        "referenced_column": fk_row.get("referenced_column").and_then(Value::as_str),
+                        "on_update": fk_row.get("on_update").and_then(Value::as_str),
+                        "on_delete": fk_row.get("on_delete").and_then(Value::as_str),
                     }),
                 );
             }

--- a/crates/postgres/src/tools/get_table_schema.rs
+++ b/crates/postgres/src/tools/get_table_schema.rs
@@ -5,13 +5,12 @@ use std::collections::HashMap;
 
 use database_mcp_server::AppError;
 use database_mcp_server::types::{GetTableSchemaRequest, TableSchemaResponse};
+use database_mcp_sql::connection::Connection as _;
 use database_mcp_sql::identifier::validate_identifier;
-use database_mcp_sql::timeout::execute_with_timeout;
 use rmcp::handler::server::router::tool::{AsyncTool, ToolBase};
 use rmcp::model::{ErrorData, ToolAnnotations};
 use serde_json::{Value, json};
 use sqlx::Row;
-use sqlx::postgres::PgRow;
 
 use crate::PostgresHandler;
 
@@ -67,7 +66,6 @@ impl PostgresHandler {
         } else {
             Some(request.database_name.as_str())
         };
-        let pool = self.get_pool(db).await?;
 
         // 1. Get basic schema
         let schema_sql = r"SELECT column_name, data_type, is_nullable, column_default,
@@ -75,12 +73,7 @@ impl PostgresHandler {
                FROM information_schema.columns
                WHERE table_schema = 'public' AND table_name = $1
                ORDER BY ordinal_position";
-        let rows: Vec<PgRow> = execute_with_timeout(
-            self.config.query_timeout,
-            schema_sql,
-            sqlx::query(schema_sql).bind(table).fetch_all(&pool),
-        )
-        .await?;
+        let rows = self.connection.fetch(sqlx::query(schema_sql).bind(table), db).await?;
 
         if rows.is_empty() {
             return Err(AppError::TableNotFound(table.clone()));
@@ -126,12 +119,7 @@ impl PostgresHandler {
             WHERE tc.constraint_type = 'FOREIGN KEY'
                 AND tc.table_name = $1
                 AND tc.table_schema = 'public'";
-        let fk_rows: Vec<PgRow> = execute_with_timeout(
-            self.config.query_timeout,
-            fk_sql,
-            sqlx::query(fk_sql).bind(table).fetch_all(&pool),
-        )
-        .await?;
+        let fk_rows = self.connection.fetch(sqlx::query(fk_sql).bind(table), db).await?;
 
         for fk_row in &fk_rows {
             let col_name: String = fk_row.try_get("column_name").unwrap_or_default();

--- a/crates/postgres/src/tools/list_databases.rs
+++ b/crates/postgres/src/tools/list_databases.rs
@@ -5,10 +5,11 @@ use std::sync::Arc;
 
 use database_mcp_server::AppError;
 use database_mcp_server::types::ListDatabasesResponse;
-use database_mcp_sql::connection::Connection as _;
+use database_mcp_sql::Connection as _;
 use rmcp::handler::server::common::schema_for_empty_input;
 use rmcp::handler::server::router::tool::{AsyncTool, ToolBase};
 use rmcp::model::{ErrorData, JsonObject, ToolAnnotations};
+use serde_json::Value;
 
 use crate::PostgresHandler;
 
@@ -66,9 +67,12 @@ impl PostgresHandler {
     /// Returns [`AppError`] if the query fails.
     pub async fn list_databases(&self) -> Result<ListDatabasesResponse, AppError> {
         let sql = "SELECT datname FROM pg_database WHERE datistemplate = false ORDER BY datname";
-        let rows: Vec<(String,)> = self.connection.fetch(sqlx::query_as(sql), None).await?;
+        let rows = self.connection.fetch(sql, None).await?;
         Ok(ListDatabasesResponse {
-            databases: rows.into_iter().map(|r| r.0).collect(),
+            databases: rows
+                .iter()
+                .filter_map(|r| r.get("datname").and_then(Value::as_str).map(str::to_owned))
+                .collect(),
         })
     }
 }

--- a/crates/postgres/src/tools/list_databases.rs
+++ b/crates/postgres/src/tools/list_databases.rs
@@ -5,7 +5,7 @@ use std::sync::Arc;
 
 use database_mcp_server::AppError;
 use database_mcp_server::types::ListDatabasesResponse;
-use database_mcp_sql::timeout::execute_with_timeout;
+use database_mcp_sql::connection::Connection as _;
 use rmcp::handler::server::common::schema_for_empty_input;
 use rmcp::handler::server::router::tool::{AsyncTool, ToolBase};
 use rmcp::model::{ErrorData, JsonObject, ToolAnnotations};
@@ -65,10 +65,8 @@ impl PostgresHandler {
     ///
     /// Returns [`AppError`] if the query fails.
     pub async fn list_databases(&self) -> Result<ListDatabasesResponse, AppError> {
-        let pool = self.get_pool(None).await?;
         let sql = "SELECT datname FROM pg_database WHERE datistemplate = false ORDER BY datname";
-        let rows: Vec<(String,)> =
-            execute_with_timeout(self.config.query_timeout, sql, sqlx::query_as(sql).fetch_all(&pool)).await?;
+        let rows: Vec<(String,)> = self.connection.fetch(sqlx::query_as(sql), None).await?;
         Ok(ListDatabasesResponse {
             databases: rows.into_iter().map(|r| r.0).collect(),
         })

--- a/crates/postgres/src/tools/list_tables.rs
+++ b/crates/postgres/src/tools/list_tables.rs
@@ -4,7 +4,7 @@ use std::borrow::Cow;
 
 use database_mcp_server::AppError;
 use database_mcp_server::types::{ListTablesRequest, ListTablesResponse};
-use database_mcp_sql::timeout::execute_with_timeout;
+use database_mcp_sql::connection::Connection as _;
 use rmcp::handler::server::router::tool::{AsyncTool, ToolBase};
 use rmcp::model::{ErrorData, ToolAnnotations};
 
@@ -61,10 +61,8 @@ impl PostgresHandler {
         } else {
             Some(request.database_name.as_str())
         };
-        let pool = self.get_pool(db).await?;
         let sql = "SELECT tablename FROM pg_tables WHERE schemaname = 'public' ORDER BY tablename";
-        let rows: Vec<(String,)> =
-            execute_with_timeout(self.config.query_timeout, sql, sqlx::query_as(sql).fetch_all(&pool)).await?;
+        let rows: Vec<(String,)> = self.connection.fetch(sqlx::query_as(sql), db).await?;
         Ok(ListTablesResponse {
             tables: rows.into_iter().map(|r| r.0).collect(),
         })

--- a/crates/postgres/src/tools/list_tables.rs
+++ b/crates/postgres/src/tools/list_tables.rs
@@ -4,9 +4,10 @@ use std::borrow::Cow;
 
 use database_mcp_server::AppError;
 use database_mcp_server::types::{ListTablesRequest, ListTablesResponse};
-use database_mcp_sql::connection::Connection as _;
+use database_mcp_sql::Connection as _;
 use rmcp::handler::server::router::tool::{AsyncTool, ToolBase};
 use rmcp::model::{ErrorData, ToolAnnotations};
+use serde_json::Value;
 
 use crate::PostgresHandler;
 
@@ -62,9 +63,12 @@ impl PostgresHandler {
             Some(request.database_name.as_str())
         };
         let sql = "SELECT tablename FROM pg_tables WHERE schemaname = 'public' ORDER BY tablename";
-        let rows: Vec<(String,)> = self.connection.fetch(sqlx::query_as(sql), db).await?;
+        let rows = self.connection.fetch(sql, db).await?;
         Ok(ListTablesResponse {
-            tables: rows.into_iter().map(|r| r.0).collect(),
+            tables: rows
+                .iter()
+                .filter_map(|r| r.get("tablename").and_then(Value::as_str).map(str::to_owned))
+                .collect(),
         })
     }
 }

--- a/crates/postgres/src/tools/read_query.rs
+++ b/crates/postgres/src/tools/read_query.rs
@@ -4,12 +4,11 @@ use std::borrow::Cow;
 
 use database_mcp_server::AppError;
 use database_mcp_server::types::{QueryRequest, QueryResponse};
-use database_mcp_sql::timeout::execute_with_timeout;
+use database_mcp_sql::connection::Connection as _;
 use database_mcp_sql::validation::validate_read_only_with_dialect;
 use rmcp::handler::server::router::tool::{AsyncTool, ToolBase};
 use rmcp::model::{ErrorData, ToolAnnotations};
 use serde_json::Value;
-use sqlx::postgres::PgRow;
 use sqlx_to_json::RowExt;
 
 use crate::PostgresHandler;
@@ -64,13 +63,7 @@ impl PostgresHandler {
     pub async fn read_query(&self, request: &QueryRequest) -> Result<QueryResponse, AppError> {
         validate_read_only_with_dialect(&request.query, &sqlparser::dialect::PostgreSqlDialect {})?;
         let db = Some(request.database_name.trim()).filter(|s| !s.is_empty());
-        let pool = self.get_pool(db).await?;
-        let rows: Vec<PgRow> = execute_with_timeout(
-            self.config.query_timeout,
-            &request.query,
-            sqlx::query(&request.query).fetch_all(&pool),
-        )
-        .await?;
+        let rows = self.connection.fetch(request.query.as_str(), db).await?;
         Ok(QueryResponse {
             rows: Value::Array(rows.iter().map(RowExt::to_json).collect()),
         })

--- a/crates/postgres/src/tools/read_query.rs
+++ b/crates/postgres/src/tools/read_query.rs
@@ -4,12 +4,11 @@ use std::borrow::Cow;
 
 use database_mcp_server::AppError;
 use database_mcp_server::types::{QueryRequest, QueryResponse};
-use database_mcp_sql::connection::Connection as _;
+use database_mcp_sql::Connection as _;
 use database_mcp_sql::validation::validate_read_only_with_dialect;
 use rmcp::handler::server::router::tool::{AsyncTool, ToolBase};
 use rmcp::model::{ErrorData, ToolAnnotations};
 use serde_json::Value;
-use sqlx_to_json::RowExt;
 
 use crate::PostgresHandler;
 
@@ -65,7 +64,7 @@ impl PostgresHandler {
         let db = Some(request.database_name.trim()).filter(|s| !s.is_empty());
         let rows = self.connection.fetch(request.query.as_str(), db).await?;
         Ok(QueryResponse {
-            rows: Value::Array(rows.iter().map(RowExt::to_json).collect()),
+            rows: Value::Array(rows),
         })
     }
 }

--- a/crates/postgres/src/tools/write_query.rs
+++ b/crates/postgres/src/tools/write_query.rs
@@ -4,11 +4,10 @@ use std::borrow::Cow;
 
 use database_mcp_server::AppError;
 use database_mcp_server::types::{QueryRequest, QueryResponse};
-use database_mcp_sql::timeout::execute_with_timeout;
+use database_mcp_sql::connection::Connection as _;
 use rmcp::handler::server::router::tool::{AsyncTool, ToolBase};
 use rmcp::model::{ErrorData, ToolAnnotations};
 use serde_json::Value;
-use sqlx::postgres::PgRow;
 use sqlx_to_json::RowExt;
 
 use crate::PostgresHandler;
@@ -59,13 +58,7 @@ impl PostgresHandler {
     /// Returns [`AppError`] if the query fails.
     pub async fn write_query(&self, request: &QueryRequest) -> Result<QueryResponse, AppError> {
         let db = Some(request.database_name.trim()).filter(|s| !s.is_empty());
-        let pool = self.get_pool(db).await?;
-        let rows: Vec<PgRow> = execute_with_timeout(
-            self.config.query_timeout,
-            &request.query,
-            sqlx::query(&request.query).fetch_all(&pool),
-        )
-        .await?;
+        let rows = self.connection.fetch(request.query.as_str(), db).await?;
         Ok(QueryResponse {
             rows: Value::Array(rows.iter().map(RowExt::to_json).collect()),
         })

--- a/crates/postgres/src/tools/write_query.rs
+++ b/crates/postgres/src/tools/write_query.rs
@@ -4,11 +4,10 @@ use std::borrow::Cow;
 
 use database_mcp_server::AppError;
 use database_mcp_server::types::{QueryRequest, QueryResponse};
-use database_mcp_sql::connection::Connection as _;
+use database_mcp_sql::Connection as _;
 use rmcp::handler::server::router::tool::{AsyncTool, ToolBase};
 use rmcp::model::{ErrorData, ToolAnnotations};
 use serde_json::Value;
-use sqlx_to_json::RowExt;
 
 use crate::PostgresHandler;
 
@@ -60,7 +59,7 @@ impl PostgresHandler {
         let db = Some(request.database_name.trim()).filter(|s| !s.is_empty());
         let rows = self.connection.fetch(request.query.as_str(), db).await?;
         Ok(QueryResponse {
-            rows: Value::Array(rows.iter().map(RowExt::to_json).collect()),
+            rows: Value::Array(rows),
         })
     }
 }

--- a/crates/server/src/error.rs
+++ b/crates/server/src/error.rs
@@ -31,6 +31,13 @@ pub enum AppError {
     #[error("Invalid identifier '{0}': must not be empty, whitespace-only, or contain control characters")]
     InvalidIdentifier(String),
 
+    /// Pool cache is at capacity and no idle pool can be evicted.
+    #[error("pool cache is full ({cap} pools, all in use); retry later")]
+    PoolCacheFull {
+        /// Maximum number of cached pools configured.
+        cap: usize,
+    },
+
     /// Query exceeded the configured timeout.
     #[error("Query timed out after {elapsed_secs:.1}s: {sql}")]
     QueryTimeout {

--- a/crates/sql/Cargo.toml
+++ b/crates/sql/Cargo.toml
@@ -11,6 +11,8 @@ repository.workspace = true
 database-mcp-server = { workspace = true }
 serde_json = { workspace = true }
 sqlparser = { workspace = true }
+sqlx = { workspace = true }
+sqlx_to_json = { workspace = true }
 tokio = { workspace = true }
 
 [lints]

--- a/crates/sql/Cargo.toml
+++ b/crates/sql/Cargo.toml
@@ -9,8 +9,8 @@ repository.workspace = true
 
 [dependencies]
 database-mcp-server = { workspace = true }
+serde_json = { workspace = true }
 sqlparser = { workspace = true }
-sqlx = { workspace = true, features = ["mysql", "postgres", "sqlite"] }
 tokio = { workspace = true }
 
 [lints]

--- a/crates/sql/Cargo.toml
+++ b/crates/sql/Cargo.toml
@@ -10,6 +10,7 @@ repository.workspace = true
 [dependencies]
 database-mcp-server = { workspace = true }
 sqlparser = { workspace = true }
+sqlx = { workspace = true, features = ["mysql", "postgres", "sqlite"] }
 tokio = { workspace = true }
 
 [lints]

--- a/crates/sql/src/connection.rs
+++ b/crates/sql/src/connection.rs
@@ -27,6 +27,7 @@ use crate::timeout::execute_with_timeout;
 /// - [`AppError::InvalidIdentifier`] — `database` failed identifier validation.
 /// - [`AppError::Connection`] — the underlying driver failed.
 /// - [`AppError::QueryTimeout`] — the query exceeded the configured timeout.
+#[allow(async_fn_in_trait)]
 pub trait Connection: Send + Sync {
     /// The sqlx database driver type (e.g. `sqlx::MySql`).
     type DB: sqlx::Database;
@@ -39,7 +40,7 @@ pub trait Connection: Send + Sync {
     /// # Errors
     ///
     /// - [`AppError::InvalidIdentifier`] — `target` failed validation.
-    fn pool(&self, target: Option<&str>) -> impl Future<Output = Result<sqlx::Pool<Self::DB>, AppError>> + Send;
+    async fn pool(&self, target: Option<&str>) -> Result<sqlx::Pool<Self::DB>, AppError>;
 
     /// Returns the configured query timeout in seconds, if any.
     fn query_timeout(&self) -> Option<u64>;
@@ -49,24 +50,19 @@ pub trait Connection: Send + Sync {
     /// # Errors
     ///
     /// See trait-level documentation.
-    fn execute(&self, query: &str, database: Option<&str>) -> impl Future<Output = Result<u64, AppError>> + Send
+    async fn execute(&self, query: &str, database: Option<&str>) -> Result<u64, AppError>
     where
         for<'c> &'c mut <Self::DB as sqlx::Database>::Connection: Executor<'c, Database = Self::DB>,
         <Self::DB as sqlx::Database>::QueryResult: sqlx_to_json::QueryResult,
     {
+        let pool = self.pool(database).await?;
         let sql = query.to_owned();
-        let db = database.map(str::to_owned);
-        let timeout = self.query_timeout();
-        async move {
-            let pool = self.pool(db.as_deref()).await?;
-            let inner_sql = sql.clone();
-            execute_with_timeout(timeout, &sql, async move {
-                let mut conn = pool.acquire().await?;
-                let result = (&mut *conn).execute(inner_sql.as_str()).await?;
-                Ok::<_, sqlx::Error>(result.rows_affected())
-            })
-            .await
-        }
+        execute_with_timeout(self.query_timeout(), query, async move {
+            let mut conn = pool.acquire().await?;
+            let result = (&mut *conn).execute(sql.as_str()).await?;
+            Ok::<_, sqlx::Error>(result.rows_affected())
+        })
+        .await
     }
 
     /// Runs a statement and collects every result row as JSON.
@@ -74,24 +70,19 @@ pub trait Connection: Send + Sync {
     /// # Errors
     ///
     /// See trait-level documentation.
-    fn fetch(&self, query: &str, database: Option<&str>) -> impl Future<Output = Result<Vec<Value>, AppError>> + Send
+    async fn fetch(&self, query: &str, database: Option<&str>) -> Result<Vec<Value>, AppError>
     where
         for<'c> &'c mut <Self::DB as sqlx::Database>::Connection: Executor<'c, Database = Self::DB>,
         <Self::DB as sqlx::Database>::Row: sqlx_to_json::RowExt,
     {
+        let pool = self.pool(database).await?;
         let sql = query.to_owned();
-        let db = database.map(str::to_owned);
-        let timeout = self.query_timeout();
-        async move {
-            let pool = self.pool(db.as_deref()).await?;
-            let inner_sql = sql.clone();
-            execute_with_timeout(timeout, &sql, async move {
-                let mut conn = pool.acquire().await?;
-                let rows = (&mut *conn).fetch_all(inner_sql.as_str()).await?;
-                Ok::<_, sqlx::Error>(rows.iter().map(sqlx_to_json::RowExt::to_json).collect())
-            })
-            .await
-        }
+        execute_with_timeout(self.query_timeout(), query, async move {
+            let mut conn = pool.acquire().await?;
+            let rows = (&mut *conn).fetch_all(sql.as_str()).await?;
+            Ok::<_, sqlx::Error>(rows.iter().map(sqlx_to_json::RowExt::to_json).collect())
+        })
+        .await
     }
 
     /// Runs a statement and returns at most one result row as JSON.
@@ -99,28 +90,19 @@ pub trait Connection: Send + Sync {
     /// # Errors
     ///
     /// See trait-level documentation.
-    fn fetch_optional(
-        &self,
-        query: &str,
-        database: Option<&str>,
-    ) -> impl Future<Output = Result<Option<Value>, AppError>> + Send
+    async fn fetch_optional(&self, query: &str, database: Option<&str>) -> Result<Option<Value>, AppError>
     where
         for<'c> &'c mut <Self::DB as sqlx::Database>::Connection: Executor<'c, Database = Self::DB>,
         <Self::DB as sqlx::Database>::Row: sqlx_to_json::RowExt,
     {
+        let pool = self.pool(database).await?;
         let sql = query.to_owned();
-        let db = database.map(str::to_owned);
-        let timeout = self.query_timeout();
-        async move {
-            let pool = self.pool(db.as_deref()).await?;
-            let inner_sql = sql.clone();
-            execute_with_timeout(timeout, &sql, async move {
-                let mut conn = pool.acquire().await?;
-                let row = (&mut *conn).fetch_optional(inner_sql.as_str()).await?;
-                Ok::<_, sqlx::Error>(row.as_ref().map(sqlx_to_json::RowExt::to_json))
-            })
-            .await
-        }
+        execute_with_timeout(self.query_timeout(), query, async move {
+            let mut conn = pool.acquire().await?;
+            let row = (&mut *conn).fetch_optional(sql.as_str()).await?;
+            Ok::<_, sqlx::Error>(row.as_ref().map(sqlx_to_json::RowExt::to_json))
+        })
+        .await
     }
 
     /// Wraps `name` in the backend's identifier quote character.

--- a/crates/sql/src/connection.rs
+++ b/crates/sql/src/connection.rs
@@ -1,16 +1,23 @@
 //! Connection abstraction shared across database backends.
 //!
 //! Defines [`Connection`] — the single entry point every backend tool
-//! handler uses to run SQL.  Methods accept plain `&str` queries and an
-//! optional target database name, returning unified JSON values.
+//! handler uses to run SQL, and [`PoolProvider`] — the backend-specific
+//! pool resolution trait that powers the blanket [`Connection`] impl.
 
 use database_mcp_server::AppError;
 use serde_json::Value;
+use sqlx::Executor;
+use sqlx_to_json::QueryResult as _;
+
+use crate::timeout::execute_with_timeout;
 
 /// Unified query surface every backend tool handler uses.
 ///
 /// Three methods cover all SQL operations: [`execute`](Connection::execute),
 /// [`fetch`](Connection::fetch), and [`fetch_optional`](Connection::fetch_optional).
+///
+/// Backends should implement [`PoolProvider`] instead of this trait
+/// directly; a blanket impl covers the shared query logic.
 ///
 /// # Errors
 ///
@@ -44,4 +51,73 @@ pub trait Connection: Send + Sync {
         query: &str,
         database: Option<&str>,
     ) -> impl Future<Output = Result<Option<Value>, AppError>> + Send;
+}
+
+/// Backend-specific pool resolution.
+///
+/// Each database backend implements this trait to provide its own pool
+/// lookup strategy (e.g. per-database caching for MySQL/PostgreSQL,
+/// single pool for `SQLite`). The blanket [`Connection`] impl uses these
+/// methods to run queries against the resolved pool.
+///
+/// # Errors
+///
+/// [`pool`](PoolProvider::pool) may return:
+///
+/// - [`AppError::InvalidIdentifier`] — the target database name failed
+///   identifier validation.
+pub trait PoolProvider: Send + Sync {
+    /// The sqlx database driver type (e.g. `sqlx::MySql`).
+    type DB: sqlx::Database;
+
+    /// Resolves the connection pool for the given target database.
+    ///
+    /// # Errors
+    ///
+    /// - [`AppError::InvalidIdentifier`] — `target` failed validation.
+    fn pool(&self, target: Option<&str>) -> impl Future<Output = Result<sqlx::Pool<Self::DB>, AppError>> + Send;
+
+    /// Returns the configured query timeout in seconds, if any.
+    fn query_timeout(&self) -> Option<u64>;
+}
+
+impl<T> Connection for T
+where
+    T: PoolProvider,
+    for<'c> &'c mut <T::DB as sqlx::Database>::Connection: Executor<'c, Database = T::DB>,
+    <T::DB as sqlx::Database>::Row: sqlx_to_json::RowExt,
+    <T::DB as sqlx::Database>::QueryResult: sqlx_to_json::QueryResult,
+{
+    async fn execute(&self, query: &str, database: Option<&str>) -> Result<u64, AppError> {
+        let pool = self.pool(database).await?;
+        let sql = query.to_owned();
+        execute_with_timeout(self.query_timeout(), query, async move {
+            let mut conn = pool.acquire().await?;
+            let result = (&mut *conn).execute(sql.as_str()).await?;
+            Ok::<_, sqlx::Error>(result.rows_affected())
+        })
+        .await
+    }
+
+    async fn fetch(&self, query: &str, database: Option<&str>) -> Result<Vec<Value>, AppError> {
+        let pool = self.pool(database).await?;
+        let sql = query.to_owned();
+        execute_with_timeout(self.query_timeout(), query, async move {
+            let mut conn = pool.acquire().await?;
+            let rows = (&mut *conn).fetch_all(sql.as_str()).await?;
+            Ok::<_, sqlx::Error>(rows.iter().map(sqlx_to_json::RowExt::to_json).collect())
+        })
+        .await
+    }
+
+    async fn fetch_optional(&self, query: &str, database: Option<&str>) -> Result<Option<Value>, AppError> {
+        let pool = self.pool(database).await?;
+        let sql = query.to_owned();
+        execute_with_timeout(self.query_timeout(), query, async move {
+            let mut conn = pool.acquire().await?;
+            let row = (&mut *conn).fetch_optional(sql.as_str()).await?;
+            Ok::<_, sqlx::Error>(row.as_ref().map(sqlx_to_json::RowExt::to_json))
+        })
+        .await
+    }
 }

--- a/crates/sql/src/connection.rs
+++ b/crates/sql/src/connection.rs
@@ -1,0 +1,243 @@
+//! Connection abstraction shared across database backends.
+//!
+//! Defines [`Connection`] — the single entry point every backend tool
+//! handler uses to run SQL — plus the sealed [`Query`] and [`Executable`]
+//! input traits that enumerate the accepted statement shapes.
+
+use database_mcp_server::AppError;
+use sqlx::Database;
+use sqlx::pool::PoolConnection;
+
+mod private {
+    pub trait Sealed {}
+}
+
+/// Shapes accepted by [`Connection::fetch`] and [`Connection::fetch_optional`].
+///
+/// Sealed — only the in-crate implementations for [`sqlx::query::Query`],
+/// [`sqlx::query::QueryAs`], [`sqlx::query::QueryScalar`], and `&str` are
+/// permitted.
+pub trait Query<DB>: private::Sealed + Send
+where
+    DB: Database,
+{
+    /// Decoded per-row output type.
+    type Output: Send + Unpin;
+
+    /// SQL text, captured before running so timeout errors can carry it.
+    fn sql(&self) -> &str;
+
+    /// Runs the query against an acquired pool connection and collects every row.
+    #[doc(hidden)]
+    fn run_fetch_all(
+        self,
+        conn: &mut PoolConnection<DB>,
+    ) -> impl Future<Output = Result<Vec<Self::Output>, sqlx::Error>> + Send;
+
+    /// Runs the query against an acquired pool connection and returns at most one row.
+    #[doc(hidden)]
+    fn run_fetch_optional(
+        self,
+        conn: &mut PoolConnection<DB>,
+    ) -> impl Future<Output = Result<Option<Self::Output>, sqlx::Error>> + Send;
+}
+
+/// Shapes accepted by [`Connection::execute`].
+///
+/// Only untyped statements make sense to `execute` — this trait is sealed
+/// and implemented exclusively by [`sqlx::query::Query`] and `&str`.
+pub trait Executable<DB>: Query<DB>
+where
+    DB: Database,
+{
+    /// Runs the statement against an acquired pool connection and discards any rows.
+    #[doc(hidden)]
+    fn run_execute(
+        self,
+        conn: &mut PoolConnection<DB>,
+    ) -> impl Future<Output = Result<DB::QueryResult, sqlx::Error>> + Send;
+}
+
+// ────────────────────── sqlx::query::Query ──────────────────────
+
+impl<'q, DB> private::Sealed for sqlx::query::Query<'q, DB, <DB as Database>::Arguments<'q>> where DB: Database {}
+
+impl<'q, DB> Query<DB> for sqlx::query::Query<'q, DB, <DB as Database>::Arguments<'q>>
+where
+    DB: Database,
+    <DB as Database>::Arguments<'q>: Send + sqlx::IntoArguments<'q, DB>,
+    for<'c> &'c mut <DB as Database>::Connection: sqlx::Executor<'c, Database = DB>,
+{
+    type Output = <DB as Database>::Row;
+
+    fn sql(&self) -> &str {
+        sqlx::Execute::sql(self)
+    }
+
+    async fn run_fetch_all(self, conn: &mut PoolConnection<DB>) -> Result<Vec<<DB as Database>::Row>, sqlx::Error> {
+        sqlx::query::Query::fetch_all(self, &mut **conn).await
+    }
+
+    async fn run_fetch_optional(
+        self,
+        conn: &mut PoolConnection<DB>,
+    ) -> Result<Option<<DB as Database>::Row>, sqlx::Error> {
+        sqlx::query::Query::fetch_optional(self, &mut **conn).await
+    }
+}
+
+impl<'q, DB> Executable<DB> for sqlx::query::Query<'q, DB, <DB as Database>::Arguments<'q>>
+where
+    DB: Database,
+    <DB as Database>::Arguments<'q>: Send + sqlx::IntoArguments<'q, DB>,
+    for<'c> &'c mut <DB as Database>::Connection: sqlx::Executor<'c, Database = DB>,
+{
+    async fn run_execute(self, conn: &mut PoolConnection<DB>) -> Result<<DB as Database>::QueryResult, sqlx::Error> {
+        sqlx::query::Query::execute(self, &mut **conn).await
+    }
+}
+
+// ────────────────────── sqlx::query::QueryAs ──────────────────────
+
+impl<'q, DB, T> private::Sealed for sqlx::query::QueryAs<'q, DB, T, <DB as Database>::Arguments<'q>> where DB: Database {}
+
+impl<'q, DB, T> Query<DB> for sqlx::query::QueryAs<'q, DB, T, <DB as Database>::Arguments<'q>>
+where
+    DB: Database,
+    T: Send + Unpin + for<'r> sqlx::FromRow<'r, <DB as Database>::Row> + 'q,
+    <DB as Database>::Arguments<'q>: Send + sqlx::IntoArguments<'q, DB>,
+    for<'c> &'c mut <DB as Database>::Connection: sqlx::Executor<'c, Database = DB>,
+{
+    type Output = T;
+
+    fn sql(&self) -> &str {
+        sqlx::Execute::sql(self)
+    }
+
+    async fn run_fetch_all(self, conn: &mut PoolConnection<DB>) -> Result<Vec<T>, sqlx::Error> {
+        sqlx::query::QueryAs::fetch_all(self, &mut **conn).await
+    }
+
+    async fn run_fetch_optional(self, conn: &mut PoolConnection<DB>) -> Result<Option<T>, sqlx::Error> {
+        sqlx::query::QueryAs::fetch_optional(self, &mut **conn).await
+    }
+}
+
+// ────────────────────── sqlx::query::QueryScalar ──────────────────────
+
+impl<'q, DB, O> private::Sealed for sqlx::query::QueryScalar<'q, DB, O, <DB as Database>::Arguments<'q>> where
+    DB: Database
+{
+}
+
+impl<'q, DB, O> Query<DB> for sqlx::query::QueryScalar<'q, DB, O, <DB as Database>::Arguments<'q>>
+where
+    DB: Database,
+    O: Send + Unpin + 'q,
+    (O,): for<'r> sqlx::FromRow<'r, <DB as Database>::Row>,
+    <DB as Database>::Arguments<'q>: Send + sqlx::IntoArguments<'q, DB>,
+    for<'c> &'c mut <DB as Database>::Connection: sqlx::Executor<'c, Database = DB>,
+{
+    type Output = O;
+
+    fn sql(&self) -> &str {
+        sqlx::Execute::sql(self)
+    }
+
+    async fn run_fetch_all(self, conn: &mut PoolConnection<DB>) -> Result<Vec<O>, sqlx::Error> {
+        sqlx::query::QueryScalar::fetch_all(self, &mut **conn).await
+    }
+
+    async fn run_fetch_optional(self, conn: &mut PoolConnection<DB>) -> Result<Option<O>, sqlx::Error> {
+        sqlx::query::QueryScalar::fetch_optional(self, &mut **conn).await
+    }
+}
+
+// ────────────────────── &str ──────────────────────
+
+impl private::Sealed for &str {}
+
+impl<DB> Query<DB> for &str
+where
+    DB: Database,
+    for<'c> &'c mut <DB as Database>::Connection: sqlx::Executor<'c, Database = DB>,
+{
+    type Output = <DB as Database>::Row;
+
+    fn sql(&self) -> &str {
+        self
+    }
+
+    async fn run_fetch_all(self, conn: &mut PoolConnection<DB>) -> Result<Vec<<DB as Database>::Row>, sqlx::Error> {
+        use sqlx::Executor;
+        (&mut **conn).fetch_all(self).await
+    }
+
+    async fn run_fetch_optional(
+        self,
+        conn: &mut PoolConnection<DB>,
+    ) -> Result<Option<<DB as Database>::Row>, sqlx::Error> {
+        use sqlx::Executor;
+        (&mut **conn).fetch_optional(self).await
+    }
+}
+
+impl<DB> Executable<DB> for &str
+where
+    DB: Database,
+    for<'c> &'c mut <DB as Database>::Connection: sqlx::Executor<'c, Database = DB>,
+{
+    async fn run_execute(self, conn: &mut PoolConnection<DB>) -> Result<<DB as Database>::QueryResult, sqlx::Error> {
+        use sqlx::Executor;
+        (&mut **conn).execute(self).await
+    }
+}
+
+// ────────────────────── Connection trait ──────────────────────
+
+/// Hands out the unified query surface every backend tool handler uses.
+///
+/// Three methods mirror sqlx's `Executor` semantics: [`execute`](Connection::execute),
+/// [`fetch`](Connection::fetch), and [`fetch_optional`](Connection::fetch_optional).
+/// Access control is delegated entirely to the database server's own credentials.
+pub trait Connection: Send + Sync {
+    /// Backend sqlx database marker (`Postgres`, `MySql`, or `Sqlite`).
+    type Database: Database;
+
+    /// Runs a statement that returns no rows.
+    ///
+    /// # Errors
+    ///
+    /// - [`AppError::InvalidIdentifier`] — `target` failed identifier validation.
+    /// - [`AppError::PoolCacheFull`] — (Postgres only) pool cache is full and cannot evict.
+    /// - [`AppError::Connection`] — the underlying driver failed.
+    fn execute<Q>(
+        &self,
+        query: Q,
+        target: Option<&str>,
+    ) -> impl Future<Output = Result<<Self::Database as Database>::QueryResult, AppError>> + Send
+    where
+        Q: Executable<Self::Database>;
+
+    /// Runs a statement and collects every result row or decoded value.
+    ///
+    /// # Errors
+    ///
+    /// See [`execute`](Connection::execute).
+    fn fetch<Q>(&self, query: Q, target: Option<&str>) -> impl Future<Output = Result<Vec<Q::Output>, AppError>> + Send
+    where
+        Q: Query<Self::Database>;
+
+    /// Runs a statement and returns at most one result row or decoded value.
+    ///
+    /// # Errors
+    ///
+    /// See [`execute`](Connection::execute).
+    fn fetch_optional<Q>(
+        &self,
+        query: Q,
+        target: Option<&str>,
+    ) -> impl Future<Output = Result<Option<Q::Output>, AppError>> + Send
+    where
+        Q: Query<Self::Database>;
+}

--- a/crates/sql/src/connection.rs
+++ b/crates/sql/src/connection.rs
@@ -1,74 +1,38 @@
 //! Connection abstraction shared across database backends.
 //!
-//! Defines [`Connection`] — the single entry point every backend tool
-//! handler uses to run SQL, and [`PoolProvider`] — the backend-specific
-//! pool resolution trait that powers the blanket [`Connection`] impl.
+//! Defines [`Connection`] — the single trait every backend implements.
+//! Backends provide pool resolution, identifier quoting config, and
+//! timeout config; default method implementations handle query execution
+//! and SQL quoting.
 
 use database_mcp_server::AppError;
 use serde_json::Value;
 use sqlx::Executor;
 use sqlx_to_json::QueryResult as _;
 
+use crate::identifier;
 use crate::timeout::execute_with_timeout;
 
-/// Unified query surface every backend tool handler uses.
+/// Unified query and quoting surface every backend tool handler uses.
 ///
-/// Three methods cover all SQL operations: [`execute`](Connection::execute),
-/// [`fetch`](Connection::fetch), and [`fetch_optional`](Connection::fetch_optional).
-///
-/// Backends should implement [`PoolProvider`] instead of this trait
-/// directly; a blanket impl covers the shared query logic.
+/// Backends supply four required items — [`DB`](Connection::DB),
+/// [`IDENTIFIER_QUOTE`](Connection::IDENTIFIER_QUOTE),
+/// [`pool`](Connection::pool), and [`query_timeout`](Connection::query_timeout)
+/// — and receive default implementations for query execution and SQL quoting.
 ///
 /// # Errors
 ///
-/// All methods may return:
+/// Query methods may return:
 ///
 /// - [`AppError::InvalidIdentifier`] — `database` failed identifier validation.
 /// - [`AppError::Connection`] — the underlying driver failed.
 /// - [`AppError::QueryTimeout`] — the query exceeded the configured timeout.
 pub trait Connection: Send + Sync {
-    /// Runs a statement that returns no meaningful rows.
-    ///
-    /// # Errors
-    ///
-    /// See trait-level documentation.
-    fn execute(&self, query: &str, database: Option<&str>) -> impl Future<Output = Result<u64, AppError>> + Send;
-
-    /// Runs a statement and collects every result row as JSON.
-    ///
-    /// # Errors
-    ///
-    /// See trait-level documentation.
-    fn fetch(&self, query: &str, database: Option<&str>) -> impl Future<Output = Result<Vec<Value>, AppError>> + Send;
-
-    /// Runs a statement and returns at most one result row as JSON.
-    ///
-    /// # Errors
-    ///
-    /// See trait-level documentation.
-    fn fetch_optional(
-        &self,
-        query: &str,
-        database: Option<&str>,
-    ) -> impl Future<Output = Result<Option<Value>, AppError>> + Send;
-}
-
-/// Backend-specific pool resolution.
-///
-/// Each database backend implements this trait to provide its own pool
-/// lookup strategy (e.g. per-database caching for MySQL/PostgreSQL,
-/// single pool for `SQLite`). The blanket [`Connection`] impl uses these
-/// methods to run queries against the resolved pool.
-///
-/// # Errors
-///
-/// [`pool`](PoolProvider::pool) may return:
-///
-/// - [`AppError::InvalidIdentifier`] — the target database name failed
-///   identifier validation.
-pub trait PoolProvider: Send + Sync {
     /// The sqlx database driver type (e.g. `sqlx::MySql`).
     type DB: sqlx::Database;
+
+    /// Character used to quote identifiers (`` ` `` for `MySQL`, `"` for `PostgreSQL`/`SQLite`).
+    const IDENTIFIER_QUOTE: char;
 
     /// Resolves the connection pool for the given target database.
     ///
@@ -79,45 +43,93 @@ pub trait PoolProvider: Send + Sync {
 
     /// Returns the configured query timeout in seconds, if any.
     fn query_timeout(&self) -> Option<u64>;
-}
 
-impl<T> Connection for T
-where
-    T: PoolProvider,
-    for<'c> &'c mut <T::DB as sqlx::Database>::Connection: Executor<'c, Database = T::DB>,
-    <T::DB as sqlx::Database>::Row: sqlx_to_json::RowExt,
-    <T::DB as sqlx::Database>::QueryResult: sqlx_to_json::QueryResult,
-{
-    async fn execute(&self, query: &str, database: Option<&str>) -> Result<u64, AppError> {
-        let pool = self.pool(database).await?;
+    /// Runs a statement that returns no meaningful rows.
+    ///
+    /// # Errors
+    ///
+    /// See trait-level documentation.
+    fn execute(&self, query: &str, database: Option<&str>) -> impl Future<Output = Result<u64, AppError>> + Send
+    where
+        for<'c> &'c mut <Self::DB as sqlx::Database>::Connection: Executor<'c, Database = Self::DB>,
+        <Self::DB as sqlx::Database>::QueryResult: sqlx_to_json::QueryResult,
+    {
         let sql = query.to_owned();
-        execute_with_timeout(self.query_timeout(), query, async move {
-            let mut conn = pool.acquire().await?;
-            let result = (&mut *conn).execute(sql.as_str()).await?;
-            Ok::<_, sqlx::Error>(result.rows_affected())
-        })
-        .await
+        let db = database.map(str::to_owned);
+        let timeout = self.query_timeout();
+        async move {
+            let pool = self.pool(db.as_deref()).await?;
+            let inner_sql = sql.clone();
+            execute_with_timeout(timeout, &sql, async move {
+                let mut conn = pool.acquire().await?;
+                let result = (&mut *conn).execute(inner_sql.as_str()).await?;
+                Ok::<_, sqlx::Error>(result.rows_affected())
+            })
+            .await
+        }
     }
 
-    async fn fetch(&self, query: &str, database: Option<&str>) -> Result<Vec<Value>, AppError> {
-        let pool = self.pool(database).await?;
+    /// Runs a statement and collects every result row as JSON.
+    ///
+    /// # Errors
+    ///
+    /// See trait-level documentation.
+    fn fetch(&self, query: &str, database: Option<&str>) -> impl Future<Output = Result<Vec<Value>, AppError>> + Send
+    where
+        for<'c> &'c mut <Self::DB as sqlx::Database>::Connection: Executor<'c, Database = Self::DB>,
+        <Self::DB as sqlx::Database>::Row: sqlx_to_json::RowExt,
+    {
         let sql = query.to_owned();
-        execute_with_timeout(self.query_timeout(), query, async move {
-            let mut conn = pool.acquire().await?;
-            let rows = (&mut *conn).fetch_all(sql.as_str()).await?;
-            Ok::<_, sqlx::Error>(rows.iter().map(sqlx_to_json::RowExt::to_json).collect())
-        })
-        .await
+        let db = database.map(str::to_owned);
+        let timeout = self.query_timeout();
+        async move {
+            let pool = self.pool(db.as_deref()).await?;
+            let inner_sql = sql.clone();
+            execute_with_timeout(timeout, &sql, async move {
+                let mut conn = pool.acquire().await?;
+                let rows = (&mut *conn).fetch_all(inner_sql.as_str()).await?;
+                Ok::<_, sqlx::Error>(rows.iter().map(sqlx_to_json::RowExt::to_json).collect())
+            })
+            .await
+        }
     }
 
-    async fn fetch_optional(&self, query: &str, database: Option<&str>) -> Result<Option<Value>, AppError> {
-        let pool = self.pool(database).await?;
+    /// Runs a statement and returns at most one result row as JSON.
+    ///
+    /// # Errors
+    ///
+    /// See trait-level documentation.
+    fn fetch_optional(
+        &self,
+        query: &str,
+        database: Option<&str>,
+    ) -> impl Future<Output = Result<Option<Value>, AppError>> + Send
+    where
+        for<'c> &'c mut <Self::DB as sqlx::Database>::Connection: Executor<'c, Database = Self::DB>,
+        <Self::DB as sqlx::Database>::Row: sqlx_to_json::RowExt,
+    {
         let sql = query.to_owned();
-        execute_with_timeout(self.query_timeout(), query, async move {
-            let mut conn = pool.acquire().await?;
-            let row = (&mut *conn).fetch_optional(sql.as_str()).await?;
-            Ok::<_, sqlx::Error>(row.as_ref().map(sqlx_to_json::RowExt::to_json))
-        })
-        .await
+        let db = database.map(str::to_owned);
+        let timeout = self.query_timeout();
+        async move {
+            let pool = self.pool(db.as_deref()).await?;
+            let inner_sql = sql.clone();
+            execute_with_timeout(timeout, &sql, async move {
+                let mut conn = pool.acquire().await?;
+                let row = (&mut *conn).fetch_optional(inner_sql.as_str()).await?;
+                Ok::<_, sqlx::Error>(row.as_ref().map(sqlx_to_json::RowExt::to_json))
+            })
+            .await
+        }
+    }
+
+    /// Wraps `name` in the backend's identifier quote character.
+    fn quote_identifier(&self, name: &str) -> String {
+        identifier::quote_identifier(name, Self::IDENTIFIER_QUOTE)
+    }
+
+    /// Wraps `value` in single quotes for use as a SQL string literal.
+    fn quote_string(&self, value: &str) -> String {
+        identifier::quote_string(value)
     }
 }

--- a/crates/sql/src/connection.rs
+++ b/crates/sql/src/connection.rs
@@ -1,243 +1,47 @@
 //! Connection abstraction shared across database backends.
 //!
 //! Defines [`Connection`] — the single entry point every backend tool
-//! handler uses to run SQL — plus the sealed [`Query`] and [`Executable`]
-//! input traits that enumerate the accepted statement shapes.
+//! handler uses to run SQL.  Methods accept plain `&str` queries and an
+//! optional target database name, returning unified JSON values.
 
 use database_mcp_server::AppError;
-use sqlx::Database;
-use sqlx::pool::PoolConnection;
+use serde_json::Value;
 
-mod private {
-    pub trait Sealed {}
-}
-
-/// Shapes accepted by [`Connection::fetch`] and [`Connection::fetch_optional`].
+/// Unified query surface every backend tool handler uses.
 ///
-/// Sealed — only the in-crate implementations for [`sqlx::query::Query`],
-/// [`sqlx::query::QueryAs`], [`sqlx::query::QueryScalar`], and `&str` are
-/// permitted.
-pub trait Query<DB>: private::Sealed + Send
-where
-    DB: Database,
-{
-    /// Decoded per-row output type.
-    type Output: Send + Unpin;
-
-    /// SQL text, captured before running so timeout errors can carry it.
-    fn sql(&self) -> &str;
-
-    /// Runs the query against an acquired pool connection and collects every row.
-    #[doc(hidden)]
-    fn run_fetch_all(
-        self,
-        conn: &mut PoolConnection<DB>,
-    ) -> impl Future<Output = Result<Vec<Self::Output>, sqlx::Error>> + Send;
-
-    /// Runs the query against an acquired pool connection and returns at most one row.
-    #[doc(hidden)]
-    fn run_fetch_optional(
-        self,
-        conn: &mut PoolConnection<DB>,
-    ) -> impl Future<Output = Result<Option<Self::Output>, sqlx::Error>> + Send;
-}
-
-/// Shapes accepted by [`Connection::execute`].
-///
-/// Only untyped statements make sense to `execute` — this trait is sealed
-/// and implemented exclusively by [`sqlx::query::Query`] and `&str`.
-pub trait Executable<DB>: Query<DB>
-where
-    DB: Database,
-{
-    /// Runs the statement against an acquired pool connection and discards any rows.
-    #[doc(hidden)]
-    fn run_execute(
-        self,
-        conn: &mut PoolConnection<DB>,
-    ) -> impl Future<Output = Result<DB::QueryResult, sqlx::Error>> + Send;
-}
-
-// ────────────────────── sqlx::query::Query ──────────────────────
-
-impl<'q, DB> private::Sealed for sqlx::query::Query<'q, DB, <DB as Database>::Arguments<'q>> where DB: Database {}
-
-impl<'q, DB> Query<DB> for sqlx::query::Query<'q, DB, <DB as Database>::Arguments<'q>>
-where
-    DB: Database,
-    <DB as Database>::Arguments<'q>: Send + sqlx::IntoArguments<'q, DB>,
-    for<'c> &'c mut <DB as Database>::Connection: sqlx::Executor<'c, Database = DB>,
-{
-    type Output = <DB as Database>::Row;
-
-    fn sql(&self) -> &str {
-        sqlx::Execute::sql(self)
-    }
-
-    async fn run_fetch_all(self, conn: &mut PoolConnection<DB>) -> Result<Vec<<DB as Database>::Row>, sqlx::Error> {
-        sqlx::query::Query::fetch_all(self, &mut **conn).await
-    }
-
-    async fn run_fetch_optional(
-        self,
-        conn: &mut PoolConnection<DB>,
-    ) -> Result<Option<<DB as Database>::Row>, sqlx::Error> {
-        sqlx::query::Query::fetch_optional(self, &mut **conn).await
-    }
-}
-
-impl<'q, DB> Executable<DB> for sqlx::query::Query<'q, DB, <DB as Database>::Arguments<'q>>
-where
-    DB: Database,
-    <DB as Database>::Arguments<'q>: Send + sqlx::IntoArguments<'q, DB>,
-    for<'c> &'c mut <DB as Database>::Connection: sqlx::Executor<'c, Database = DB>,
-{
-    async fn run_execute(self, conn: &mut PoolConnection<DB>) -> Result<<DB as Database>::QueryResult, sqlx::Error> {
-        sqlx::query::Query::execute(self, &mut **conn).await
-    }
-}
-
-// ────────────────────── sqlx::query::QueryAs ──────────────────────
-
-impl<'q, DB, T> private::Sealed for sqlx::query::QueryAs<'q, DB, T, <DB as Database>::Arguments<'q>> where DB: Database {}
-
-impl<'q, DB, T> Query<DB> for sqlx::query::QueryAs<'q, DB, T, <DB as Database>::Arguments<'q>>
-where
-    DB: Database,
-    T: Send + Unpin + for<'r> sqlx::FromRow<'r, <DB as Database>::Row> + 'q,
-    <DB as Database>::Arguments<'q>: Send + sqlx::IntoArguments<'q, DB>,
-    for<'c> &'c mut <DB as Database>::Connection: sqlx::Executor<'c, Database = DB>,
-{
-    type Output = T;
-
-    fn sql(&self) -> &str {
-        sqlx::Execute::sql(self)
-    }
-
-    async fn run_fetch_all(self, conn: &mut PoolConnection<DB>) -> Result<Vec<T>, sqlx::Error> {
-        sqlx::query::QueryAs::fetch_all(self, &mut **conn).await
-    }
-
-    async fn run_fetch_optional(self, conn: &mut PoolConnection<DB>) -> Result<Option<T>, sqlx::Error> {
-        sqlx::query::QueryAs::fetch_optional(self, &mut **conn).await
-    }
-}
-
-// ────────────────────── sqlx::query::QueryScalar ──────────────────────
-
-impl<'q, DB, O> private::Sealed for sqlx::query::QueryScalar<'q, DB, O, <DB as Database>::Arguments<'q>> where
-    DB: Database
-{
-}
-
-impl<'q, DB, O> Query<DB> for sqlx::query::QueryScalar<'q, DB, O, <DB as Database>::Arguments<'q>>
-where
-    DB: Database,
-    O: Send + Unpin + 'q,
-    (O,): for<'r> sqlx::FromRow<'r, <DB as Database>::Row>,
-    <DB as Database>::Arguments<'q>: Send + sqlx::IntoArguments<'q, DB>,
-    for<'c> &'c mut <DB as Database>::Connection: sqlx::Executor<'c, Database = DB>,
-{
-    type Output = O;
-
-    fn sql(&self) -> &str {
-        sqlx::Execute::sql(self)
-    }
-
-    async fn run_fetch_all(self, conn: &mut PoolConnection<DB>) -> Result<Vec<O>, sqlx::Error> {
-        sqlx::query::QueryScalar::fetch_all(self, &mut **conn).await
-    }
-
-    async fn run_fetch_optional(self, conn: &mut PoolConnection<DB>) -> Result<Option<O>, sqlx::Error> {
-        sqlx::query::QueryScalar::fetch_optional(self, &mut **conn).await
-    }
-}
-
-// ────────────────────── &str ──────────────────────
-
-impl private::Sealed for &str {}
-
-impl<DB> Query<DB> for &str
-where
-    DB: Database,
-    for<'c> &'c mut <DB as Database>::Connection: sqlx::Executor<'c, Database = DB>,
-{
-    type Output = <DB as Database>::Row;
-
-    fn sql(&self) -> &str {
-        self
-    }
-
-    async fn run_fetch_all(self, conn: &mut PoolConnection<DB>) -> Result<Vec<<DB as Database>::Row>, sqlx::Error> {
-        use sqlx::Executor;
-        (&mut **conn).fetch_all(self).await
-    }
-
-    async fn run_fetch_optional(
-        self,
-        conn: &mut PoolConnection<DB>,
-    ) -> Result<Option<<DB as Database>::Row>, sqlx::Error> {
-        use sqlx::Executor;
-        (&mut **conn).fetch_optional(self).await
-    }
-}
-
-impl<DB> Executable<DB> for &str
-where
-    DB: Database,
-    for<'c> &'c mut <DB as Database>::Connection: sqlx::Executor<'c, Database = DB>,
-{
-    async fn run_execute(self, conn: &mut PoolConnection<DB>) -> Result<<DB as Database>::QueryResult, sqlx::Error> {
-        use sqlx::Executor;
-        (&mut **conn).execute(self).await
-    }
-}
-
-// ────────────────────── Connection trait ──────────────────────
-
-/// Hands out the unified query surface every backend tool handler uses.
-///
-/// Three methods mirror sqlx's `Executor` semantics: [`execute`](Connection::execute),
+/// Three methods cover all SQL operations: [`execute`](Connection::execute),
 /// [`fetch`](Connection::fetch), and [`fetch_optional`](Connection::fetch_optional).
-/// Access control is delegated entirely to the database server's own credentials.
+///
+/// # Errors
+///
+/// All methods may return:
+///
+/// - [`AppError::InvalidIdentifier`] — `database` failed identifier validation.
+/// - [`AppError::Connection`] — the underlying driver failed.
+/// - [`AppError::QueryTimeout`] — the query exceeded the configured timeout.
 pub trait Connection: Send + Sync {
-    /// Backend sqlx database marker (`Postgres`, `MySql`, or `Sqlite`).
-    type Database: Database;
-
-    /// Runs a statement that returns no rows.
+    /// Runs a statement that returns no meaningful rows.
     ///
     /// # Errors
     ///
-    /// - [`AppError::InvalidIdentifier`] — `target` failed identifier validation.
-    /// - [`AppError::PoolCacheFull`] — (Postgres only) pool cache is full and cannot evict.
-    /// - [`AppError::Connection`] — the underlying driver failed.
-    fn execute<Q>(
+    /// See trait-level documentation.
+    fn execute(&self, query: &str, database: Option<&str>) -> impl Future<Output = Result<u64, AppError>> + Send;
+
+    /// Runs a statement and collects every result row as JSON.
+    ///
+    /// # Errors
+    ///
+    /// See trait-level documentation.
+    fn fetch(&self, query: &str, database: Option<&str>) -> impl Future<Output = Result<Vec<Value>, AppError>> + Send;
+
+    /// Runs a statement and returns at most one result row as JSON.
+    ///
+    /// # Errors
+    ///
+    /// See trait-level documentation.
+    fn fetch_optional(
         &self,
-        query: Q,
-        target: Option<&str>,
-    ) -> impl Future<Output = Result<<Self::Database as Database>::QueryResult, AppError>> + Send
-    where
-        Q: Executable<Self::Database>;
-
-    /// Runs a statement and collects every result row or decoded value.
-    ///
-    /// # Errors
-    ///
-    /// See [`execute`](Connection::execute).
-    fn fetch<Q>(&self, query: Q, target: Option<&str>) -> impl Future<Output = Result<Vec<Q::Output>, AppError>> + Send
-    where
-        Q: Query<Self::Database>;
-
-    /// Runs a statement and returns at most one result row or decoded value.
-    ///
-    /// # Errors
-    ///
-    /// See [`execute`](Connection::execute).
-    fn fetch_optional<Q>(
-        &self,
-        query: Q,
-        target: Option<&str>,
-    ) -> impl Future<Output = Result<Option<Q::Output>, AppError>> + Send
-    where
-        Q: Query<Self::Database>;
+        query: &str,
+        database: Option<&str>,
+    ) -> impl Future<Output = Result<Option<Value>, AppError>> + Send;
 }

--- a/crates/sql/src/identifier.rs
+++ b/crates/sql/src/identifier.rs
@@ -12,6 +12,15 @@ pub fn quote_identifier(name: &str, quote_char: char) -> String {
     format!("{quote_char}{escaped}{quote_char}")
 }
 
+/// Wraps `value` in single quotes for safe use as a SQL string literal.
+///
+/// Escapes internal single quotes by doubling them.
+#[must_use]
+pub fn quote_string(value: &str) -> String {
+    let escaped = value.replace('\'', "''");
+    format!("'{escaped}'")
+}
+
 /// Validates that `name` is a non-empty identifier without control characters.
 ///
 /// # Errors
@@ -82,5 +91,21 @@ mod tests {
     fn quote_with_backticks() {
         assert_eq!(quote_identifier("users", '`'), "`users`");
         assert_eq!(quote_identifier("test`db", '`'), "`test``db`");
+    }
+
+    #[test]
+    fn quote_string_normal() {
+        assert_eq!(quote_string("my_db"), "'my_db'");
+    }
+
+    #[test]
+    fn quote_string_empty() {
+        assert_eq!(quote_string(""), "''");
+    }
+
+    #[test]
+    fn quote_string_with_single_quotes() {
+        assert_eq!(quote_string("it's"), "'it''s'");
+        assert_eq!(quote_string("a'b'c"), "'a''b''c'");
     }
 }

--- a/crates/sql/src/lib.rs
+++ b/crates/sql/src/lib.rs
@@ -10,4 +10,4 @@ pub mod identifier;
 pub mod timeout;
 pub mod validation;
 
-pub use connection::Connection;
+pub use connection::{Connection, PoolProvider};

--- a/crates/sql/src/lib.rs
+++ b/crates/sql/src/lib.rs
@@ -1,8 +1,13 @@
-//! SQL validation and identifier utilities for database backends.
+//! SQL validation, identifier, and connection utilities.
 //!
 //! Provides [`identifier`] helpers for quoting and validating SQL
-//! identifiers, and [`validation`] for read-only query enforcement.
+//! identifiers, [`validation`] for read-only query enforcement,
+//! [`timeout`] for query-level timeout wrapping, and the
+//! [`connection`] trait shared by every backend.
 
+pub mod connection;
 pub mod identifier;
 pub mod timeout;
 pub mod validation;
+
+pub use connection::Connection;

--- a/crates/sql/src/lib.rs
+++ b/crates/sql/src/lib.rs
@@ -10,4 +10,4 @@ pub mod identifier;
 pub mod timeout;
 pub mod validation;
 
-pub use connection::{Connection, PoolProvider};
+pub use connection::Connection;

--- a/crates/sqlite/src/connection.rs
+++ b/crates/sqlite/src/connection.rs
@@ -9,7 +9,7 @@ use std::time::Duration;
 use database_mcp_config::DatabaseConfig;
 use database_mcp_server::AppError;
 use database_mcp_sql::Connection;
-use sqlx::sqlite::{SqliteConnectOptions, SqlitePool, SqlitePoolOptions};
+use sqlx::sqlite::{SqliteConnectOptions, SqlitePool};
 
 /// Owns the lazy `SQLite` pool and the logic that builds it.
 #[derive(Clone)]
@@ -29,7 +29,7 @@ impl SqliteConnection {
     pub(crate) fn new(config: &DatabaseConfig) -> Self {
         Self {
             config: config.clone(),
-            pool: pool_options(config).connect_lazy_with(connect_options(config)),
+            pool: create_lazy_pool(config),
         }
     }
 
@@ -56,24 +56,22 @@ impl Connection for SqliteConnection {
     }
 }
 
-/// Builds [`SqlitePoolOptions`] with lifecycle defaults from a [`DatabaseConfig`].
-fn pool_options(config: &DatabaseConfig) -> SqlitePoolOptions {
-    let mut opts = SqlitePoolOptions::new()
-        .max_connections(1) // SQLite is a single-writer
+/// Creates a lazy `SQLite` pool from a [`DatabaseConfig`].
+///
+/// Forces `max_connections` to 1 — `SQLite` is a single-writer backend.
+fn create_lazy_pool(config: &DatabaseConfig) -> SqlitePool {
+    let opts = SqliteConnectOptions::new().filename(config.name.as_deref().unwrap_or_default());
+    let mut pool_opts = sqlx::pool::PoolOptions::new()
+        .max_connections(1)
         .min_connections(DatabaseConfig::DEFAULT_MIN_CONNECTIONS)
         .idle_timeout(Duration::from_secs(DatabaseConfig::DEFAULT_IDLE_TIMEOUT_SECS))
         .max_lifetime(Duration::from_secs(DatabaseConfig::DEFAULT_MAX_LIFETIME_SECS));
 
     if let Some(timeout) = config.connection_timeout {
-        opts = opts.acquire_timeout(Duration::from_secs(timeout));
+        pool_opts = pool_opts.acquire_timeout(Duration::from_secs(timeout));
     }
 
-    opts
-}
-
-/// Builds [`SqliteConnectOptions`] from a [`DatabaseConfig`].
-fn connect_options(config: &DatabaseConfig) -> SqliteConnectOptions {
-    SqliteConnectOptions::new().filename(config.name.as_deref().unwrap_or_default())
+    pool_opts.connect_lazy_with(opts)
 }
 
 #[cfg(test)]
@@ -89,67 +87,19 @@ mod tests {
         }
     }
 
-    #[test]
-    fn pool_options_applies_defaults() {
-        let config = base_config();
-        let opts = pool_options(&config);
-
-        assert_eq!(opts.get_max_connections(), 1, "SQLite must be single-writer");
-        assert_eq!(opts.get_min_connections(), DatabaseConfig::DEFAULT_MIN_CONNECTIONS);
-        assert_eq!(
-            opts.get_idle_timeout(),
-            Some(Duration::from_secs(DatabaseConfig::DEFAULT_IDLE_TIMEOUT_SECS))
-        );
-        assert_eq!(
-            opts.get_max_lifetime(),
-            Some(Duration::from_secs(DatabaseConfig::DEFAULT_MAX_LIFETIME_SECS))
-        );
+    #[tokio::test]
+    async fn create_lazy_pool_returns_idle_pool() {
+        let pool = create_lazy_pool(&base_config());
+        assert_eq!(pool.size(), 0, "pool should be lazy (no connections yet)");
     }
 
-    #[test]
-    fn pool_options_applies_connection_timeout() {
-        let config = DatabaseConfig {
-            connection_timeout: Some(7),
-            ..base_config()
-        };
-        let opts = pool_options(&config);
-
-        assert_eq!(opts.get_acquire_timeout(), Duration::from_secs(7));
-    }
-
-    #[test]
-    fn pool_options_without_connection_timeout_uses_sqlx_default() {
-        let config = base_config();
-        let opts = pool_options(&config);
-
-        assert_eq!(opts.get_acquire_timeout(), Duration::from_secs(30));
-    }
-
-    #[test]
-    fn pool_options_ignores_max_pool_size() {
-        let config = DatabaseConfig {
-            max_pool_size: 20,
-            ..base_config()
-        };
-        let opts = pool_options(&config);
-
-        assert_eq!(opts.get_max_connections(), 1, "SQLite must always be single-writer");
-    }
-
-    #[test]
-    fn try_from_sets_filename() {
-        let opts = connect_options(&base_config());
-        assert_eq!(opts.get_filename().to_str().expect("valid path"), "test.db");
-    }
-
-    #[test]
-    fn try_from_empty_name_defaults() {
-        let config = DatabaseConfig {
+    #[tokio::test]
+    async fn create_lazy_pool_without_name() {
+        let pool = create_lazy_pool(&DatabaseConfig {
             name: None,
             ..base_config()
-        };
-        let opts = connect_options(&config);
-        assert_eq!(opts.get_filename().to_str().expect("valid path"), "");
+        });
+        assert_eq!(pool.size(), 0);
     }
 
     #[tokio::test]

--- a/crates/sqlite/src/connection.rs
+++ b/crates/sqlite/src/connection.rs
@@ -60,7 +60,7 @@ impl Connection for SqliteConnection {
 ///
 /// Forces `max_connections` to 1 — `SQLite` is a single-writer backend.
 fn create_lazy_pool(config: &DatabaseConfig) -> SqlitePool {
-    let opts = SqliteConnectOptions::new().filename(config.name.as_deref().unwrap_or_default());
+    let conn_ops = SqliteConnectOptions::new().filename(config.name.as_deref().unwrap_or_default());
     let mut pool_opts = sqlx::pool::PoolOptions::new()
         .max_connections(1)
         .min_connections(DatabaseConfig::DEFAULT_MIN_CONNECTIONS)
@@ -71,7 +71,7 @@ fn create_lazy_pool(config: &DatabaseConfig) -> SqlitePool {
         pool_opts = pool_opts.acquire_timeout(Duration::from_secs(timeout));
     }
 
-    pool_opts.connect_lazy_with(opts)
+    pool_opts.connect_lazy_with(conn_ops)
 }
 
 #[cfg(test)]

--- a/crates/sqlite/src/connection.rs
+++ b/crates/sqlite/src/connection.rs
@@ -1,4 +1,4 @@
-//! `SQLite` connection: pool ownership + initialization.
+//! `SQLite` connection: pool ownership, initialization, and [`PoolProvider`] impl.
 //!
 //! Owns the single lazy [`SqlitePool`] used by [`SqliteHandler`](crate::SqliteHandler).
 //! `SQLite` is a single-file, single-writer backend; the pool is fixed
@@ -8,12 +8,8 @@ use std::time::Duration;
 
 use database_mcp_config::DatabaseConfig;
 use database_mcp_server::AppError;
-use database_mcp_sql::connection::Connection;
-use database_mcp_sql::timeout::execute_with_timeout;
-use serde_json::Value;
-use sqlx::Executor;
+use database_mcp_sql::PoolProvider;
 use sqlx::sqlite::{SqliteConnectOptions, SqlitePool, SqlitePoolOptions};
-use sqlx_to_json::RowExt;
 
 /// Owns the lazy `SQLite` pool and the logic that builds it.
 #[derive(Clone)]
@@ -53,38 +49,15 @@ impl SqliteConnection {
     }
 }
 
-impl Connection for SqliteConnection {
-    async fn execute(&self, query: &str, database: Option<&str>) -> Result<u64, AppError> {
-        let pool = self.pool(database).await?;
-        let sql = query.to_owned();
-        execute_with_timeout(self.config.query_timeout, query, async move {
-            let mut conn = pool.acquire().await?;
-            let result = (&mut *conn).execute(sql.as_str()).await?;
-            Ok::<_, sqlx::Error>(result.rows_affected())
-        })
-        .await
+impl PoolProvider for SqliteConnection {
+    type DB = sqlx::Sqlite;
+
+    async fn pool(&self, target: Option<&str>) -> Result<sqlx::Pool<Self::DB>, AppError> {
+        self.pool(target).await
     }
 
-    async fn fetch(&self, query: &str, database: Option<&str>) -> Result<Vec<Value>, AppError> {
-        let pool = self.pool(database).await?;
-        let sql = query.to_owned();
-        execute_with_timeout(self.config.query_timeout, query, async move {
-            let mut conn = pool.acquire().await?;
-            let rows = (&mut *conn).fetch_all(sql.as_str()).await?;
-            Ok::<_, sqlx::Error>(rows.iter().map(RowExt::to_json).collect())
-        })
-        .await
-    }
-
-    async fn fetch_optional(&self, query: &str, database: Option<&str>) -> Result<Option<Value>, AppError> {
-        let pool = self.pool(database).await?;
-        let sql = query.to_owned();
-        execute_with_timeout(self.config.query_timeout, query, async move {
-            let mut conn = pool.acquire().await?;
-            let row = (&mut *conn).fetch_optional(sql.as_str()).await?;
-            Ok::<_, sqlx::Error>(row.as_ref().map(RowExt::to_json))
-        })
-        .await
+    fn query_timeout(&self) -> Option<u64> {
+        self.config.query_timeout
     }
 }
 

--- a/crates/sqlite/src/connection.rs
+++ b/crates/sqlite/src/connection.rs
@@ -8,10 +8,12 @@ use std::time::Duration;
 
 use database_mcp_config::DatabaseConfig;
 use database_mcp_server::AppError;
-use database_mcp_sql::connection::{Connection, Executable, Query};
+use database_mcp_sql::connection::Connection;
 use database_mcp_sql::timeout::execute_with_timeout;
-use sqlx::Sqlite;
-use sqlx::sqlite::{SqliteConnectOptions, SqlitePool, SqlitePoolOptions, SqliteQueryResult};
+use serde_json::Value;
+use sqlx::Executor;
+use sqlx::sqlite::{SqliteConnectOptions, SqlitePool, SqlitePoolOptions};
+use sqlx_to_json::RowExt;
 
 /// Owns the lazy `SQLite` pool and the logic that builds it.
 #[derive(Clone)]
@@ -52,43 +54,35 @@ impl SqliteConnection {
 }
 
 impl Connection for SqliteConnection {
-    type Database = Sqlite;
-
-    async fn execute<Q>(&self, query: Q, target: Option<&str>) -> Result<SqliteQueryResult, AppError>
-    where
-        Q: Executable<Sqlite>,
-    {
-        let pool = self.pool(target).await?;
-        let sql = query.sql().to_owned();
-        execute_with_timeout(self.config.query_timeout, &sql, async move {
+    async fn execute(&self, query: &str, database: Option<&str>) -> Result<u64, AppError> {
+        let pool = self.pool(database).await?;
+        let sql = query.to_owned();
+        execute_with_timeout(self.config.query_timeout, query, async move {
             let mut conn = pool.acquire().await?;
-            query.run_execute(&mut conn).await
+            let result = (&mut *conn).execute(sql.as_str()).await?;
+            Ok::<_, sqlx::Error>(result.rows_affected())
         })
         .await
     }
 
-    async fn fetch<Q>(&self, query: Q, target: Option<&str>) -> Result<Vec<Q::Output>, AppError>
-    where
-        Q: Query<Sqlite>,
-    {
-        let pool = self.pool(target).await?;
-        let sql = query.sql().to_owned();
-        execute_with_timeout(self.config.query_timeout, &sql, async move {
+    async fn fetch(&self, query: &str, database: Option<&str>) -> Result<Vec<Value>, AppError> {
+        let pool = self.pool(database).await?;
+        let sql = query.to_owned();
+        execute_with_timeout(self.config.query_timeout, query, async move {
             let mut conn = pool.acquire().await?;
-            query.run_fetch_all(&mut conn).await
+            let rows = (&mut *conn).fetch_all(sql.as_str()).await?;
+            Ok::<_, sqlx::Error>(rows.iter().map(RowExt::to_json).collect())
         })
         .await
     }
 
-    async fn fetch_optional<Q>(&self, query: Q, target: Option<&str>) -> Result<Option<Q::Output>, AppError>
-    where
-        Q: Query<Sqlite>,
-    {
-        let pool = self.pool(target).await?;
-        let sql = query.sql().to_owned();
-        execute_with_timeout(self.config.query_timeout, &sql, async move {
+    async fn fetch_optional(&self, query: &str, database: Option<&str>) -> Result<Option<Value>, AppError> {
+        let pool = self.pool(database).await?;
+        let sql = query.to_owned();
+        execute_with_timeout(self.config.query_timeout, query, async move {
             let mut conn = pool.acquire().await?;
-            query.run_fetch_optional(&mut conn).await
+            let row = (&mut *conn).fetch_optional(sql.as_str()).await?;
+            Ok::<_, sqlx::Error>(row.as_ref().map(RowExt::to_json))
         })
         .await
     }

--- a/crates/sqlite/src/connection.rs
+++ b/crates/sqlite/src/connection.rs
@@ -1,4 +1,4 @@
-//! `SQLite` connection: pool ownership, initialization, and [`PoolProvider`] impl.
+//! `SQLite` connection: pool ownership, initialization, and [`Connection`] impl.
 //!
 //! Owns the single lazy [`SqlitePool`] used by [`SqliteHandler`](crate::SqliteHandler).
 //! `SQLite` is a single-file, single-writer backend; the pool is fixed
@@ -8,7 +8,7 @@ use std::time::Duration;
 
 use database_mcp_config::DatabaseConfig;
 use database_mcp_server::AppError;
-use database_mcp_sql::PoolProvider;
+use database_mcp_sql::Connection;
 use sqlx::sqlite::{SqliteConnectOptions, SqlitePool, SqlitePoolOptions};
 
 /// Owns the lazy `SQLite` pool and the logic that builds it.
@@ -33,12 +33,6 @@ impl SqliteConnection {
         }
     }
 
-    /// Wraps `name` in double quotes for safe use in `SQLite` SQL statements.
-    #[allow(clippy::unused_self)]
-    pub(crate) fn quote_identifier(&self, name: &str) -> String {
-        database_mcp_sql::identifier::quote_identifier(name, '"')
-    }
-
     /// Returns the single pool. Target is ignored (`SQLite` is single-file).
     ///
     /// Crate-private so every tool path goes through the unified
@@ -49,8 +43,9 @@ impl SqliteConnection {
     }
 }
 
-impl PoolProvider for SqliteConnection {
+impl Connection for SqliteConnection {
     type DB = sqlx::Sqlite;
+    const IDENTIFIER_QUOTE: char = '"';
 
     async fn pool(&self, target: Option<&str>) -> Result<sqlx::Pool<Self::DB>, AppError> {
         self.pool(target).await

--- a/crates/sqlite/src/connection.rs
+++ b/crates/sqlite/src/connection.rs
@@ -1,0 +1,208 @@
+//! `SQLite` connection: pool ownership + initialization.
+//!
+//! Owns the single lazy [`SqlitePool`] used by [`SqliteHandler`](crate::SqliteHandler).
+//! `SQLite` is a single-file, single-writer backend; the pool is fixed
+//! at one connection.
+
+use std::time::Duration;
+
+use database_mcp_config::DatabaseConfig;
+use database_mcp_server::AppError;
+use database_mcp_sql::connection::{Connection, Executable, Query};
+use database_mcp_sql::timeout::execute_with_timeout;
+use sqlx::Sqlite;
+use sqlx::sqlite::{SqliteConnectOptions, SqlitePool, SqlitePoolOptions, SqliteQueryResult};
+
+/// Owns the lazy `SQLite` pool and the logic that builds it.
+#[derive(Clone)]
+pub(crate) struct SqliteConnection {
+    config: DatabaseConfig,
+    pool: SqlitePool,
+}
+
+impl std::fmt::Debug for SqliteConnection {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("SqliteConnection").finish_non_exhaustive()
+    }
+}
+
+impl SqliteConnection {
+    /// Builds the connection and its lazy pool.
+    pub(crate) fn new(config: &DatabaseConfig) -> Self {
+        Self {
+            config: config.clone(),
+            pool: pool_options(config).connect_lazy_with(connect_options(config)),
+        }
+    }
+
+    /// Wraps `name` in double quotes for safe use in `SQLite` SQL statements.
+    #[allow(clippy::unused_self)]
+    pub(crate) fn quote_identifier(&self, name: &str) -> String {
+        database_mcp_sql::identifier::quote_identifier(name, '"')
+    }
+
+    /// Returns the single pool. Target is ignored (`SQLite` is single-file).
+    ///
+    /// Crate-private so every tool path goes through the unified
+    /// [`Connection`] methods and cannot bypass timeout / error capture.
+    #[allow(clippy::unused_async)]
+    pub(crate) async fn pool(&self, _target: Option<&str>) -> Result<SqlitePool, AppError> {
+        Ok(self.pool.clone())
+    }
+}
+
+impl Connection for SqliteConnection {
+    type Database = Sqlite;
+
+    async fn execute<Q>(&self, query: Q, target: Option<&str>) -> Result<SqliteQueryResult, AppError>
+    where
+        Q: Executable<Sqlite>,
+    {
+        let pool = self.pool(target).await?;
+        let sql = query.sql().to_owned();
+        execute_with_timeout(self.config.query_timeout, &sql, async move {
+            let mut conn = pool.acquire().await?;
+            query.run_execute(&mut conn).await
+        })
+        .await
+    }
+
+    async fn fetch<Q>(&self, query: Q, target: Option<&str>) -> Result<Vec<Q::Output>, AppError>
+    where
+        Q: Query<Sqlite>,
+    {
+        let pool = self.pool(target).await?;
+        let sql = query.sql().to_owned();
+        execute_with_timeout(self.config.query_timeout, &sql, async move {
+            let mut conn = pool.acquire().await?;
+            query.run_fetch_all(&mut conn).await
+        })
+        .await
+    }
+
+    async fn fetch_optional<Q>(&self, query: Q, target: Option<&str>) -> Result<Option<Q::Output>, AppError>
+    where
+        Q: Query<Sqlite>,
+    {
+        let pool = self.pool(target).await?;
+        let sql = query.sql().to_owned();
+        execute_with_timeout(self.config.query_timeout, &sql, async move {
+            let mut conn = pool.acquire().await?;
+            query.run_fetch_optional(&mut conn).await
+        })
+        .await
+    }
+}
+
+/// Builds [`SqlitePoolOptions`] with lifecycle defaults from a [`DatabaseConfig`].
+fn pool_options(config: &DatabaseConfig) -> SqlitePoolOptions {
+    let mut opts = SqlitePoolOptions::new()
+        .max_connections(1) // SQLite is a single-writer
+        .min_connections(DatabaseConfig::DEFAULT_MIN_CONNECTIONS)
+        .idle_timeout(Duration::from_secs(DatabaseConfig::DEFAULT_IDLE_TIMEOUT_SECS))
+        .max_lifetime(Duration::from_secs(DatabaseConfig::DEFAULT_MAX_LIFETIME_SECS));
+
+    if let Some(timeout) = config.connection_timeout {
+        opts = opts.acquire_timeout(Duration::from_secs(timeout));
+    }
+
+    opts
+}
+
+/// Builds [`SqliteConnectOptions`] from a [`DatabaseConfig`].
+fn connect_options(config: &DatabaseConfig) -> SqliteConnectOptions {
+    SqliteConnectOptions::new().filename(config.name.as_deref().unwrap_or_default())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use database_mcp_config::DatabaseBackend;
+
+    fn base_config() -> DatabaseConfig {
+        DatabaseConfig {
+            backend: DatabaseBackend::Sqlite,
+            name: Some("test.db".into()),
+            ..DatabaseConfig::default()
+        }
+    }
+
+    #[test]
+    fn pool_options_applies_defaults() {
+        let config = base_config();
+        let opts = pool_options(&config);
+
+        assert_eq!(opts.get_max_connections(), 1, "SQLite must be single-writer");
+        assert_eq!(opts.get_min_connections(), DatabaseConfig::DEFAULT_MIN_CONNECTIONS);
+        assert_eq!(
+            opts.get_idle_timeout(),
+            Some(Duration::from_secs(DatabaseConfig::DEFAULT_IDLE_TIMEOUT_SECS))
+        );
+        assert_eq!(
+            opts.get_max_lifetime(),
+            Some(Duration::from_secs(DatabaseConfig::DEFAULT_MAX_LIFETIME_SECS))
+        );
+    }
+
+    #[test]
+    fn pool_options_applies_connection_timeout() {
+        let config = DatabaseConfig {
+            connection_timeout: Some(7),
+            ..base_config()
+        };
+        let opts = pool_options(&config);
+
+        assert_eq!(opts.get_acquire_timeout(), Duration::from_secs(7));
+    }
+
+    #[test]
+    fn pool_options_without_connection_timeout_uses_sqlx_default() {
+        let config = base_config();
+        let opts = pool_options(&config);
+
+        assert_eq!(opts.get_acquire_timeout(), Duration::from_secs(30));
+    }
+
+    #[test]
+    fn pool_options_ignores_max_pool_size() {
+        let config = DatabaseConfig {
+            max_pool_size: 20,
+            ..base_config()
+        };
+        let opts = pool_options(&config);
+
+        assert_eq!(opts.get_max_connections(), 1, "SQLite must always be single-writer");
+    }
+
+    #[test]
+    fn try_from_sets_filename() {
+        let opts = connect_options(&base_config());
+        assert_eq!(opts.get_filename().to_str().expect("valid path"), "test.db");
+    }
+
+    #[test]
+    fn try_from_empty_name_defaults() {
+        let config = DatabaseConfig {
+            name: None,
+            ..base_config()
+        };
+        let opts = connect_options(&config);
+        assert_eq!(opts.get_filename().to_str().expect("valid path"), "");
+    }
+
+    #[tokio::test]
+    async fn new_creates_lazy_pool() {
+        let connection = SqliteConnection::new(&base_config());
+        assert_eq!(connection.pool.size(), 0, "pool should be lazy");
+    }
+
+    #[tokio::test]
+    async fn pool_returns_single_pool() {
+        let connection = SqliteConnection::new(&base_config());
+        connection.pool(None).await.expect("None target should succeed");
+        connection
+            .pool(Some("anything"))
+            .await
+            .expect("any target should return the same single pool");
+    }
+}

--- a/crates/sqlite/src/handler.rs
+++ b/crates/sqlite/src/handler.rs
@@ -1,9 +1,9 @@
-//! `SQLite` handler: connection pool, MCP tool router, and `ServerHandler` impl.
+//! `SQLite` handler: composes a [`SqliteConnection`] with the MCP tool router.
 //!
-//! Uses [`SqlitePoolOptions::connect_lazy_with`] so no file I/O happens
-//! until the first tool invocation.
-
-use std::time::Duration;
+//! All pool ownership and pool initialization logic lives in the
+//! [`SqliteConnection`]. This module exposes the MCP
+//! `ServerHandler` surface and one thin delegator method that the
+//! per-tool implementations call.
 
 use database_mcp_config::DatabaseConfig;
 use database_mcp_server::{Server, server_info};
@@ -13,9 +13,8 @@ use rmcp::handler::server::tool::ToolCallContext;
 use rmcp::model::{CallToolRequestParams, CallToolResult, ListToolsResult, PaginatedRequestParams, ServerInfo, Tool};
 use rmcp::service::RequestContext;
 use rmcp::{ErrorData, ServerHandler};
-use sqlx::SqlitePool;
-use sqlx::sqlite::{SqliteConnectOptions, SqlitePoolOptions};
 
+use crate::connection::SqliteConnection;
 use crate::tools::{
     DropTableTool, ExplainQueryTool, GetTableSchemaTool, ListTablesTool, ReadQueryTool, WriteQueryTool,
 };
@@ -38,13 +37,12 @@ const INSTRUCTIONS: &str = r"## Workflow
 
 /// `SQLite` file-based database handler.
 ///
-/// The connection pool is created with [`SqlitePoolOptions::connect_lazy_with`],
-/// which defers all file I/O until the first query. Connection errors
-/// surface as tool-level errors returned to the MCP client.
+/// Composes one [`SqliteConnection`] (which owns the pool and
+/// the pool initialization logic) with the per-backend MCP tool router.
 #[derive(Clone)]
 pub struct SqliteHandler {
     pub(crate) config: DatabaseConfig,
-    pub(crate) pool: SqlitePool,
+    pub(crate) connection: SqliteConnection,
     tool_router: ToolRouter<Self>,
 }
 
@@ -52,28 +50,23 @@ impl std::fmt::Debug for SqliteHandler {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.debug_struct("SqliteHandler")
             .field("read_only", &self.config.read_only)
+            .field("connection", &self.connection)
             .finish_non_exhaustive()
     }
 }
 
 impl SqliteHandler {
-    /// Creates a new `SQLite` handler with a lazy connection pool.
+    /// Creates a new `SQLite` handler.
     ///
-    /// Does **not** open the database file. The pool connects on-demand
-    /// when the first query is executed. The MCP tool router is built once
-    /// here and reused for every request.
+    /// Constructs the [`SqliteConnection`] (which builds the
+    /// lazy pool) and the MCP tool router. No file I/O happens here.
     #[must_use]
     pub fn new(config: &DatabaseConfig) -> Self {
         Self {
             config: config.clone(),
-            pool: pool_options(config).connect_lazy_with(connect_options(config)),
+            connection: SqliteConnection::new(config),
             tool_router: build_tool_router(config.read_only),
         }
-    }
-
-    /// Wraps `name` in double quotes for safe use in `SQLite` SQL statements.
-    pub(crate) fn quote_identifier(name: &str) -> String {
-        database_mcp_sql::identifier::quote_identifier(name, '"')
     }
 }
 
@@ -82,26 +75,6 @@ impl From<SqliteHandler> for Server {
     fn from(handler: SqliteHandler) -> Self {
         Self::new(handler)
     }
-}
-
-/// Builds [`SqlitePoolOptions`] with lifecycle defaults from a [`DatabaseConfig`].
-fn pool_options(config: &DatabaseConfig) -> SqlitePoolOptions {
-    let mut opts = SqlitePoolOptions::new()
-        .max_connections(1) // SQLite is a single-writer
-        .min_connections(DatabaseConfig::DEFAULT_MIN_CONNECTIONS)
-        .idle_timeout(Duration::from_secs(DatabaseConfig::DEFAULT_IDLE_TIMEOUT_SECS))
-        .max_lifetime(Duration::from_secs(DatabaseConfig::DEFAULT_MAX_LIFETIME_SECS));
-
-    if let Some(timeout) = config.connection_timeout {
-        opts = opts.acquire_timeout(Duration::from_secs(timeout));
-    }
-
-    opts
-}
-
-/// Builds [`SqliteConnectOptions`] from a [`DatabaseConfig`].
-fn connect_options(config: &DatabaseConfig) -> SqliteConnectOptions {
-    SqliteConnectOptions::new().filename(config.name.as_deref().unwrap_or_default())
 }
 
 /// Builds the tool router, including write tools only when not in read-only mode.
@@ -159,14 +132,6 @@ mod tests {
     use super::*;
     use database_mcp_config::DatabaseBackend;
 
-    fn base_config() -> DatabaseConfig {
-        DatabaseConfig {
-            backend: DatabaseBackend::Sqlite,
-            name: Some("test.db".into()),
-            ..DatabaseConfig::default()
-        }
-    }
-
     fn handler(read_only: bool) -> SqliteHandler {
         SqliteHandler::new(&DatabaseConfig {
             backend: DatabaseBackend::Sqlite,
@@ -174,80 +139,6 @@ mod tests {
             read_only,
             ..DatabaseConfig::default()
         })
-    }
-
-    #[test]
-    fn pool_options_applies_defaults() {
-        let config = base_config();
-        let opts = pool_options(&config);
-
-        assert_eq!(opts.get_max_connections(), 1, "SQLite must be single-writer");
-        assert_eq!(opts.get_min_connections(), DatabaseConfig::DEFAULT_MIN_CONNECTIONS);
-        assert_eq!(
-            opts.get_idle_timeout(),
-            Some(Duration::from_secs(DatabaseConfig::DEFAULT_IDLE_TIMEOUT_SECS))
-        );
-        assert_eq!(
-            opts.get_max_lifetime(),
-            Some(Duration::from_secs(DatabaseConfig::DEFAULT_MAX_LIFETIME_SECS))
-        );
-    }
-
-    #[test]
-    fn pool_options_applies_connection_timeout() {
-        let config = DatabaseConfig {
-            connection_timeout: Some(7),
-            ..base_config()
-        };
-        let opts = pool_options(&config);
-
-        assert_eq!(opts.get_acquire_timeout(), Duration::from_secs(7));
-    }
-
-    #[test]
-    fn pool_options_without_connection_timeout_uses_sqlx_default() {
-        let config = base_config();
-        let opts = pool_options(&config);
-
-        assert_eq!(opts.get_acquire_timeout(), Duration::from_secs(30));
-    }
-
-    #[test]
-    fn pool_options_ignores_max_pool_size() {
-        let config = DatabaseConfig {
-            max_pool_size: 20,
-            ..base_config()
-        };
-        let opts = pool_options(&config);
-
-        assert_eq!(opts.get_max_connections(), 1, "SQLite must always be single-writer");
-    }
-
-    #[test]
-    fn try_from_sets_filename() {
-        let opts = connect_options(&base_config());
-
-        assert_eq!(opts.get_filename().to_str().expect("valid path"), "test.db");
-    }
-
-    #[test]
-    fn try_from_empty_name_defaults() {
-        let config = DatabaseConfig {
-            name: None,
-            ..base_config()
-        };
-        let opts = connect_options(&config);
-
-        // Empty string filename — validated elsewhere by Config::validate()
-        assert_eq!(opts.get_filename().to_str().expect("valid path"), "");
-    }
-
-    #[tokio::test]
-    async fn new_creates_lazy_pool() {
-        let config = base_config();
-        let handler = SqliteHandler::new(&config);
-        // Pool exists but has no active connections (lazy).
-        assert_eq!(handler.pool.size(), 0);
     }
 
     #[tokio::test]

--- a/crates/sqlite/src/lib.rs
+++ b/crates/sqlite/src/lib.rs
@@ -3,6 +3,7 @@
 //! Provides [`SqliteHandler`] for database operations with MCP
 //! tool registration via [`ServerHandler`](rmcp::ServerHandler).
 
+mod connection;
 mod handler;
 mod tools;
 pub mod types;

--- a/crates/sqlite/src/tools/drop_table.rs
+++ b/crates/sqlite/src/tools/drop_table.rs
@@ -4,8 +4,8 @@ use std::borrow::Cow;
 
 use database_mcp_server::AppError;
 use database_mcp_server::types::MessageResponse;
+use database_mcp_sql::connection::Connection as _;
 use database_mcp_sql::identifier::validate_identifier;
-use database_mcp_sql::timeout::execute_with_timeout;
 use rmcp::handler::server::router::tool::{AsyncTool, ToolBase};
 use rmcp::model::{ErrorData, ToolAnnotations};
 
@@ -66,14 +66,8 @@ impl SqliteHandler {
         let table = &request.table_name;
         validate_identifier(table)?;
 
-        let pool = self.pool.clone();
-        let drop_sql = format!("DROP TABLE {}", Self::quote_identifier(table));
-        execute_with_timeout(
-            self.config.query_timeout,
-            &drop_sql,
-            sqlx::query(&drop_sql).execute(&pool),
-        )
-        .await?;
+        let drop_sql = format!("DROP TABLE {}", self.connection.quote_identifier(table));
+        self.connection.execute(drop_sql.as_str(), None).await?;
 
         Ok(MessageResponse {
             message: format!("Table '{table}' dropped successfully."),

--- a/crates/sqlite/src/tools/drop_table.rs
+++ b/crates/sqlite/src/tools/drop_table.rs
@@ -4,7 +4,7 @@ use std::borrow::Cow;
 
 use database_mcp_server::AppError;
 use database_mcp_server::types::MessageResponse;
-use database_mcp_sql::connection::Connection as _;
+use database_mcp_sql::Connection as _;
 use database_mcp_sql::identifier::validate_identifier;
 use rmcp::handler::server::router::tool::{AsyncTool, ToolBase};
 use rmcp::model::{ErrorData, ToolAnnotations};

--- a/crates/sqlite/src/tools/explain_query.rs
+++ b/crates/sqlite/src/tools/explain_query.rs
@@ -4,11 +4,10 @@ use std::borrow::Cow;
 
 use database_mcp_server::AppError;
 use database_mcp_server::types::QueryResponse;
-use database_mcp_sql::connection::Connection as _;
+use database_mcp_sql::Connection as _;
 use rmcp::handler::server::router::tool::{AsyncTool, ToolBase};
 use rmcp::model::{ErrorData, ToolAnnotations};
 use serde_json::Value;
-use sqlx_to_json::RowExt;
 
 use crate::SqliteHandler;
 use crate::types::ExplainQueryRequest;
@@ -64,7 +63,7 @@ impl SqliteHandler {
         let explain_sql = format!("EXPLAIN QUERY PLAN {}", request.query);
         let rows = self.connection.fetch(explain_sql.as_str(), None).await?;
         Ok(QueryResponse {
-            rows: Value::Array(rows.iter().map(RowExt::to_json).collect()),
+            rows: Value::Array(rows),
         })
     }
 }

--- a/crates/sqlite/src/tools/explain_query.rs
+++ b/crates/sqlite/src/tools/explain_query.rs
@@ -4,11 +4,10 @@ use std::borrow::Cow;
 
 use database_mcp_server::AppError;
 use database_mcp_server::types::QueryResponse;
-use database_mcp_sql::timeout::execute_with_timeout;
+use database_mcp_sql::connection::Connection as _;
 use rmcp::handler::server::router::tool::{AsyncTool, ToolBase};
 use rmcp::model::{ErrorData, ToolAnnotations};
 use serde_json::Value;
-use sqlx::sqlite::SqliteRow;
 use sqlx_to_json::RowExt;
 
 use crate::SqliteHandler;
@@ -62,14 +61,8 @@ impl SqliteHandler {
     ///
     /// Returns [`AppError::Query`] if the backend reports an error.
     pub async fn explain_query(&self, request: &ExplainQueryRequest) -> Result<QueryResponse, AppError> {
-        let pool = self.pool.clone();
         let explain_sql = format!("EXPLAIN QUERY PLAN {}", request.query);
-        let rows: Vec<SqliteRow> = execute_with_timeout(
-            self.config.query_timeout,
-            &explain_sql,
-            sqlx::query(&explain_sql).fetch_all(&pool),
-        )
-        .await?;
+        let rows = self.connection.fetch(explain_sql.as_str(), None).await?;
         Ok(QueryResponse {
             rows: Value::Array(rows.iter().map(RowExt::to_json).collect()),
         })

--- a/crates/sqlite/src/tools/get_table_schema.rs
+++ b/crates/sqlite/src/tools/get_table_schema.rs
@@ -5,13 +5,12 @@ use std::collections::HashMap;
 
 use database_mcp_server::AppError;
 use database_mcp_server::types::TableSchemaResponse;
+use database_mcp_sql::connection::Connection as _;
 use database_mcp_sql::identifier::validate_identifier;
-use database_mcp_sql::timeout::execute_with_timeout;
 use rmcp::handler::server::router::tool::{AsyncTool, ToolBase};
 use rmcp::model::{ErrorData, ToolAnnotations};
 use serde_json::{Value, json};
 use sqlx::Row;
-use sqlx::sqlite::SqliteRow;
 
 use crate::SqliteHandler;
 use crate::types::GetTableSchemaRequest;
@@ -66,13 +65,8 @@ impl SqliteHandler {
         validate_identifier(table)?;
 
         // 1. Get basic schema
-        let pragma_sql = format!("PRAGMA table_info({})", Self::quote_identifier(table));
-        let rows: Vec<SqliteRow> = execute_with_timeout(
-            self.config.query_timeout,
-            &pragma_sql,
-            sqlx::query(&pragma_sql).fetch_all(&self.pool),
-        )
-        .await?;
+        let pragma_sql = format!("PRAGMA table_info({})", self.connection.quote_identifier(table));
+        let rows = self.connection.fetch(pragma_sql.as_str(), None).await?;
 
         if rows.is_empty() {
             return Err(AppError::TableNotFound(table.clone()));
@@ -99,13 +93,8 @@ impl SqliteHandler {
         }
 
         // 2. Get FK info via PRAGMA
-        let fk_pragma_sql = format!("PRAGMA foreign_key_list({})", Self::quote_identifier(table));
-        let fk_rows: Vec<SqliteRow> = execute_with_timeout(
-            self.config.query_timeout,
-            &fk_pragma_sql,
-            sqlx::query(&fk_pragma_sql).fetch_all(&self.pool),
-        )
-        .await?;
+        let fk_pragma_sql = format!("PRAGMA foreign_key_list({})", self.connection.quote_identifier(table));
+        let fk_rows = self.connection.fetch(fk_pragma_sql.as_str(), None).await?;
 
         for fk_row in &fk_rows {
             let from_col: String = fk_row.try_get("from").unwrap_or_default();

--- a/crates/sqlite/src/tools/get_table_schema.rs
+++ b/crates/sqlite/src/tools/get_table_schema.rs
@@ -5,12 +5,11 @@ use std::collections::HashMap;
 
 use database_mcp_server::AppError;
 use database_mcp_server::types::TableSchemaResponse;
-use database_mcp_sql::connection::Connection as _;
+use database_mcp_sql::Connection as _;
 use database_mcp_sql::identifier::validate_identifier;
 use rmcp::handler::server::router::tool::{AsyncTool, ToolBase};
 use rmcp::model::{ErrorData, ToolAnnotations};
 use serde_json::{Value, json};
-use sqlx::Row;
 
 use crate::SqliteHandler;
 use crate::types::GetTableSchemaRequest;
@@ -74,11 +73,11 @@ impl SqliteHandler {
 
         let mut columns: HashMap<String, Value> = HashMap::new();
         for row in &rows {
-            let col_name: String = row.try_get("name").unwrap_or_default();
-            let col_type: String = row.try_get("type").unwrap_or_default();
-            let notnull: i32 = row.try_get("notnull").unwrap_or(0);
-            let default: Option<String> = row.try_get("dflt_value").ok();
-            let pk: i32 = row.try_get("pk").unwrap_or(0);
+            let col_name = row.get("name").and_then(Value::as_str).unwrap_or_default().to_owned();
+            let col_type = row.get("type").and_then(Value::as_str).unwrap_or_default().to_owned();
+            let notnull = row.get("notnull").and_then(Value::as_i64).unwrap_or(0);
+            let default = row.get("dflt_value").and_then(Value::as_str).map(str::to_owned);
+            let pk = row.get("pk").and_then(Value::as_i64).unwrap_or(0);
             columns.insert(
                 col_name,
                 json!({
@@ -97,14 +96,30 @@ impl SqliteHandler {
         let fk_rows = self.connection.fetch(fk_pragma_sql.as_str(), None).await?;
 
         for fk_row in &fk_rows {
-            let from_col: String = fk_row.try_get("from").unwrap_or_default();
+            let from_col = fk_row
+                .get("from")
+                .and_then(Value::as_str)
+                .unwrap_or_default()
+                .to_owned();
             if let Some(col_info) = columns.get_mut(&from_col)
                 && let Some(obj) = col_info.as_object_mut()
             {
-                let ref_table: String = fk_row.try_get("table").unwrap_or_default();
-                let ref_col: String = fk_row.try_get("to").unwrap_or_default();
-                let on_update: String = fk_row.try_get("on_update").unwrap_or_default();
-                let on_delete: String = fk_row.try_get("on_delete").unwrap_or_default();
+                let ref_table = fk_row
+                    .get("table")
+                    .and_then(Value::as_str)
+                    .unwrap_or_default()
+                    .to_owned();
+                let ref_col = fk_row.get("to").and_then(Value::as_str).unwrap_or_default().to_owned();
+                let on_update = fk_row
+                    .get("on_update")
+                    .and_then(Value::as_str)
+                    .unwrap_or_default()
+                    .to_owned();
+                let on_delete = fk_row
+                    .get("on_delete")
+                    .and_then(Value::as_str)
+                    .unwrap_or_default()
+                    .to_owned();
                 obj.insert(
                     "foreign_key".to_string(),
                     json!({

--- a/crates/sqlite/src/tools/list_tables.rs
+++ b/crates/sqlite/src/tools/list_tables.rs
@@ -5,10 +5,11 @@ use std::sync::Arc;
 
 use database_mcp_server::AppError;
 use database_mcp_server::types::ListTablesResponse;
-use database_mcp_sql::timeout::execute_with_timeout;
+use database_mcp_sql::connection::Connection as _;
 use rmcp::handler::server::common::schema_for_empty_input;
 use rmcp::handler::server::router::tool::{AsyncTool, ToolBase};
 use rmcp::model::{ErrorData, JsonObject, ToolAnnotations};
+use sqlx::Row;
 
 use crate::SqliteHandler;
 
@@ -61,12 +62,13 @@ impl SqliteHandler {
     ///
     /// Returns [`AppError`] if the query fails.
     pub async fn list_tables(&self) -> Result<ListTablesResponse, AppError> {
-        let pool = self.pool.clone();
         let sql = "SELECT name FROM sqlite_master WHERE type='table' AND name NOT LIKE 'sqlite_%' ORDER BY name";
-        let rows: Vec<(String,)> =
-            execute_with_timeout(self.config.query_timeout, sql, sqlx::query_as(sql).fetch_all(&pool)).await?;
-        Ok(ListTablesResponse {
-            tables: rows.into_iter().map(|r| r.0).collect(),
-        })
+        let rows = self.connection.fetch(sql, None).await?;
+        let tables = rows
+            .iter()
+            .map(|row| row.try_get::<String, _>(0))
+            .collect::<Result<Vec<_>, _>>()
+            .map_err(|e| AppError::Query(format!("failed to decode table name: {e}")))?;
+        Ok(ListTablesResponse { tables })
     }
 }

--- a/crates/sqlite/src/tools/list_tables.rs
+++ b/crates/sqlite/src/tools/list_tables.rs
@@ -5,11 +5,11 @@ use std::sync::Arc;
 
 use database_mcp_server::AppError;
 use database_mcp_server::types::ListTablesResponse;
-use database_mcp_sql::connection::Connection as _;
+use database_mcp_sql::Connection as _;
 use rmcp::handler::server::common::schema_for_empty_input;
 use rmcp::handler::server::router::tool::{AsyncTool, ToolBase};
 use rmcp::model::{ErrorData, JsonObject, ToolAnnotations};
-use sqlx::Row;
+use serde_json::Value;
 
 use crate::SqliteHandler;
 
@@ -66,9 +66,8 @@ impl SqliteHandler {
         let rows = self.connection.fetch(sql, None).await?;
         let tables = rows
             .iter()
-            .map(|row| row.try_get::<String, _>(0))
-            .collect::<Result<Vec<_>, _>>()
-            .map_err(|e| AppError::Query(format!("failed to decode table name: {e}")))?;
+            .filter_map(|row| row.get("name").and_then(Value::as_str).map(str::to_owned))
+            .collect::<Vec<_>>();
         Ok(ListTablesResponse { tables })
     }
 }

--- a/crates/sqlite/src/tools/read_query.rs
+++ b/crates/sqlite/src/tools/read_query.rs
@@ -4,12 +4,11 @@ use std::borrow::Cow;
 
 use database_mcp_server::AppError;
 use database_mcp_server::types::QueryResponse;
-use database_mcp_sql::timeout::execute_with_timeout;
+use database_mcp_sql::connection::Connection as _;
 use database_mcp_sql::validation::validate_read_only_with_dialect;
 use rmcp::handler::server::router::tool::{AsyncTool, ToolBase};
 use rmcp::model::{ErrorData, ToolAnnotations};
 use serde_json::Value;
-use sqlx::sqlite::SqliteRow;
 use sqlx_to_json::RowExt;
 
 use crate::SqliteHandler;
@@ -64,13 +63,7 @@ impl SqliteHandler {
     /// read-only, or [`AppError::Query`] if the backend reports an error.
     pub async fn read_query(&self, request: &QueryRequest) -> Result<QueryResponse, AppError> {
         validate_read_only_with_dialect(&request.query, &sqlparser::dialect::SQLiteDialect {})?;
-        let pool = self.pool.clone();
-        let rows: Vec<SqliteRow> = execute_with_timeout(
-            self.config.query_timeout,
-            &request.query,
-            sqlx::query(&request.query).fetch_all(&pool),
-        )
-        .await?;
+        let rows = self.connection.fetch(request.query.as_str(), None).await?;
         Ok(QueryResponse {
             rows: Value::Array(rows.iter().map(RowExt::to_json).collect()),
         })

--- a/crates/sqlite/src/tools/read_query.rs
+++ b/crates/sqlite/src/tools/read_query.rs
@@ -4,12 +4,11 @@ use std::borrow::Cow;
 
 use database_mcp_server::AppError;
 use database_mcp_server::types::QueryResponse;
-use database_mcp_sql::connection::Connection as _;
+use database_mcp_sql::Connection as _;
 use database_mcp_sql::validation::validate_read_only_with_dialect;
 use rmcp::handler::server::router::tool::{AsyncTool, ToolBase};
 use rmcp::model::{ErrorData, ToolAnnotations};
 use serde_json::Value;
-use sqlx_to_json::RowExt;
 
 use crate::SqliteHandler;
 use crate::types::QueryRequest;
@@ -65,7 +64,7 @@ impl SqliteHandler {
         validate_read_only_with_dialect(&request.query, &sqlparser::dialect::SQLiteDialect {})?;
         let rows = self.connection.fetch(request.query.as_str(), None).await?;
         Ok(QueryResponse {
-            rows: Value::Array(rows.iter().map(RowExt::to_json).collect()),
+            rows: Value::Array(rows),
         })
     }
 }

--- a/crates/sqlite/src/tools/write_query.rs
+++ b/crates/sqlite/src/tools/write_query.rs
@@ -4,11 +4,10 @@ use std::borrow::Cow;
 
 use database_mcp_server::AppError;
 use database_mcp_server::types::QueryResponse;
-use database_mcp_sql::connection::Connection as _;
+use database_mcp_sql::Connection as _;
 use rmcp::handler::server::router::tool::{AsyncTool, ToolBase};
 use rmcp::model::{ErrorData, ToolAnnotations};
 use serde_json::Value;
-use sqlx_to_json::RowExt;
 
 use crate::SqliteHandler;
 use crate::types::QueryRequest;
@@ -60,7 +59,7 @@ impl SqliteHandler {
     pub async fn write_query(&self, request: &QueryRequest) -> Result<QueryResponse, AppError> {
         let rows = self.connection.fetch(request.query.as_str(), None).await?;
         Ok(QueryResponse {
-            rows: Value::Array(rows.iter().map(RowExt::to_json).collect()),
+            rows: Value::Array(rows),
         })
     }
 }

--- a/crates/sqlite/src/tools/write_query.rs
+++ b/crates/sqlite/src/tools/write_query.rs
@@ -4,11 +4,10 @@ use std::borrow::Cow;
 
 use database_mcp_server::AppError;
 use database_mcp_server::types::QueryResponse;
-use database_mcp_sql::timeout::execute_with_timeout;
+use database_mcp_sql::connection::Connection as _;
 use rmcp::handler::server::router::tool::{AsyncTool, ToolBase};
 use rmcp::model::{ErrorData, ToolAnnotations};
 use serde_json::Value;
-use sqlx::sqlite::SqliteRow;
 use sqlx_to_json::RowExt;
 
 use crate::SqliteHandler;
@@ -59,13 +58,7 @@ impl SqliteHandler {
     ///
     /// Returns [`AppError`] if the query fails.
     pub async fn write_query(&self, request: &QueryRequest) -> Result<QueryResponse, AppError> {
-        let pool = self.pool.clone();
-        let rows: Vec<SqliteRow> = execute_with_timeout(
-            self.config.query_timeout,
-            &request.query,
-            sqlx::query(&request.query).fetch_all(&pool),
-        )
-        .await?;
+        let rows = self.connection.fetch(request.query.as_str(), None).await?;
         Ok(QueryResponse {
             rows: Value::Array(rows.iter().map(RowExt::to_json).collect()),
         })

--- a/crates/sqlx-to-json/src/lib.rs
+++ b/crates/sqlx-to-json/src/lib.rs
@@ -1,7 +1,8 @@
-//! Database-agnostic row-to-JSON conversion for sqlx.
+//! Database-agnostic row-to-JSON conversion and query result traits for sqlx.
 //!
-//! Provides the [`RowExt`] trait for converting a single database row
-//! into a [`Value::Object`]. Implementations are provided for
+//! Provides [`RowExt`] for converting a single database row into a
+//! [`Value::Object`] and [`QueryResult`] for extracting affected row
+//! counts.  Implementations are provided for
 //! [`SqliteRow`](sqlx::sqlite::SqliteRow),
 //! [`PgRow`](sqlx::postgres::PgRow), and
 //! [`MySqlRow`](sqlx::mysql::MySqlRow).
@@ -11,4 +12,4 @@ mod postgres;
 mod sqlite;
 mod traits;
 
-pub use traits::RowExt;
+pub use traits::{QueryResult, RowExt};

--- a/crates/sqlx-to-json/src/traits.rs
+++ b/crates/sqlx-to-json/src/traits.rs
@@ -1,4 +1,4 @@
-//! Row-to-JSON conversion trait.
+//! Row-to-JSON conversion and query-result traits.
 
 use serde_json::Value;
 
@@ -15,4 +15,33 @@ pub trait RowExt {
     /// A [`Value::Object`] where keys are column names and values are
     /// type-appropriate JSON values.
     fn to_json(&self) -> Value;
+}
+
+/// Extracts the affected row count from a backend query result.
+///
+/// sqlx's `Database::QueryResult` associated type exposes
+/// `rows_affected()` as an inherent method on each concrete backend
+/// type.  This trait provides a single generic bound so the blanket
+/// `Connection` impl can call it without knowing the concrete type.
+pub trait QueryResult {
+    /// Returns the number of rows affected by the executed statement.
+    fn rows_affected(&self) -> u64;
+}
+
+impl QueryResult for sqlx::mysql::MySqlQueryResult {
+    fn rows_affected(&self) -> u64 {
+        self.rows_affected()
+    }
+}
+
+impl QueryResult for sqlx::postgres::PgQueryResult {
+    fn rows_affected(&self) -> u64 {
+        self.rows_affected()
+    }
+}
+
+impl QueryResult for sqlx::sqlite::SqliteQueryResult {
+    fn rows_affected(&self) -> u64 {
+        self.rows_affected()
+    }
 }

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -400,6 +400,23 @@ mod tests {
     }
 
     #[test]
+    fn db_query_timeout_zero_disables() {
+        let args = parse(&[BIN, "--db-query-timeout", "0"]);
+        let config = Config::from(&args);
+        assert_eq!(config.database.query_timeout, None);
+    }
+
+    #[test]
+    fn db_query_timeout_default_applied() {
+        let args = parse(&[BIN]);
+        let config = Config::from(&args);
+        assert_eq!(
+            config.database.query_timeout,
+            Some(DatabaseConfig::DEFAULT_QUERY_TIMEOUT_SECS)
+        );
+    }
+
+    #[test]
     fn db_connection_timeout_wired_to_config() {
         let args = parse(&[BIN, "--db-connection-timeout", "10"]);
         let config = Config::from(&args);

--- a/tests/functional/mysql.rs
+++ b/tests/functional/mysql.rs
@@ -39,6 +39,95 @@ fn handler(read_only: bool) -> MysqlHandler {
 }
 
 #[tokio::test]
+async fn test_write_query_insert_and_verify() {
+    let handler = handler(false);
+
+    let insert = QueryRequest {
+        query: "INSERT INTO users (name, email) VALUES ('WriteTest', 'write@test.com')".into(),
+        database_name: "app".into(),
+    };
+    let response = handler.write_query(&insert).await.unwrap();
+    assert!(response.rows.is_array());
+
+    // Verify the row was inserted
+    let select = QueryRequest {
+        query: "SELECT name FROM users WHERE email = 'write@test.com'".into(),
+        database_name: "app".into(),
+    };
+    let rows = handler.read_query(&select).await.unwrap();
+    let arr = rows.rows.as_array().expect("array");
+    assert_eq!(arr.len(), 1);
+    assert_eq!(arr[0]["name"], "WriteTest");
+
+    // Clean up
+    let delete = QueryRequest {
+        query: "DELETE FROM users WHERE email = 'write@test.com'".into(),
+        database_name: "app".into(),
+    };
+    handler.write_query(&delete).await.unwrap();
+}
+
+#[tokio::test]
+async fn test_write_query_update() {
+    let handler = handler(false);
+
+    // Insert a row
+    let insert = QueryRequest {
+        query: "INSERT INTO users (name, email) VALUES ('Before', 'update@test.com')".into(),
+        database_name: "app".into(),
+    };
+    handler.write_query(&insert).await.unwrap();
+
+    // Update it
+    let update = QueryRequest {
+        query: "UPDATE users SET name = 'After' WHERE email = 'update@test.com'".into(),
+        database_name: "app".into(),
+    };
+    handler.write_query(&update).await.unwrap();
+
+    // Verify
+    let select = QueryRequest {
+        query: "SELECT name FROM users WHERE email = 'update@test.com'".into(),
+        database_name: "app".into(),
+    };
+    let rows = handler.read_query(&select).await.unwrap();
+    let arr = rows.rows.as_array().expect("array");
+    assert_eq!(arr[0]["name"], "After");
+
+    // Clean up
+    let delete = QueryRequest {
+        query: "DELETE FROM users WHERE email = 'update@test.com'".into(),
+        database_name: "app".into(),
+    };
+    handler.write_query(&delete).await.unwrap();
+}
+
+#[tokio::test]
+async fn test_write_query_delete() {
+    let handler = handler(false);
+
+    let insert = QueryRequest {
+        query: "INSERT INTO users (name, email) VALUES ('Deletable', 'delete@test.com')".into(),
+        database_name: "app".into(),
+    };
+    handler.write_query(&insert).await.unwrap();
+
+    let delete = QueryRequest {
+        query: "DELETE FROM users WHERE email = 'delete@test.com'".into(),
+        database_name: "app".into(),
+    };
+    handler.write_query(&delete).await.unwrap();
+
+    let select = QueryRequest {
+        query: "SELECT * FROM users WHERE email = 'delete@test.com'".into(),
+        database_name: "app".into(),
+    };
+    let rows = handler.read_query(&select).await.unwrap();
+    let arr = rows.rows.as_array().expect("array");
+    assert!(arr.is_empty(), "Row should be deleted");
+}
+
+#[tokio::test]
 async fn test_lists_databases() {
     let handler = handler(false);
 
@@ -471,4 +560,626 @@ async fn test_explain_query_analyze_write_blocked_read_only() {
         response.is_err(),
         "Expected error for EXPLAIN ANALYZE on write statement in read-only mode"
     );
+}
+
+#[tokio::test]
+async fn test_get_table_schema_nonexistent_table() {
+    let handler = handler(false);
+    let request = GetTableSchemaRequest {
+        database_name: "app".into(),
+        table_name: "nonexistent_table_xyz".into(),
+    };
+
+    let response = handler.get_table_schema(&request).await;
+    assert!(response.is_err(), "Expected error for nonexistent table");
+}
+
+#[tokio::test]
+async fn test_get_table_schema_invalid_table_name() {
+    let handler = handler(false);
+    let request = GetTableSchemaRequest {
+        database_name: "app".into(),
+        table_name: String::new(),
+    };
+
+    let response = handler.get_table_schema(&request).await;
+    assert!(response.is_err(), "Expected error for empty table name");
+}
+
+#[tokio::test]
+async fn test_get_table_schema_invalid_database_name() {
+    let handler = handler(false);
+    let request = GetTableSchemaRequest {
+        database_name: String::new(),
+        table_name: "users".into(),
+    };
+
+    let response = handler.get_table_schema(&request).await;
+    assert!(response.is_err(), "Expected error for empty database name");
+}
+
+#[tokio::test]
+async fn test_list_tables_nonexistent_database_returns_empty() {
+    let handler = handler(false);
+    let request = ListTablesRequest {
+        database_name: "nonexistent_db_xyz".into(),
+    };
+
+    // MySQL queries information_schema.TABLES — a nonexistent schema returns
+    // zero rows rather than an error.
+    let response = handler.list_tables(&request).await.unwrap();
+    assert!(
+        response.tables.is_empty(),
+        "Nonexistent database should return empty table list, got: {:?}",
+        response.tables
+    );
+}
+
+#[tokio::test]
+async fn test_list_tables_invalid_database_name() {
+    let handler = handler(false);
+    let request = ListTablesRequest {
+        database_name: String::new(),
+    };
+
+    let response = handler.list_tables(&request).await;
+    assert!(response.is_err(), "Expected error for empty database name");
+}
+
+#[tokio::test]
+async fn test_create_database_already_exists() {
+    let handler = handler(false);
+    let request = CreateDatabaseRequest {
+        database_name: "app".into(),
+    };
+
+    let response = handler.create_database(&request).await.unwrap();
+    assert!(
+        response.message.contains("already exists"),
+        "Expected 'already exists' message, got: {}",
+        response.message
+    );
+}
+
+#[tokio::test]
+async fn test_create_database_invalid_identifier() {
+    let handler = handler(false);
+    let request = CreateDatabaseRequest {
+        database_name: String::new(),
+    };
+
+    let response = handler.create_database(&request).await;
+    assert!(response.is_err(), "Expected error for empty database name");
+}
+
+#[tokio::test]
+async fn test_explain_query_analyze() {
+    let handler = handler(false);
+    let request = ExplainQueryRequest {
+        database_name: "app".into(),
+        query: "SELECT * FROM users".into(),
+        analyze: true,
+    };
+
+    // MariaDB does not support EXPLAIN ANALYZE, so this may fail on MariaDB.
+    // We accept either a successful plan or a query error.
+    match handler.explain_query(&request).await {
+        Ok(response) => {
+            let plan = response.rows.as_array().expect("rows should be an array");
+            assert!(!plan.is_empty(), "Expected non-empty execution plan with analyze");
+        }
+        Err(e) => {
+            let err_msg = e.to_string();
+            assert!(
+                err_msg.contains("syntax") || err_msg.contains("ANALYZE"),
+                "Unexpected error (expected MariaDB syntax error): {err_msg}"
+            );
+        }
+    }
+}
+
+#[tokio::test]
+async fn test_explain_query_plain_write_allowed_in_read_only() {
+    let handler = handler(true);
+    let request = ExplainQueryRequest {
+        database_name: "app".into(),
+        query: "INSERT INTO users (name, email) VALUES ('x', 'x@x.com')".into(),
+        analyze: false,
+    };
+
+    let response = handler.explain_query(&request).await.unwrap();
+    let plan = response.rows.as_array().expect("rows should be an array");
+    assert!(
+        !plan.is_empty(),
+        "Plain EXPLAIN should work for write statements even in read-only mode"
+    );
+}
+
+#[tokio::test]
+async fn test_explain_query_invalid_query() {
+    let handler = handler(false);
+    let request = ExplainQueryRequest {
+        database_name: "app".into(),
+        query: "NOT VALID SQL AT ALL".into(),
+        analyze: false,
+    };
+
+    let response = handler.explain_query(&request).await;
+    assert!(response.is_err(), "Expected error for invalid SQL");
+}
+
+#[tokio::test]
+async fn test_read_query_empty_query() {
+    let handler = handler(false);
+    let request = QueryRequest {
+        query: String::new(),
+        database_name: "app".into(),
+    };
+
+    let response = handler.read_query(&request).await;
+    assert!(response.is_err(), "Expected error for empty query");
+}
+
+#[tokio::test]
+async fn test_read_query_whitespace_only_query() {
+    let handler = handler(false);
+    let request = QueryRequest {
+        query: "   \t\n  ".into(),
+        database_name: "app".into(),
+    };
+
+    let response = handler.read_query(&request).await;
+    assert!(response.is_err(), "Expected error for whitespace-only query");
+}
+
+#[tokio::test]
+async fn test_read_query_multi_statement_blocked() {
+    let handler = handler(false);
+    let request = QueryRequest {
+        query: "SELECT 1; DROP TABLE users".into(),
+        database_name: "app".into(),
+    };
+
+    let response = handler.read_query(&request).await;
+    assert!(response.is_err(), "Expected error for multi-statement query");
+}
+
+#[tokio::test]
+async fn test_read_query_load_file_blocked() {
+    let handler = handler(false);
+    let request = QueryRequest {
+        query: "SELECT LOAD_FILE('/etc/passwd')".into(),
+        database_name: "app".into(),
+    };
+
+    let response = handler.read_query(&request).await;
+    assert!(response.is_err(), "Expected error for LOAD_FILE");
+}
+
+#[tokio::test]
+async fn test_read_query_into_outfile_blocked() {
+    let handler = handler(false);
+    let request = QueryRequest {
+        query: "SELECT * FROM users INTO OUTFILE '/tmp/out'".into(),
+        database_name: "app".into(),
+    };
+
+    let response = handler.read_query(&request).await;
+    assert!(response.is_err(), "Expected error for INTO OUTFILE");
+}
+
+#[tokio::test]
+async fn test_read_query_show_tables() {
+    let handler = handler(false);
+    let request = QueryRequest {
+        query: "SHOW TABLES".into(),
+        database_name: "app".into(),
+    };
+
+    let response = handler.read_query(&request).await.unwrap();
+    let rows = response.rows.as_array().expect("array");
+    assert!(!rows.is_empty(), "SHOW TABLES should return results");
+}
+
+#[tokio::test]
+async fn test_read_query_describe_table() {
+    let handler = handler(false);
+    let request = QueryRequest {
+        query: "DESCRIBE users".into(),
+        database_name: "app".into(),
+    };
+
+    let response = handler.read_query(&request).await.unwrap();
+    let rows = response.rows.as_array().expect("array");
+    assert!(!rows.is_empty(), "DESCRIBE should return column info");
+}
+
+#[tokio::test]
+async fn test_drop_table_nonexistent() {
+    let handler = handler(false);
+    let drop_request = DropTableRequest {
+        database_name: "app".into(),
+        table_name: "nonexistent_table_xyz".into(),
+    };
+
+    let response = handler.drop_table(&drop_request).await;
+    assert!(response.is_err(), "Expected error for nonexistent table");
+}
+
+#[tokio::test]
+async fn test_drop_table_cross_database() {
+    let handler = handler(false);
+
+    // Create a table in the analytics database
+    let create = QueryRequest {
+        query: "CREATE TABLE drop_cross_test (id INT PRIMARY KEY)".into(),
+        database_name: "analytics".into(),
+    };
+    handler.write_query(&create).await.unwrap();
+
+    // Drop it from the analytics database
+    let drop_request = DropTableRequest {
+        database_name: "analytics".into(),
+        table_name: "drop_cross_test".into(),
+    };
+    let response = handler.drop_table(&drop_request).await.unwrap();
+    assert!(response.message.contains("dropped successfully"));
+}
+
+#[tokio::test]
+async fn test_write_query_cross_database() {
+    let handler = handler(false);
+
+    let insert = QueryRequest {
+        query: "INSERT INTO events (name, payload) VALUES ('cross_test', '{\"test\":true}')".into(),
+        database_name: "analytics".into(),
+    };
+    handler.write_query(&insert).await.unwrap();
+
+    let select = QueryRequest {
+        query: "SELECT name FROM events WHERE name = 'cross_test'".into(),
+        database_name: "analytics".into(),
+    };
+    let rows = handler.read_query(&select).await.unwrap();
+    let arr = rows.rows.as_array().expect("array");
+    assert!(!arr.is_empty(), "Cross-database write should persist");
+
+    // Clean up
+    let delete = QueryRequest {
+        query: "DELETE FROM events WHERE name = 'cross_test'".into(),
+        database_name: "analytics".into(),
+    };
+    handler.write_query(&delete).await.unwrap();
+}
+
+#[tokio::test]
+async fn test_get_table_schema_junction_table() {
+    let handler = handler(false);
+    let request = GetTableSchemaRequest {
+        database_name: "app".into(),
+        table_name: "post_tags".into(),
+    };
+
+    let schema = handler.get_table_schema(&request).await.unwrap();
+    assert_eq!(schema.table_name, "post_tags");
+
+    let columns = schema.columns.as_object().expect("columns object");
+    assert!(columns.contains_key("post_id"), "Missing 'post_id'");
+    assert!(columns.contains_key("tag_id"), "Missing 'tag_id'");
+
+    // Both columns should have foreign keys
+    let post_id = columns["post_id"].as_object().expect("post_id object");
+    assert!(
+        post_id.get("foreign_key").is_some_and(|fk| !fk.is_null()),
+        "post_id should have a foreign key"
+    );
+
+    let tag_id = columns["tag_id"].as_object().expect("tag_id object");
+    assert!(
+        tag_id.get("foreign_key").is_some_and(|fk| !fk.is_null()),
+        "tag_id should have a foreign key"
+    );
+}
+
+#[tokio::test]
+async fn test_read_query_empty_result_set() {
+    let handler = handler(false);
+    let request = QueryRequest {
+        query: "SELECT * FROM users WHERE email = 'nobody@nowhere.com'".into(),
+        database_name: "app".into(),
+    };
+
+    let response = handler.read_query(&request).await.unwrap();
+    let rows = response.rows.as_array().expect("array");
+    assert!(rows.is_empty(), "Expected empty result set");
+}
+
+#[tokio::test]
+async fn test_read_query_null_values() {
+    let handler = handler(false);
+    // posts.body can be NULL, and published defaults to 0
+    let request = QueryRequest {
+        query: "SELECT title, body FROM posts WHERE title = 'My First Post'".into(),
+        database_name: "app".into(),
+    };
+
+    let response = handler.read_query(&request).await.unwrap();
+    let rows = response.rows.as_array().expect("array");
+    assert_eq!(rows.len(), 1);
+    // body should be present (even if not null in seed data, the column exists)
+    assert!(rows[0].get("body").is_some(), "body column should be present");
+}
+
+#[tokio::test]
+async fn test_read_query_aggregate() {
+    let handler = handler(false);
+    let request = QueryRequest {
+        query: "SELECT COUNT(*) AS total FROM users".into(),
+        database_name: "app".into(),
+    };
+
+    let response = handler.read_query(&request).await.unwrap();
+    let rows = response.rows.as_array().expect("array");
+    assert_eq!(rows.len(), 1);
+    assert_eq!(rows[0]["total"], 3);
+}
+
+#[tokio::test]
+async fn test_read_query_group_by() {
+    let handler = handler(false);
+    let request = QueryRequest {
+        query: "SELECT user_id, COUNT(*) AS post_count FROM posts GROUP BY user_id ORDER BY user_id".into(),
+        database_name: "app".into(),
+    };
+
+    let response = handler.read_query(&request).await.unwrap();
+    let rows = response.rows.as_array().expect("array");
+    assert!(rows.len() >= 2, "Expected at least 2 groups");
+}
+
+#[tokio::test]
+async fn test_read_query_use_statement() {
+    let handler = handler(false);
+    let request = QueryRequest {
+        query: "USE app".into(),
+        database_name: "app".into(),
+    };
+
+    // USE passes read_only validation and executes without returning rows
+    let response = handler.read_query(&request).await.unwrap();
+    let rows = response.rows.as_array().expect("array");
+    assert!(rows.is_empty(), "USE returns no rows");
+}
+
+#[tokio::test]
+async fn test_read_query_show_databases() {
+    let handler = handler(false);
+    let request = QueryRequest {
+        query: "SHOW DATABASES".into(),
+        database_name: "app".into(),
+    };
+
+    let response = handler.read_query(&request).await.unwrap();
+    let rows = response.rows.as_array().expect("array");
+    assert!(!rows.is_empty(), "SHOW DATABASES should return results");
+}
+
+#[tokio::test]
+async fn test_explain_query_cross_database() {
+    let handler = handler(false);
+    let request = ExplainQueryRequest {
+        database_name: "analytics".into(),
+        query: "SELECT * FROM events".into(),
+        analyze: false,
+    };
+
+    let response = handler.explain_query(&request).await.unwrap();
+    let plan = response.rows.as_array().expect("rows should be an array");
+    assert!(!plan.is_empty(), "EXPLAIN should work cross-database");
+}
+
+#[tokio::test]
+async fn test_read_query_with_comments() {
+    let handler = handler(false);
+    let request = QueryRequest {
+        query: "/* fetch users */ SELECT * FROM users ORDER BY id".into(),
+        database_name: "app".into(),
+    };
+
+    let response = handler.read_query(&request).await.unwrap();
+    let rows = response.rows.as_array().expect("array");
+    assert_eq!(rows.len(), 3, "Comment-prefixed SELECT should work");
+}
+
+#[tokio::test]
+async fn test_read_query_subquery() {
+    let handler = handler(false);
+    let request = QueryRequest {
+        query: "SELECT * FROM users WHERE id IN (SELECT user_id FROM posts WHERE published = 1)".into(),
+        database_name: "app".into(),
+    };
+
+    let response = handler.read_query(&request).await.unwrap();
+    let rows = response.rows.as_array().expect("array");
+    assert!(!rows.is_empty(), "Subquery should return results");
+}
+
+#[tokio::test]
+async fn test_read_query_with_join() {
+    let handler = handler(false);
+    let request = QueryRequest {
+        query: "SELECT p.title, u.name FROM posts p JOIN users u ON p.user_id = u.id ORDER BY p.id".into(),
+        database_name: "app".into(),
+    };
+
+    let response = handler.read_query(&request).await.unwrap();
+    let rows = response.rows.as_array().expect("array");
+    assert_eq!(rows.len(), 5, "Should return all 5 posts with user names");
+    assert!(rows[0].get("title").is_some());
+    assert!(rows[0].get("name").is_some());
+}
+
+#[tokio::test]
+async fn test_explain_query_analyze_select_allowed_in_read_only() {
+    let handler = handler(true);
+    let request = ExplainQueryRequest {
+        database_name: "app".into(),
+        query: "SELECT * FROM users".into(),
+        analyze: true,
+    };
+
+    // MariaDB doesn't support EXPLAIN ANALYZE, so tolerate both outcomes
+    match handler.explain_query(&request).await {
+        Ok(response) => {
+            let plan = response.rows.as_array().expect("rows should be an array");
+            assert!(
+                !plan.is_empty(),
+                "EXPLAIN ANALYZE on SELECT should succeed in read-only mode"
+            );
+        }
+        Err(e) => {
+            // MariaDB syntax error is acceptable
+            let err_msg = e.to_string();
+            assert!(
+                err_msg.contains("syntax") || err_msg.contains("ANALYZE"),
+                "Unexpected error: {err_msg}"
+            );
+        }
+    }
+}
+
+#[tokio::test]
+async fn test_write_query_invalid_sql() {
+    let handler = handler(false);
+    let request = QueryRequest {
+        query: "NOT VALID SQL AT ALL".into(),
+        database_name: "app".into(),
+    };
+
+    let response = handler.write_query(&request).await;
+    assert!(response.is_err(), "Expected error for invalid SQL in write_query");
+}
+
+#[tokio::test]
+async fn test_get_table_schema_column_details() {
+    let handler = handler(false);
+    let request = GetTableSchemaRequest {
+        database_name: "app".into(),
+        table_name: "users".into(),
+    };
+
+    let schema = handler.get_table_schema(&request).await.unwrap();
+    let columns = schema.columns.as_object().expect("columns object");
+
+    // Verify id column has key info (PRIMARY KEY)
+    let id_col = columns["id"].as_object().expect("id object");
+    let key = id_col.get("key").and_then(|v| v.as_str()).unwrap_or("");
+    assert_eq!(key, "PRI", "id should be PRI key");
+
+    // Verify email column type
+    let email_col = columns["email"].as_object().expect("email object");
+    let col_type = email_col.get("type").and_then(|v| v.as_str()).unwrap_or("");
+    assert!(
+        col_type.to_lowercase().contains("varchar"),
+        "email type should contain 'varchar', got: {col_type}"
+    );
+}
+
+#[tokio::test]
+async fn test_read_query_with_limit() {
+    let handler = handler(false);
+    let request = QueryRequest {
+        query: "SELECT * FROM users ORDER BY id LIMIT 2".into(),
+        database_name: "app".into(),
+    };
+
+    let response = handler.read_query(&request).await.unwrap();
+    let rows = response.rows.as_array().expect("array");
+    assert_eq!(rows.len(), 2, "LIMIT 2 should return exactly 2 rows");
+}
+
+#[tokio::test]
+async fn test_drop_table_invalid_database_name() {
+    let handler = handler(false);
+    let drop_request = DropTableRequest {
+        database_name: String::new(),
+        table_name: "users".into(),
+    };
+
+    let response = handler.drop_table(&drop_request).await;
+    assert!(response.is_err(), "Expected error for empty database name");
+}
+
+#[tokio::test]
+async fn test_read_query_with_line_comment() {
+    let handler = handler(false);
+    let request = QueryRequest {
+        query: "-- get users\nSELECT * FROM users ORDER BY id".into(),
+        database_name: "app".into(),
+    };
+
+    let response = handler.read_query(&request).await.unwrap();
+    let rows = response.rows.as_array().expect("array");
+    assert_eq!(rows.len(), 3, "Line-comment prefixed SELECT should work");
+}
+
+#[tokio::test]
+async fn test_read_query_into_dumpfile_blocked() {
+    let handler = handler(false);
+    let request = QueryRequest {
+        query: "SELECT * FROM users INTO DUMPFILE '/tmp/out'".into(),
+        database_name: "app".into(),
+    };
+
+    let response = handler.read_query(&request).await;
+    assert!(response.is_err(), "Expected error for INTO DUMPFILE");
+}
+
+#[tokio::test]
+async fn test_get_table_schema_no_foreign_keys() {
+    let handler = handler(false);
+    let request = GetTableSchemaRequest {
+        database_name: "app".into(),
+        table_name: "tags".into(),
+    };
+
+    let schema = handler.get_table_schema(&request).await.unwrap();
+    assert_eq!(schema.table_name, "tags");
+    let columns = schema.columns.as_object().expect("columns object");
+    assert!(columns.contains_key("id"));
+    assert!(columns.contains_key("name"));
+}
+
+#[tokio::test]
+async fn test_create_database_blocked_in_read_only() {
+    let handler = handler(true);
+    let request = CreateDatabaseRequest {
+        database_name: "should_not_create".into(),
+    };
+
+    let response = handler.create_database(&request).await;
+    assert!(response.is_err(), "create_database should be blocked in read-only mode");
+}
+
+#[tokio::test]
+async fn test_drop_database_blocked_in_read_only() {
+    let handler = handler(true);
+    let request = DropDatabaseRequest {
+        database_name: "app".into(),
+    };
+
+    let response = handler.drop_database(&request).await;
+    assert!(response.is_err(), "drop_database should be blocked in read-only mode");
+}
+
+#[tokio::test]
+async fn test_drop_table_blocked_in_read_only() {
+    let handler = handler(true);
+    let drop_request = DropTableRequest {
+        database_name: "app".into(),
+        table_name: "users".into(),
+    };
+
+    let response = handler.drop_table(&drop_request).await;
+    assert!(response.is_err(), "drop_table should be blocked in read-only mode");
 }

--- a/tests/functional/postgres.rs
+++ b/tests/functional/postgres.rs
@@ -38,6 +38,92 @@ fn handler(read_only: bool) -> PostgresHandler {
 }
 
 #[tokio::test]
+async fn test_write_query_insert_and_verify() {
+    let handler = handler(false);
+
+    let insert = QueryRequest {
+        query: "INSERT INTO users (name, email) VALUES ('WriteTest', 'write@test.com')".into(),
+        database_name: "app".into(),
+    };
+    let response = handler.write_query(&insert).await.unwrap();
+    assert!(response.rows.is_array());
+
+    // Verify the row was inserted
+    let select = QueryRequest {
+        query: "SELECT name FROM users WHERE email = 'write@test.com'".into(),
+        database_name: "app".into(),
+    };
+    let rows = handler.read_query(&select).await.unwrap();
+    let arr = rows.rows.as_array().expect("array");
+    assert_eq!(arr.len(), 1);
+    assert_eq!(arr[0]["name"], "WriteTest");
+
+    // Clean up
+    let delete = QueryRequest {
+        query: "DELETE FROM users WHERE email = 'write@test.com'".into(),
+        database_name: "app".into(),
+    };
+    handler.write_query(&delete).await.unwrap();
+}
+
+#[tokio::test]
+async fn test_write_query_update() {
+    let handler = handler(false);
+
+    let insert = QueryRequest {
+        query: "INSERT INTO users (name, email) VALUES ('Before', 'update@test.com')".into(),
+        database_name: "app".into(),
+    };
+    handler.write_query(&insert).await.unwrap();
+
+    let update = QueryRequest {
+        query: "UPDATE users SET name = 'After' WHERE email = 'update@test.com'".into(),
+        database_name: "app".into(),
+    };
+    handler.write_query(&update).await.unwrap();
+
+    let select = QueryRequest {
+        query: "SELECT name FROM users WHERE email = 'update@test.com'".into(),
+        database_name: "app".into(),
+    };
+    let rows = handler.read_query(&select).await.unwrap();
+    let arr = rows.rows.as_array().expect("array");
+    assert_eq!(arr[0]["name"], "After");
+
+    // Clean up
+    let delete = QueryRequest {
+        query: "DELETE FROM users WHERE email = 'update@test.com'".into(),
+        database_name: "app".into(),
+    };
+    handler.write_query(&delete).await.unwrap();
+}
+
+#[tokio::test]
+async fn test_write_query_delete() {
+    let handler = handler(false);
+
+    let insert = QueryRequest {
+        query: "INSERT INTO users (name, email) VALUES ('Deletable', 'delete@test.com')".into(),
+        database_name: "app".into(),
+    };
+    handler.write_query(&insert).await.unwrap();
+
+    let delete = QueryRequest {
+        query: "DELETE FROM users WHERE email = 'delete@test.com'".into(),
+        database_name: "app".into(),
+    };
+    handler.write_query(&delete).await.unwrap();
+
+    let select = QueryRequest {
+        query: "SELECT * FROM users WHERE email = 'delete@test.com'".into(),
+        database_name: "app".into(),
+    };
+    let rows = handler.read_query(&select).await.unwrap();
+    let arr = rows.rows.as_array().expect("array");
+    assert!(arr.is_empty(), "Row should be deleted");
+}
+
+#[tokio::test]
 async fn test_lists_databases() {
     let handler = handler(false);
 
@@ -577,4 +663,435 @@ async fn test_explain_query_invalid_query() {
 
     let response = handler.explain_query(&request).await;
     assert!(response.is_err(), "Expected error for invalid SQL");
+}
+
+#[tokio::test]
+async fn test_get_table_schema_nonexistent_table() {
+    let handler = handler(false);
+    let request = GetTableSchemaRequest {
+        database_name: "app".into(),
+        table_name: "nonexistent_table_xyz".into(),
+    };
+
+    let response = handler.get_table_schema(&request).await;
+    assert!(response.is_err(), "Expected error for nonexistent table");
+}
+
+#[tokio::test]
+async fn test_get_table_schema_invalid_table_name() {
+    let handler = handler(false);
+    let request = GetTableSchemaRequest {
+        database_name: "app".into(),
+        table_name: String::new(),
+    };
+
+    let response = handler.get_table_schema(&request).await;
+    assert!(response.is_err(), "Expected error for empty table name");
+}
+
+#[tokio::test]
+async fn test_create_database_already_exists() {
+    let handler = handler(false);
+    let request = CreateDatabaseRequest {
+        database_name: "app".into(),
+    };
+
+    let response = handler.create_database(&request).await;
+    // PostgreSQL returns an error that contains "already exists"
+    let err_msg = format!(
+        "{:?}",
+        response.expect_err("Expected error when creating existing database")
+    );
+    assert!(
+        err_msg.contains("already exists"),
+        "Expected 'already exists' in error, got: {err_msg}"
+    );
+}
+
+#[tokio::test]
+async fn test_create_database_invalid_identifier() {
+    let handler = handler(false);
+    let request = CreateDatabaseRequest {
+        database_name: String::new(),
+    };
+
+    let response = handler.create_database(&request).await;
+    assert!(response.is_err(), "Expected error for empty database name");
+}
+
+#[tokio::test]
+async fn test_list_tables_invalid_database_name() {
+    let handler = handler(false);
+    let request = ListTablesRequest {
+        database_name: String::new(),
+    };
+
+    // Empty database_name is treated as None (uses default pool)
+    let response = handler.list_tables(&request).await.unwrap();
+    let tables = response.tables;
+    assert!(
+        tables.iter().any(|t| t == "users"),
+        "Empty db name should fall back to default: {tables:?}"
+    );
+}
+
+#[tokio::test]
+async fn test_read_query_empty_query() {
+    let handler = handler(false);
+    let request = QueryRequest {
+        query: String::new(),
+        database_name: "app".into(),
+    };
+
+    let response = handler.read_query(&request).await;
+    assert!(response.is_err(), "Expected error for empty query");
+}
+
+#[tokio::test]
+async fn test_read_query_whitespace_only_query() {
+    let handler = handler(false);
+    let request = QueryRequest {
+        query: "   \t\n  ".into(),
+        database_name: "app".into(),
+    };
+
+    let response = handler.read_query(&request).await;
+    assert!(response.is_err(), "Expected error for whitespace-only query");
+}
+
+#[tokio::test]
+async fn test_read_query_multi_statement_blocked() {
+    let handler = handler(false);
+    let request = QueryRequest {
+        query: "SELECT 1; DROP TABLE users".into(),
+        database_name: "app".into(),
+    };
+
+    let response = handler.read_query(&request).await;
+    assert!(response.is_err(), "Expected error for multi-statement query");
+}
+
+#[tokio::test]
+async fn test_read_query_into_outfile_blocked() {
+    let handler = handler(false);
+    let request = QueryRequest {
+        query: "SELECT * FROM users INTO OUTFILE '/tmp/out'".into(),
+        database_name: "app".into(),
+    };
+
+    let response = handler.read_query(&request).await;
+    assert!(response.is_err(), "Expected error for INTO OUTFILE");
+}
+
+#[tokio::test]
+async fn test_drop_table_cross_database() {
+    let handler = handler(false);
+
+    // Create a table in the analytics database
+    let create = QueryRequest {
+        query: "CREATE TABLE drop_cross_test (id SERIAL PRIMARY KEY)".into(),
+        database_name: "analytics".into(),
+    };
+    handler.write_query(&create).await.unwrap();
+
+    // Drop it from the analytics database
+    let drop_request = DropTableRequest {
+        database_name: "analytics".into(),
+        table_name: "drop_cross_test".into(),
+        cascade: false,
+    };
+    let response = handler.drop_table(&drop_request).await.unwrap();
+    assert!(response.message.contains("dropped successfully"));
+}
+
+#[tokio::test]
+async fn test_write_query_cross_database() {
+    let handler = handler(false);
+
+    let insert = QueryRequest {
+        query: "INSERT INTO events (name, payload) VALUES ('cross_test', '{\"test\":true}')".into(),
+        database_name: "analytics".into(),
+    };
+    handler.write_query(&insert).await.unwrap();
+
+    let select = QueryRequest {
+        query: "SELECT name FROM events WHERE name = 'cross_test'".into(),
+        database_name: "analytics".into(),
+    };
+    let rows = handler.read_query(&select).await.unwrap();
+    let arr = rows.rows.as_array().expect("array");
+    assert!(!arr.is_empty(), "Cross-database write should persist");
+
+    // Clean up
+    let delete = QueryRequest {
+        query: "DELETE FROM events WHERE name = 'cross_test'".into(),
+        database_name: "analytics".into(),
+    };
+    handler.write_query(&delete).await.unwrap();
+}
+
+#[tokio::test]
+async fn test_get_table_schema_junction_table() {
+    let handler = handler(false);
+    let request = GetTableSchemaRequest {
+        database_name: "app".into(),
+        table_name: "post_tags".into(),
+    };
+
+    let schema = handler.get_table_schema(&request).await.unwrap();
+    assert_eq!(schema.table_name, "post_tags");
+
+    let columns = schema.columns.as_object().expect("columns object");
+    assert!(columns.contains_key("post_id"), "Missing 'post_id'");
+    assert!(columns.contains_key("tag_id"), "Missing 'tag_id'");
+
+    // Both columns should have foreign keys
+    let post_id = columns["post_id"].as_object().expect("post_id object");
+    assert!(
+        post_id.get("foreign_key").is_some_and(|fk| !fk.is_null()),
+        "post_id should have a foreign key"
+    );
+
+    let tag_id = columns["tag_id"].as_object().expect("tag_id object");
+    assert!(
+        tag_id.get("foreign_key").is_some_and(|fk| !fk.is_null()),
+        "tag_id should have a foreign key"
+    );
+}
+
+#[tokio::test]
+async fn test_read_query_empty_result_set() {
+    let handler = handler(false);
+    let request = QueryRequest {
+        query: "SELECT * FROM users WHERE email = 'nobody@nowhere.com'".into(),
+        database_name: "app".into(),
+    };
+
+    let response = handler.read_query(&request).await.unwrap();
+    let rows = response.rows.as_array().expect("array");
+    assert!(rows.is_empty(), "Expected empty result set");
+}
+
+#[tokio::test]
+async fn test_read_query_aggregate() {
+    let handler = handler(false);
+    let request = QueryRequest {
+        query: "SELECT COUNT(*) AS total FROM users".into(),
+        database_name: "app".into(),
+    };
+
+    let response = handler.read_query(&request).await.unwrap();
+    let rows = response.rows.as_array().expect("array");
+    assert_eq!(rows.len(), 1);
+    assert_eq!(rows[0]["total"], 3);
+}
+
+#[tokio::test]
+async fn test_read_query_group_by() {
+    let handler = handler(false);
+    let request = QueryRequest {
+        query: "SELECT user_id, COUNT(*) AS post_count FROM posts GROUP BY user_id ORDER BY user_id".into(),
+        database_name: "app".into(),
+    };
+
+    let response = handler.read_query(&request).await.unwrap();
+    let rows = response.rows.as_array().expect("array");
+    assert!(rows.len() >= 2, "Expected at least 2 groups");
+}
+
+#[tokio::test]
+async fn test_explain_query_cross_database() {
+    let handler = handler(false);
+    let request = ExplainQueryRequest {
+        database_name: "analytics".into(),
+        query: "SELECT * FROM events".into(),
+        analyze: false,
+    };
+
+    let response = handler.explain_query(&request).await.unwrap();
+    let plan = response.rows.as_array().expect("rows should be an array");
+    assert!(!plan.is_empty(), "EXPLAIN should work cross-database");
+}
+
+#[tokio::test]
+async fn test_read_query_with_comments() {
+    let handler = handler(false);
+    let request = QueryRequest {
+        query: "/* fetch users */ SELECT * FROM users ORDER BY id".into(),
+        database_name: "app".into(),
+    };
+
+    let response = handler.read_query(&request).await.unwrap();
+    let rows = response.rows.as_array().expect("array");
+    assert_eq!(rows.len(), 3, "Comment-prefixed SELECT should work");
+}
+
+#[tokio::test]
+async fn test_read_query_subquery() {
+    let handler = handler(false);
+    let request = QueryRequest {
+        query: "SELECT * FROM users WHERE id IN (SELECT user_id FROM posts WHERE published = true)".into(),
+        database_name: "app".into(),
+    };
+
+    let response = handler.read_query(&request).await.unwrap();
+    let rows = response.rows.as_array().expect("array");
+    assert!(!rows.is_empty(), "Subquery should return results");
+}
+
+#[tokio::test]
+async fn test_read_query_with_join() {
+    let handler = handler(false);
+    let request = QueryRequest {
+        query: "SELECT p.title, u.name FROM posts p JOIN users u ON p.user_id = u.id ORDER BY p.id".into(),
+        database_name: "app".into(),
+    };
+
+    let response = handler.read_query(&request).await.unwrap();
+    let rows = response.rows.as_array().expect("array");
+    assert_eq!(rows.len(), 5, "Should return all 5 posts with user names");
+    assert!(rows[0].get("title").is_some());
+    assert!(rows[0].get("name").is_some());
+}
+
+#[tokio::test]
+async fn test_explain_query_analyze_select_allowed_in_read_only() {
+    let handler = handler(true);
+    let request = ExplainQueryRequest {
+        database_name: "app".into(),
+        query: "SELECT * FROM users".into(),
+        analyze: true,
+    };
+
+    let response = handler.explain_query(&request).await.unwrap();
+    let plan = response.rows.as_array().expect("rows should be an array");
+    assert!(
+        !plan.is_empty(),
+        "EXPLAIN ANALYZE on SELECT should succeed in read-only mode"
+    );
+}
+
+#[tokio::test]
+async fn test_write_query_invalid_sql() {
+    let handler = handler(false);
+    let request = QueryRequest {
+        query: "NOT VALID SQL AT ALL".into(),
+        database_name: "app".into(),
+    };
+
+    let response = handler.write_query(&request).await;
+    assert!(response.is_err(), "Expected error for invalid SQL in write_query");
+}
+
+#[tokio::test]
+async fn test_get_table_schema_column_details() {
+    let handler = handler(false);
+    let request = GetTableSchemaRequest {
+        database_name: "app".into(),
+        table_name: "users".into(),
+    };
+
+    let schema = handler.get_table_schema(&request).await.unwrap();
+    let columns = schema.columns.as_object().expect("columns object");
+
+    // Verify email column type
+    let email_col = columns["email"].as_object().expect("email object");
+    let col_type = email_col.get("type").and_then(|v| v.as_str()).unwrap_or("");
+    assert!(
+        col_type.to_lowercase().contains("character varying") || col_type.to_lowercase().contains("varchar"),
+        "email type should contain 'character varying' or 'varchar', got: {col_type}"
+    );
+
+    // Verify nullable field
+    let nullable = email_col.get("nullable").and_then(Value::as_bool);
+    assert_eq!(nullable, Some(false), "email should be NOT NULL");
+}
+
+#[tokio::test]
+async fn test_read_query_with_limit() {
+    let handler = handler(false);
+    let request = QueryRequest {
+        query: "SELECT * FROM users ORDER BY id LIMIT 2".into(),
+        database_name: "app".into(),
+    };
+
+    let response = handler.read_query(&request).await.unwrap();
+    let rows = response.rows.as_array().expect("array");
+    assert_eq!(rows.len(), 2, "LIMIT 2 should return exactly 2 rows");
+}
+
+#[tokio::test]
+async fn test_drop_table_invalid_database_name() {
+    let handler = handler(false);
+    let drop_request = DropTableRequest {
+        database_name: String::new(),
+        table_name: "users".into(),
+        cascade: false,
+    };
+
+    let response = handler.drop_table(&drop_request).await;
+    assert!(response.is_err(), "Expected error for empty database name");
+}
+
+#[tokio::test]
+async fn test_read_query_with_line_comment() {
+    let handler = handler(false);
+    let request = QueryRequest {
+        query: "-- get users\nSELECT * FROM users ORDER BY id".into(),
+        database_name: "app".into(),
+    };
+
+    let response = handler.read_query(&request).await.unwrap();
+    let rows = response.rows.as_array().expect("array");
+    assert_eq!(rows.len(), 3, "Line-comment prefixed SELECT should work");
+}
+
+#[tokio::test]
+async fn test_get_table_schema_no_foreign_keys() {
+    let handler = handler(false);
+    let request = GetTableSchemaRequest {
+        database_name: "app".into(),
+        table_name: "tags".into(),
+    };
+
+    let schema = handler.get_table_schema(&request).await.unwrap();
+    assert_eq!(schema.table_name, "tags");
+    let columns = schema.columns.as_object().expect("columns object");
+    assert!(columns.contains_key("id"));
+    assert!(columns.contains_key("name"));
+}
+
+#[tokio::test]
+async fn test_create_database_blocked_in_read_only() {
+    let handler = handler(true);
+    let request = CreateDatabaseRequest {
+        database_name: "should_not_create".into(),
+    };
+
+    let response = handler.create_database(&request).await;
+    assert!(response.is_err(), "create_database should be blocked in read-only mode");
+}
+
+#[tokio::test]
+async fn test_drop_database_blocked_in_read_only() {
+    let handler = handler(true);
+    let request = DropDatabaseRequest {
+        database_name: "app".into(),
+    };
+
+    let response = handler.drop_database(&request).await;
+    assert!(response.is_err(), "drop_database should be blocked in read-only mode");
+}
+
+#[tokio::test]
+async fn test_drop_table_blocked_in_read_only() {
+    let handler = handler(true);
+    let drop_request = DropTableRequest {
+        database_name: "app".into(),
+        table_name: "users".into(),
+        cascade: false,
+    };
+
+    let response = handler.drop_table(&drop_request).await;
+    assert!(response.is_err(), "drop_table should be blocked in read-only mode");
 }

--- a/tests/functional/sqlite.rs
+++ b/tests/functional/sqlite.rs
@@ -29,6 +29,82 @@ fn handler(read_only: bool) -> SqliteHandler {
 }
 
 #[tokio::test]
+async fn test_write_query_insert_and_verify() {
+    let handler = handler(false);
+
+    let insert = QueryRequest {
+        query: "INSERT INTO users (name, email) VALUES ('WriteTest', 'write@test.com')".into(),
+    };
+    let response = handler.write_query(&insert).await.unwrap();
+    assert!(response.rows.is_array());
+
+    // Verify
+    let select = QueryRequest {
+        query: "SELECT name FROM users WHERE email = 'write@test.com'".into(),
+    };
+    let rows = handler.read_query(&select).await.unwrap();
+    let arr = rows.rows.as_array().expect("array");
+    assert_eq!(arr.len(), 1);
+    assert_eq!(arr[0]["name"], "WriteTest");
+
+    // Clean up
+    let delete = QueryRequest {
+        query: "DELETE FROM users WHERE email = 'write@test.com'".into(),
+    };
+    handler.write_query(&delete).await.unwrap();
+}
+
+#[tokio::test]
+async fn test_write_query_update() {
+    let handler = handler(false);
+
+    let insert = QueryRequest {
+        query: "INSERT INTO users (name, email) VALUES ('Before', 'update@test.com')".into(),
+    };
+    handler.write_query(&insert).await.unwrap();
+
+    let update = QueryRequest {
+        query: "UPDATE users SET name = 'After' WHERE email = 'update@test.com'".into(),
+    };
+    handler.write_query(&update).await.unwrap();
+
+    let select = QueryRequest {
+        query: "SELECT name FROM users WHERE email = 'update@test.com'".into(),
+    };
+    let rows = handler.read_query(&select).await.unwrap();
+    let arr = rows.rows.as_array().expect("array");
+    assert_eq!(arr[0]["name"], "After");
+
+    // Clean up
+    let delete = QueryRequest {
+        query: "DELETE FROM users WHERE email = 'update@test.com'".into(),
+    };
+    handler.write_query(&delete).await.unwrap();
+}
+
+#[tokio::test]
+async fn test_write_query_delete() {
+    let handler = handler(false);
+
+    let insert = QueryRequest {
+        query: "INSERT INTO users (name, email) VALUES ('Deletable', 'delete@test.com')".into(),
+    };
+    handler.write_query(&insert).await.unwrap();
+
+    let delete = QueryRequest {
+        query: "DELETE FROM users WHERE email = 'delete@test.com'".into(),
+    };
+    handler.write_query(&delete).await.unwrap();
+
+    let select = QueryRequest {
+        query: "SELECT * FROM users WHERE email = 'delete@test.com'".into(),
+    };
+    let rows = handler.read_query(&select).await.unwrap();
+    let arr = rows.rows.as_array().expect("array");
+    assert!(arr.is_empty(), "Row should be deleted");
+}
+
+#[tokio::test]
 async fn test_lists_tables() {
     let handler = handler(false);
 
@@ -183,4 +259,334 @@ async fn test_explain_query_select() {
     let response = handler.explain_query(&request).await.unwrap();
     let plan = response.rows.as_array().expect("rows should be an array");
     assert!(!plan.is_empty(), "Expected non-empty execution plan");
+}
+
+#[tokio::test]
+async fn test_explain_query_with_join() {
+    let handler = handler(false);
+    let request = ExplainQueryRequest {
+        query: "SELECT p.title, u.name FROM posts p JOIN users u ON p.user_id = u.id".into(),
+    };
+
+    let response = handler.explain_query(&request).await.unwrap();
+    let plan = response.rows.as_array().expect("rows should be an array");
+    assert!(!plan.is_empty(), "EXPLAIN QUERY PLAN should return plan for JOIN query");
+}
+
+#[tokio::test]
+async fn test_explain_query_invalid_sql() {
+    let handler = handler(false);
+    let request = ExplainQueryRequest {
+        query: "NOT VALID SQL AT ALL".into(),
+    };
+
+    let response = handler.explain_query(&request).await;
+    assert!(response.is_err(), "Expected error for invalid SQL");
+}
+
+#[tokio::test]
+async fn test_get_table_schema_nonexistent_table() {
+    let handler = handler(false);
+    let request = GetTableSchemaRequest {
+        table_name: "nonexistent_table_xyz".into(),
+    };
+
+    let response = handler.get_table_schema(&request).await;
+    assert!(response.is_err(), "Expected error for nonexistent table");
+}
+
+#[tokio::test]
+async fn test_get_table_schema_invalid_table_name() {
+    let handler = handler(false);
+    let request = GetTableSchemaRequest {
+        table_name: String::new(),
+    };
+
+    let response = handler.get_table_schema(&request).await;
+    assert!(response.is_err(), "Expected error for empty table name");
+}
+
+#[tokio::test]
+async fn test_drop_table_invalid_identifier() {
+    let handler = handler(false);
+    let drop_request = DropTableRequest {
+        table_name: String::new(),
+    };
+
+    let response = handler.drop_table(&drop_request).await;
+    assert!(response.is_err(), "Expected error for empty table name");
+}
+
+#[tokio::test]
+async fn test_read_query_empty_query() {
+    let handler = handler(false);
+    let request = QueryRequest { query: String::new() };
+
+    let response = handler.read_query(&request).await;
+    assert!(response.is_err(), "Expected error for empty query");
+}
+
+#[tokio::test]
+async fn test_read_query_whitespace_only_query() {
+    let handler = handler(false);
+    let request = QueryRequest {
+        query: "   \t\n  ".into(),
+    };
+
+    let response = handler.read_query(&request).await;
+    assert!(response.is_err(), "Expected error for whitespace-only query");
+}
+
+#[tokio::test]
+async fn test_read_query_multi_statement_blocked() {
+    let handler = handler(false);
+    let request = QueryRequest {
+        query: "SELECT 1; DROP TABLE users".into(),
+    };
+
+    let response = handler.read_query(&request).await;
+    assert!(response.is_err(), "Expected error for multi-statement query");
+}
+
+#[tokio::test]
+async fn test_read_query_into_outfile_blocked() {
+    let handler = handler(false);
+    let request = QueryRequest {
+        query: "SELECT * FROM users INTO OUTFILE '/tmp/out'".into(),
+    };
+
+    let response = handler.read_query(&request).await;
+    assert!(response.is_err(), "Expected error for INTO OUTFILE");
+}
+
+#[tokio::test]
+async fn test_read_query_with_join() {
+    let handler = handler(false);
+    let request = QueryRequest {
+        query: "SELECT p.title, u.name FROM posts p JOIN users u ON p.user_id = u.id ORDER BY p.id".into(),
+    };
+
+    let response = handler.read_query(&request).await.unwrap();
+    let rows = response.rows.as_array().expect("array");
+    assert!(!rows.is_empty(), "JOIN query should return results");
+    assert!(rows[0].get("title").is_some(), "Should have title column");
+    assert!(rows[0].get("name").is_some(), "Should have name column");
+}
+
+#[tokio::test]
+async fn test_write_query_create_table() {
+    let handler = handler(false);
+
+    let create = QueryRequest {
+        query: "CREATE TABLE write_test_create (id INTEGER PRIMARY KEY, value TEXT)".into(),
+    };
+    handler.write_query(&create).await.unwrap();
+
+    // Verify it appears in list_tables
+    let tables = handler.list_tables().await.unwrap();
+    assert!(
+        tables.tables.iter().any(|t| t == "write_test_create"),
+        "Created table should appear in list"
+    );
+
+    // Clean up
+    let drop = DropTableRequest {
+        table_name: "write_test_create".into(),
+    };
+    handler.drop_table(&drop).await.unwrap();
+}
+
+#[tokio::test]
+async fn test_get_table_schema_junction_table() {
+    let handler = handler(false);
+    let request = GetTableSchemaRequest {
+        table_name: "post_tags".into(),
+    };
+
+    let schema = handler.get_table_schema(&request).await.unwrap();
+    assert_eq!(schema.table_name, "post_tags");
+
+    let columns = schema.columns.as_object().expect("columns object");
+    assert!(columns.contains_key("post_id"), "Missing 'post_id'");
+    assert!(columns.contains_key("tag_id"), "Missing 'tag_id'");
+
+    // Both columns should have foreign keys
+    let post_id = columns["post_id"].as_object().expect("post_id object");
+    assert!(
+        post_id.get("foreign_key").is_some_and(|fk| !fk.is_null()),
+        "post_id should have a foreign key"
+    );
+
+    let tag_id = columns["tag_id"].as_object().expect("tag_id object");
+    assert!(
+        tag_id.get("foreign_key").is_some_and(|fk| !fk.is_null()),
+        "tag_id should have a foreign key"
+    );
+}
+
+#[tokio::test]
+async fn test_read_query_empty_result_set() {
+    let handler = handler(false);
+    let request = QueryRequest {
+        query: "SELECT * FROM users WHERE email = 'nobody@nowhere.com'".into(),
+    };
+
+    let response = handler.read_query(&request).await.unwrap();
+    let rows = response.rows.as_array().expect("array");
+    assert!(rows.is_empty(), "Expected empty result set");
+}
+
+#[tokio::test]
+async fn test_read_query_aggregate() {
+    let handler = handler(false);
+    let request = QueryRequest {
+        query: "SELECT COUNT(*) AS total FROM users".into(),
+    };
+
+    let response = handler.read_query(&request).await.unwrap();
+    let rows = response.rows.as_array().expect("array");
+    assert_eq!(rows.len(), 1);
+    assert_eq!(rows[0]["total"], 3);
+}
+
+#[tokio::test]
+async fn test_read_query_group_by() {
+    let handler = handler(false);
+    let request = QueryRequest {
+        query: "SELECT user_id, COUNT(*) AS post_count FROM posts GROUP BY user_id ORDER BY user_id".into(),
+    };
+
+    let response = handler.read_query(&request).await.unwrap();
+    let rows = response.rows.as_array().expect("array");
+    assert!(rows.len() >= 2, "Expected at least 2 groups");
+}
+
+#[tokio::test]
+async fn test_read_query_with_comments() {
+    let handler = handler(false);
+    let request = QueryRequest {
+        query: "/* fetch users */ SELECT * FROM users ORDER BY id".into(),
+    };
+
+    let response = handler.read_query(&request).await.unwrap();
+    let rows = response.rows.as_array().expect("array");
+    assert_eq!(rows.len(), 3, "Comment-prefixed SELECT should work");
+}
+
+#[tokio::test]
+async fn test_read_query_subquery() {
+    let handler = handler(false);
+    let request = QueryRequest {
+        query: "SELECT * FROM users WHERE id IN (SELECT user_id FROM posts WHERE published = 1)".into(),
+    };
+
+    let response = handler.read_query(&request).await.unwrap();
+    let rows = response.rows.as_array().expect("array");
+    assert!(!rows.is_empty(), "Subquery should return results");
+}
+
+#[tokio::test]
+async fn test_get_table_schema_no_foreign_keys() {
+    let handler = handler(false);
+    let request = GetTableSchemaRequest {
+        table_name: "tags".into(),
+    };
+
+    let schema = handler.get_table_schema(&request).await.unwrap();
+    assert_eq!(schema.table_name, "tags");
+
+    let columns = schema.columns.as_object().expect("columns object");
+    assert!(columns.contains_key("id"), "Missing 'id'");
+    assert!(columns.contains_key("name"), "Missing 'name'");
+
+    // id column should have no foreign key
+    let id_col = columns["id"].as_object().expect("id object");
+    let fk = id_col.get("foreign_key");
+    assert!(
+        fk.is_none() || fk.is_some_and(Value::is_null),
+        "tags.id should not have a foreign key"
+    );
+}
+
+#[tokio::test]
+async fn test_write_query_invalid_sql() {
+    let handler = handler(false);
+    let request = QueryRequest {
+        query: "NOT VALID SQL AT ALL".into(),
+    };
+
+    let response = handler.write_query(&request).await;
+    assert!(response.is_err(), "Expected error for invalid SQL in write_query");
+}
+
+#[tokio::test]
+async fn test_get_table_schema_column_details() {
+    let handler = handler(false);
+    let request = GetTableSchemaRequest {
+        table_name: "users".into(),
+    };
+
+    let schema = handler.get_table_schema(&request).await.unwrap();
+    let columns = schema.columns.as_object().expect("columns object");
+
+    // Verify id column has key info (PRIMARY KEY)
+    let id_col = columns["id"].as_object().expect("id object");
+    let key = id_col.get("key").and_then(|v| v.as_str()).unwrap_or("");
+    assert_eq!(key, "PRI", "id should be PRI key");
+
+    // Verify email column type
+    let email_col = columns["email"].as_object().expect("email object");
+    let col_type = email_col.get("type").and_then(|v| v.as_str()).unwrap_or("");
+    assert!(
+        col_type.to_lowercase().contains("varchar") || col_type.to_lowercase().contains("text"),
+        "email type should contain 'varchar' or 'text', got: {col_type}"
+    );
+}
+
+#[tokio::test]
+async fn test_read_query_with_limit() {
+    let handler = handler(false);
+    let request = QueryRequest {
+        query: "SELECT * FROM users ORDER BY id LIMIT 2".into(),
+    };
+
+    let response = handler.read_query(&request).await.unwrap();
+    let rows = response.rows.as_array().expect("array");
+    assert_eq!(rows.len(), 2, "LIMIT 2 should return exactly 2 rows");
+}
+
+#[tokio::test]
+async fn test_read_query_with_line_comment() {
+    let handler = handler(false);
+    let request = QueryRequest {
+        query: "-- get users\nSELECT * FROM users ORDER BY id".into(),
+    };
+
+    let response = handler.read_query(&request).await.unwrap();
+    let rows = response.rows.as_array().expect("array");
+    assert_eq!(rows.len(), 3, "Line-comment prefixed SELECT should work");
+}
+
+#[tokio::test]
+async fn test_read_query_null_values() {
+    let handler = handler(false);
+    let request = QueryRequest {
+        query: "SELECT title, body FROM posts WHERE title = 'My First Post'".into(),
+    };
+
+    let response = handler.read_query(&request).await.unwrap();
+    let rows = response.rows.as_array().expect("array");
+    assert_eq!(rows.len(), 1);
+    assert!(rows[0].get("body").is_some(), "body column should be present");
+}
+
+#[tokio::test]
+async fn test_drop_table_blocked_in_read_only() {
+    let handler = handler(true);
+    let drop_request = DropTableRequest {
+        table_name: "users".into(),
+    };
+
+    let response = handler.drop_table(&drop_request).await;
+    assert!(response.is_err(), "drop_table should be blocked in read-only mode");
 }


### PR DESCRIPTION
## Summary

- **Extract shared `Connection` trait** into `crates/sql` with default implementations for `execute`, `fetch`, `fetch_optional`, and SQL quoting — eliminating duplicated code across MySQL, PostgreSQL, and SQLite backends
- **Replace MySQL `USE` statements with per-database connection pools** using moka cache, matching the PostgreSQL approach for cross-database operations
- **Unify pool storage** by merging `default_pool` into the shared pools cache, simplifying pool resolution to a single lookup path
- **Inline helpers** (`PoolProvider`, `is_default_db`) and rename variables for consistency across all three connection modules
- **Add 119 new functional tests** covering every MCP tool edge case: write operations, schema introspection (junction tables, composite keys, column details), security enforcement (LOAD_FILE, INTO OUTFILE/DUMPFILE, multi-statement injection), read-only mode blocking on destructive operations, cross-database queries, EXPLAIN ANALYZE, and error handling

## Test plan

- [x] `cargo fmt --check` — no formatting issues
- [x] `cargo clippy --workspace --tests -- -D warnings` — no warnings
- [x] `cargo test --workspace --lib --bins` — 111 unit tests pass
- [x] `./tests/run.sh` — 249 integration tests pass across MariaDB 12, MySQL 9, PostgreSQL 18, and SQLite