### PR TITLE
docs(tools): improve MCP tool descriptions

### DIFF
--- a/crates/mysql/src/handler.rs
+++ b/crates/mysql/src/handler.rs
@@ -31,12 +31,14 @@ const INSTRUCTIONS: &str = r"## Workflow
 3. Call `get_table_schema` with `database_name` and `table_name` to inspect columns, types, and foreign keys before writing queries.
 4. Use `read_query` for read-only SQL (SELECT, SHOW, DESCRIBE, USE, EXPLAIN).
 5. Use `write_query` for data changes (INSERT, UPDATE, DELETE, CREATE, ALTER, DROP).
-6. Use `create_database` to create a new database.
-7. Use `drop_database` to drop an existing database.
+6. Use `explain_query` to analyze query execution plans and diagnose slow queries.
+7. Use `create_database` to create a new database.
+8. Use `drop_database` to drop an existing database.
+9. Use `drop_table` to remove a table from a database.
 
 ## Constraints
 
-- The `write_query`, `create_database`, and `drop_database` tools are hidden when read-only mode is active.
+- The `write_query`, `create_database`, `drop_database`, and `drop_table` tools are hidden when read-only mode is active.
 - Multi-statement queries are not supported. Send one statement per request.";
 
 /// MySQL/MariaDB database handler.

--- a/crates/mysql/src/tools/create_database.rs
+++ b/crates/mysql/src/tools/create_database.rs
@@ -16,7 +16,27 @@ pub(crate) struct CreateDatabaseTool;
 
 impl CreateDatabaseTool {
     const NAME: &'static str = "create_database";
-    const DESCRIPTION: &'static str = "Create a new database.";
+    const DESCRIPTION: &'static str = r#"Create a new database on the connected server.
+
+<usecase>
+Use when:
+- Setting up a new database for a project or application
+- The user asks to create a database
+</usecase>
+
+<examples>
+✓ "Create a database called analytics" → create_database(database_name="analytics")
+✗ "Create a table" → use write_query with CREATE TABLE
+</examples>
+
+<important>
+Database names must contain only alphanumeric characters and underscores.
+If the database already exists, returns a message indicating so without error.
+</important>
+
+<what_it_returns>
+A confirmation message with the created database name.
+</what_it_returns>"#;
 }
 
 impl ToolBase for CreateDatabaseTool {

--- a/crates/mysql/src/tools/drop_database.rs
+++ b/crates/mysql/src/tools/drop_database.rs
@@ -16,7 +16,27 @@ pub(crate) struct DropDatabaseTool;
 
 impl DropDatabaseTool {
     const NAME: &'static str = "drop_database";
-    const DESCRIPTION: &'static str = "Drop an existing database. Cannot drop the currently connected database.";
+    const DESCRIPTION: &'static str = r#"Drop an existing database from the connected server.
+
+<usecase>
+Use when:
+- Removing a database that is no longer needed
+- Cleaning up test or temporary databases
+</usecase>
+
+<examples>
+✓ "Drop the test_db database" → drop_database(database_name="test_db")
+✗ "Drop a table" → use drop_table instead
+</examples>
+
+<safety>
+IMPORTANT: This permanently deletes the database and ALL its data. This action cannot be undone.
+Cannot drop the database you are currently connected to.
+</safety>
+
+<what_it_returns>
+A confirmation message with the dropped database name.
+</what_it_returns>"#;
 }
 
 impl ToolBase for DropDatabaseTool {

--- a/crates/mysql/src/tools/drop_table.rs
+++ b/crates/mysql/src/tools/drop_table.rs
@@ -17,7 +17,28 @@ pub(crate) struct DropTableTool;
 
 impl DropTableTool {
     const NAME: &'static str = "drop_table";
-    const DESCRIPTION: &'static str = "Drop a table from a database.";
+    const DESCRIPTION: &'static str = r#"Drop a table from a database.
+
+<usecase>
+Use when:
+- Removing a table that is no longer needed
+- Cleaning up test or temporary tables
+</usecase>
+
+<examples>
+✓ "Drop the temp_logs table from mydb" → drop_table(database_name="mydb", table_name="temp_logs")
+✗ "Delete rows from a table" → use write_query with DELETE
+✗ "Drop a database" → use drop_database instead
+</examples>
+
+<safety>
+IMPORTANT: This permanently deletes the table and ALL its data. This action cannot be undone.
+If the table has foreign key dependencies, the drop will fail — resolve dependencies first.
+</safety>
+
+<what_it_returns>
+A confirmation message with the dropped table name.
+</what_it_returns>"#;
 }
 
 impl ToolBase for DropTableTool {

--- a/crates/mysql/src/tools/explain_query.rs
+++ b/crates/mysql/src/tools/explain_query.rs
@@ -17,7 +17,36 @@ pub(crate) struct ExplainQueryTool;
 
 impl ExplainQueryTool {
     const NAME: &'static str = "explain_query";
-    const DESCRIPTION: &'static str = "Return the execution plan for a SQL query.";
+    const DESCRIPTION: &'static str = r#"Return the execution plan for a SQL query to diagnose performance. Use this tool instead of running EXPLAIN directly through read_query — it provides structured output.
+
+<usecase>
+Use when:
+- A query runs slowly and you need to understand why
+- Investigating performance bottlenecks
+- Planning index creation to optimize queries
+- Analyzing join methods, table scan strategies, and sort operations
+</usecase>
+
+<when_not_to_use>
+- Running actual queries → use read_query or write_query
+- Checking table structure → use get_table_schema
+</when_not_to_use>
+
+<examples>
+✓ "Why is my SELECT on orders slow?" → explain_query(query="SELECT ...")
+✓ "Should I add an index?" → explain_query with analyze=true
+✗ "Run this SELECT" → use read_query
+</examples>
+
+<safety>
+Set `analyze` to true for actual execution statistics (EXPLAIN ANALYZE).
+IMPORTANT: EXPLAIN ANALYZE actually executes the query! In read-only mode, only read-only statements are allowed with analyze.
+When analyze is false, returns EXPLAIN FORMAT=JSON output without executing.
+</safety>
+
+<what_it_returns>
+A JSON array of execution plan rows showing access methods, join types, row estimates, and costs.
+</what_it_returns>"#;
 }
 
 impl ToolBase for ExplainQueryTool {

--- a/crates/mysql/src/tools/get_table_schema.rs
+++ b/crates/mysql/src/tools/get_table_schema.rs
@@ -18,7 +18,24 @@ pub(crate) struct GetTableSchemaTool;
 
 impl GetTableSchemaTool {
     const NAME: &'static str = "get_table_schema";
-    const DESCRIPTION: &'static str = "Get column definitions (type, nullable, key, default) and foreign key\nrelationships for a table. Requires `database_name` and `table_name`.";
+    const DESCRIPTION: &'static str = r#"Get column definitions and foreign key relationships for a table. Requires `database_name` and `table_name` — call `list_databases` and `list_tables` first.
+
+<usecase>
+ALWAYS call this before writing queries to understand:
+- Column names and data types
+- Which columns are nullable, primary keys, or have defaults
+- Foreign key relationships for writing JOINs
+</usecase>
+
+<examples>
+✓ "What columns does the orders table have?" → get_table_schema(database_name="mydb", table_name="orders")
+✓ Before writing a SELECT → get_table_schema first to confirm column names
+✓ "How are users and orders related?" → check foreign keys in both tables
+</examples>
+
+<what_it_returns>
+A JSON object with table_name and columns keyed by column name, each containing type, nullable, key, default, and foreign_key info.
+</what_it_returns>"#;
 }
 
 impl ToolBase for GetTableSchemaTool {

--- a/crates/mysql/src/tools/list_databases.rs
+++ b/crates/mysql/src/tools/list_databases.rs
@@ -17,7 +17,23 @@ pub(crate) struct ListDatabasesTool;
 
 impl ListDatabasesTool {
     const NAME: &'static str = "list_databases";
-    const DESCRIPTION: &'static str = "List all accessible databases on the connected database server.\nCall this first to discover available database names.";
+    const DESCRIPTION: &'static str = r#"List all accessible databases on the connected server. Use this tool to discover what databases are available before using other tools.
+
+<usecase>
+ALWAYS call this tool FIRST when:
+- You need to explore what databases exist on the server
+- You need a database name for list_tables, get_table_schema, or query tools
+- The user asks what data is available
+</usecase>
+
+<examples>
+✓ "What databases are on this server?"
+✓ "Show me what's available" → call list_databases first
+</examples>
+
+<what_it_returns>
+A sorted JSON array of database name strings.
+</what_it_returns>"#;
 }
 
 impl ToolBase for ListDatabasesTool {

--- a/crates/mysql/src/tools/list_tables.rs
+++ b/crates/mysql/src/tools/list_tables.rs
@@ -16,8 +16,24 @@ pub(crate) struct ListTablesTool;
 
 impl ListTablesTool {
     const NAME: &'static str = "list_tables";
-    const DESCRIPTION: &'static str =
-        "List all tables in a specific database.\nRequires `database_name` from `list_databases`.";
+    const DESCRIPTION: &'static str = r#"List all tables in a specific database. Requires `database_name` — call `list_databases` first to discover available databases.
+
+<usecase>
+Use when:
+- Exploring a database to find relevant tables
+- Verifying a table exists before querying or inspecting it
+- The user asks what tables are in a database
+</usecase>
+
+<examples>
+✓ "What tables are in the mydb database?" → list_tables(database_name="mydb")
+✓ "Does a users table exist?" → list_tables to check
+✗ "Show me the columns of users" → use get_table_schema instead
+</examples>
+
+<what_it_returns>
+A sorted JSON array of table name strings.
+</what_it_returns>"#;
 }
 
 impl ToolBase for ListTablesTool {

--- a/crates/mysql/src/tools/read_query.rs
+++ b/crates/mysql/src/tools/read_query.rs
@@ -17,7 +17,34 @@ pub(crate) struct ReadQueryTool;
 
 impl ReadQueryTool {
     const NAME: &'static str = "read_query";
-    const DESCRIPTION: &'static str = "Execute a read-only SQL query (SELECT, SHOW, DESCRIBE, USE, EXPLAIN).";
+    const DESCRIPTION: &'static str = r#"Execute a read-only SQL query. Allowed statements: SELECT, SHOW, DESCRIBE, USE, EXPLAIN.
+
+<usecase>
+Use when:
+- Querying data from tables (SELECT with WHERE, JOIN, GROUP BY, etc.)
+- Aggregations: COUNT, SUM, AVG, GROUP BY, HAVING
+- Listing server variables or status (SHOW)
+- Viewing table structure (DESCRIBE)
+- Switching database context (USE)
+</usecase>
+
+<when_not_to_use>
+- Data changes (INSERT, UPDATE, DELETE) → use write_query
+- Query performance analysis → use explain_query
+- Discovering tables or columns → use list_tables or get_table_schema
+</when_not_to_use>
+
+<examples>
+✓ "SELECT * FROM users WHERE status = 'active'"
+✓ "SELECT COUNT(*) FROM orders GROUP BY region"
+✓ "SHOW TABLES" or "DESCRIBE users"
+✗ "INSERT INTO users ..." → use write_query
+✗ "EXPLAIN SELECT ..." → use explain_query for structured analysis
+</examples>
+
+<what_it_returns>
+A JSON array of row objects, each keyed by column name.
+</what_it_returns>"#;
 }
 
 impl ToolBase for ReadQueryTool {

--- a/crates/mysql/src/tools/write_query.rs
+++ b/crates/mysql/src/tools/write_query.rs
@@ -16,7 +16,31 @@ pub(crate) struct WriteQueryTool;
 
 impl WriteQueryTool {
     const NAME: &'static str = "write_query";
-    const DESCRIPTION: &'static str = "Execute a write SQL query (INSERT, UPDATE, DELETE, CREATE, ALTER, DROP).";
+    const DESCRIPTION: &'static str = r#"Execute a write SQL query (INSERT, UPDATE, DELETE, CREATE, ALTER, DROP).
+
+<usecase>
+Use when:
+- Inserting, updating, or deleting rows
+- Creating or altering tables, indexes, views, or other schema objects
+- Any data modification operation
+</usecase>
+
+<when_not_to_use>
+- Read-only queries (SELECT, SHOW) → use read_query
+- Query performance analysis → use explain_query
+- Creating/dropping entire databases → use create_database or drop_database
+</when_not_to_use>
+
+<examples>
+✓ "INSERT INTO users (name, email) VALUES ('Alice', 'alice@example.com')"
+✓ "UPDATE orders SET status = 'shipped' WHERE id = 42"
+✓ "CREATE TABLE logs (id INT PRIMARY KEY, message TEXT)"
+✗ "SELECT * FROM users" → use read_query
+</examples>
+
+<what_it_returns>
+A JSON array of affected/returning row objects, each keyed by column name.
+</what_it_returns>"#;
 }
 
 impl ToolBase for WriteQueryTool {

--- a/crates/postgres/src/handler.rs
+++ b/crates/postgres/src/handler.rs
@@ -32,14 +32,16 @@ const INSTRUCTIONS: &str = r"## Workflow
 3. Call `get_table_schema` with `database_name` and `table_name` to inspect columns, types, and foreign keys before writing queries.
 4. Use `read_query` for read-only SQL (SELECT, SHOW, EXPLAIN).
 5. Use `write_query` for data changes (INSERT, UPDATE, DELETE, CREATE, ALTER, DROP).
-6. Use `create_database` to create a new database.
-7. Use `drop_database` to drop an existing database.
+6. Use `explain_query` to analyze query execution plans and diagnose slow queries.
+7. Use `create_database` to create a new database.
+8. Use `drop_database` to drop an existing database.
+9. Use `drop_table` to remove a table from a database (supports `cascade` for foreign key dependencies).
 
 Tools accept an optional `database_name` parameter to query across databases without reconnecting.
 
 ## Constraints
 
-- The `write_query`, `create_database`, and `drop_database` tools are hidden when read-only mode is active.
+- The `write_query`, `create_database`, `drop_database`, and `drop_table` tools are hidden when read-only mode is active.
 - Multi-statement queries are not supported. Send one statement per request.";
 
 /// `PostgreSQL` database handler.

--- a/crates/postgres/src/tools/create_database.rs
+++ b/crates/postgres/src/tools/create_database.rs
@@ -16,7 +16,26 @@ pub(crate) struct CreateDatabaseTool;
 
 impl CreateDatabaseTool {
     const NAME: &'static str = "create_database";
-    const DESCRIPTION: &'static str = "Create a new database.";
+    const DESCRIPTION: &'static str = r#"Create a new database on the connected server.
+
+<usecase>
+Use when:
+- Setting up a new database for a project or application
+- The user asks to create a database
+</usecase>
+
+<examples>
+✓ "Create a database called analytics" → create_database(database_name="analytics")
+✗ "Create a table" → use write_query with CREATE TABLE
+</examples>
+
+<important>
+Database names must contain only alphanumeric characters and underscores.
+</important>
+
+<what_it_returns>
+A confirmation message with the created database name.
+</what_it_returns>"#;
 }
 
 impl ToolBase for CreateDatabaseTool {

--- a/crates/postgres/src/tools/drop_database.rs
+++ b/crates/postgres/src/tools/drop_database.rs
@@ -16,7 +16,27 @@ pub(crate) struct DropDatabaseTool;
 
 impl DropDatabaseTool {
     const NAME: &'static str = "drop_database";
-    const DESCRIPTION: &'static str = "Drop an existing database. Cannot drop the currently connected database.";
+    const DESCRIPTION: &'static str = r#"Drop an existing database from the connected server.
+
+<usecase>
+Use when:
+- Removing a database that is no longer needed
+- Cleaning up test or temporary databases
+</usecase>
+
+<examples>
+✓ "Drop the test_db database" → drop_database(database_name="test_db")
+✗ "Drop a table" → use drop_table instead
+</examples>
+
+<safety>
+IMPORTANT: This permanently deletes the database and ALL its data. This action cannot be undone.
+Cannot drop the database you are currently connected to.
+</safety>
+
+<what_it_returns>
+A confirmation message with the dropped database name.
+</what_it_returns>"#;
 }
 
 impl ToolBase for DropDatabaseTool {

--- a/crates/postgres/src/tools/drop_table.rs
+++ b/crates/postgres/src/tools/drop_table.rs
@@ -17,7 +17,30 @@ pub(crate) struct DropTableTool;
 
 impl DropTableTool {
     const NAME: &'static str = "drop_table";
-    const DESCRIPTION: &'static str = "Drop a table from a database. Checks for foreign key dependencies\nvia the database engine — use `cascade` to force on `PostgreSQL`.";
+    const DESCRIPTION: &'static str = r#"Drop a table from a database. Checks for foreign key dependencies via the database engine.
+
+<usecase>
+Use when:
+- Removing a table that is no longer needed
+- Cleaning up test or temporary tables
+</usecase>
+
+<examples>
+✓ "Drop the temp_logs table" → drop_table(database_name="mydb", table_name="temp_logs")
+✓ "Force drop with dependencies" → drop_table(..., cascade=true)
+✗ "Delete rows from a table" → use write_query with DELETE
+✗ "Drop a database" → use drop_database instead
+</examples>
+
+<safety>
+IMPORTANT: This permanently deletes the table and ALL its data. This action cannot be undone.
+Set `cascade` to true to also drop dependent foreign key constraints.
+Without cascade, the drop will fail if other tables reference this one.
+</safety>
+
+<what_it_returns>
+A confirmation message with the dropped table name.
+</what_it_returns>"#;
 }
 
 impl ToolBase for DropTableTool {

--- a/crates/postgres/src/tools/explain_query.rs
+++ b/crates/postgres/src/tools/explain_query.rs
@@ -17,7 +17,36 @@ pub(crate) struct ExplainQueryTool;
 
 impl ExplainQueryTool {
     const NAME: &'static str = "explain_query";
-    const DESCRIPTION: &'static str = "Return the execution plan for a SQL query.";
+    const DESCRIPTION: &'static str = r#"Return the execution plan for a SQL query to diagnose performance. Use this tool instead of running EXPLAIN directly through read_query — it provides structured JSON output. Accepts an optional `database_name` to explain queries against a different database.
+
+<usecase>
+Use when:
+- A query runs slowly and you need to understand why
+- Investigating performance bottlenecks
+- Planning index creation to optimize queries
+- Analyzing join methods, table scan strategies, and sort operations
+</usecase>
+
+<when_not_to_use>
+- Running actual queries → use read_query or write_query
+- Checking table structure → use get_table_schema
+</when_not_to_use>
+
+<examples>
+✓ "Why is my SELECT on orders slow?" → explain_query(query="SELECT ...")
+✓ "Should I add an index?" → explain_query with analyze=true
+✗ "Run this SELECT" → use read_query
+</examples>
+
+<safety>
+Set `analyze` to true for actual execution statistics (EXPLAIN ANALYZE).
+IMPORTANT: EXPLAIN ANALYZE actually executes the query! In read-only mode, only read-only statements are allowed with analyze.
+When analyze is false, returns EXPLAIN (FORMAT JSON) output without executing.
+</safety>
+
+<what_it_returns>
+A JSON array of execution plan rows showing access methods, join types, row estimates, and costs.
+</what_it_returns>"#;
 }
 
 impl ToolBase for ExplainQueryTool {

--- a/crates/postgres/src/tools/get_table_schema.rs
+++ b/crates/postgres/src/tools/get_table_schema.rs
@@ -18,7 +18,24 @@ pub(crate) struct GetTableSchemaTool;
 
 impl GetTableSchemaTool {
     const NAME: &'static str = "get_table_schema";
-    const DESCRIPTION: &'static str = "Get column definitions (type, nullable, key, default) and foreign key\nrelationships for a table. Requires `database_name` and `table_name`.";
+    const DESCRIPTION: &'static str = r#"Get column definitions and foreign key relationships for a table. Requires `database_name` and `table_name` — call `list_databases` and `list_tables` first.
+
+<usecase>
+ALWAYS call this before writing queries to understand:
+- Column names and data types
+- Which columns are nullable, primary keys, or have defaults
+- Foreign key relationships for writing JOINs
+</usecase>
+
+<examples>
+✓ "What columns does the orders table have?" → get_table_schema(database_name="mydb", table_name="orders")
+✓ Before writing a SELECT → get_table_schema first to confirm column names
+✓ "How are users and orders related?" → check foreign keys in both tables
+</examples>
+
+<what_it_returns>
+A JSON object with table_name and columns keyed by column name, each containing type, nullable, key, default, and foreign_key info.
+</what_it_returns>"#;
 }
 
 impl ToolBase for GetTableSchemaTool {

--- a/crates/postgres/src/tools/list_databases.rs
+++ b/crates/postgres/src/tools/list_databases.rs
@@ -18,7 +18,23 @@ pub(crate) struct ListDatabasesTool;
 
 impl ListDatabasesTool {
     const NAME: &'static str = "list_databases";
-    const DESCRIPTION: &'static str = "List all accessible databases on the connected database server.\nCall this first to discover available database names.";
+    const DESCRIPTION: &'static str = r#"List all accessible databases on the connected server. Use this tool to discover what databases are available before using other tools.
+
+<usecase>
+ALWAYS call this tool FIRST when:
+- You need to explore what databases exist on the server
+- You need a database name for list_tables, get_table_schema, or query tools
+- The user asks what data is available
+</usecase>
+
+<examples>
+✓ "What databases are on this server?"
+✓ "Show me what's available" → call list_databases first
+</examples>
+
+<what_it_returns>
+A sorted JSON array of database name strings.
+</what_it_returns>"#;
 }
 
 impl ToolBase for ListDatabasesTool {

--- a/crates/postgres/src/tools/list_tables.rs
+++ b/crates/postgres/src/tools/list_tables.rs
@@ -16,8 +16,24 @@ pub(crate) struct ListTablesTool;
 
 impl ListTablesTool {
     const NAME: &'static str = "list_tables";
-    const DESCRIPTION: &'static str =
-        "List all tables in a specific database.\nRequires `database_name` from `list_databases`.";
+    const DESCRIPTION: &'static str = r#"List all tables in a specific database. Requires `database_name` — call `list_databases` first to discover available databases.
+
+<usecase>
+Use when:
+- Exploring a database to find relevant tables
+- Verifying a table exists before querying or inspecting it
+- The user asks what tables are in a database
+</usecase>
+
+<examples>
+✓ "What tables are in the mydb database?" → list_tables(database_name="mydb")
+✓ "Does a users table exist?" → list_tables to check
+✗ "Show me the columns of users" → use get_table_schema instead
+</examples>
+
+<what_it_returns>
+A sorted JSON array of table name strings.
+</what_it_returns>"#;
 }
 
 impl ToolBase for ListTablesTool {

--- a/crates/postgres/src/tools/read_query.rs
+++ b/crates/postgres/src/tools/read_query.rs
@@ -17,7 +17,32 @@ pub(crate) struct ReadQueryTool;
 
 impl ReadQueryTool {
     const NAME: &'static str = "read_query";
-    const DESCRIPTION: &'static str = "Execute a read-only SQL query (SELECT, SHOW, DESCRIBE, USE, EXPLAIN).";
+    const DESCRIPTION: &'static str = r#"Execute a read-only SQL query. Allowed statements: SELECT, SHOW, EXPLAIN. Accepts an optional `database_name` to query across databases without reconnecting.
+
+<usecase>
+Use when:
+- Querying data from tables (SELECT with WHERE, JOIN, GROUP BY, etc.)
+- Aggregations: COUNT, SUM, AVG, GROUP BY, HAVING
+- Listing server configuration parameters (SHOW)
+</usecase>
+
+<when_not_to_use>
+- Data changes (INSERT, UPDATE, DELETE) → use write_query
+- Query performance analysis → use explain_query
+- Discovering tables or columns → use list_tables or get_table_schema
+</when_not_to_use>
+
+<examples>
+✓ "SELECT * FROM users WHERE status = 'active'"
+✓ "SELECT COUNT(*) FROM orders GROUP BY region"
+✓ "SHOW server_version"
+✗ "INSERT INTO users ..." → use write_query
+✗ "EXPLAIN SELECT ..." → use explain_query for structured analysis
+</examples>
+
+<what_it_returns>
+A JSON array of row objects, each keyed by column name.
+</what_it_returns>"#;
 }
 
 impl ToolBase for ReadQueryTool {

--- a/crates/postgres/src/tools/write_query.rs
+++ b/crates/postgres/src/tools/write_query.rs
@@ -16,7 +16,31 @@ pub(crate) struct WriteQueryTool;
 
 impl WriteQueryTool {
     const NAME: &'static str = "write_query";
-    const DESCRIPTION: &'static str = "Execute a write SQL query (INSERT, UPDATE, DELETE, CREATE, ALTER, DROP).";
+    const DESCRIPTION: &'static str = r#"Execute a write SQL query (INSERT, UPDATE, DELETE, CREATE, ALTER, DROP).
+
+<usecase>
+Use when:
+- Inserting, updating, or deleting rows
+- Creating or altering tables, indexes, views, or other schema objects
+- Any data modification operation
+</usecase>
+
+<when_not_to_use>
+- Read-only queries (SELECT, SHOW) → use read_query
+- Query performance analysis → use explain_query
+- Creating/dropping entire databases → use create_database or drop_database
+</when_not_to_use>
+
+<examples>
+✓ "INSERT INTO users (name, email) VALUES ('Alice', 'alice@example.com')"
+✓ "UPDATE orders SET status = 'shipped' WHERE id = 42"
+✓ "CREATE TABLE logs (id SERIAL PRIMARY KEY, message TEXT)"
+✗ "SELECT * FROM users" → use read_query
+</examples>
+
+<what_it_returns>
+A JSON array of affected/returning row objects, each keyed by column name.
+</what_it_returns>"#;
 }
 
 impl ToolBase for WriteQueryTool {

--- a/crates/sqlite/src/handler.rs
+++ b/crates/sqlite/src/handler.rs
@@ -27,12 +27,14 @@ const INSTRUCTIONS: &str = r"## Workflow
 
 1. Call `list_tables` to discover tables in the connected database.
 2. Call `get_table_schema` with a `table_name` to inspect columns, types, and foreign keys before writing queries.
-3. Use `read_query` for read-only SQL (SELECT, EXPLAIN).
+3. Use `read_query` for read-only SQL (SELECT).
 4. Use `write_query` for data changes (INSERT, UPDATE, DELETE, CREATE, ALTER, DROP).
+5. Use `explain_query` to analyze query execution plans and diagnose slow queries.
+6. Use `drop_table` to remove a table from the database.
 
 ## Constraints
 
-- The `write_query` tool is hidden when read-only mode is active.
+- The `write_query` and `drop_table` tools are hidden when read-only mode is active.
 - Multi-statement queries are not supported. Send one statement per request.";
 
 /// `SQLite` file-based database handler.
@@ -168,15 +170,9 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn list_tables_metadata_matches_macro_parity() {
+    async fn list_tables_annotations() {
         let router = handler(false).tool_router;
         let tool = router.get("list_tables").expect("list_tables registered");
-
-        assert_eq!(tool.name, "list_tables");
-        assert_eq!(
-            tool.description.as_deref(),
-            Some("List all tables in the connected `SQLite` database.")
-        );
 
         let annotations = tool.annotations.as_ref().expect("annotations present");
         assert_eq!(annotations.read_only_hint, Some(true));

--- a/crates/sqlite/src/tools/drop_table.rs
+++ b/crates/sqlite/src/tools/drop_table.rs
@@ -17,7 +17,26 @@ pub(crate) struct DropTableTool;
 
 impl DropTableTool {
     const NAME: &'static str = "drop_table";
-    const DESCRIPTION: &'static str = "Drop a table from the database.";
+    const DESCRIPTION: &'static str = r#"Drop a table from the database.
+
+<usecase>
+Use when:
+- Removing a table that is no longer needed
+- Cleaning up test or temporary tables
+</usecase>
+
+<examples>
+✓ "Drop the temp_logs table" → drop_table(table_name="temp_logs")
+✗ "Delete rows from a table" → use write_query with DELETE
+</examples>
+
+<safety>
+IMPORTANT: This permanently deletes the table and ALL its data. This action cannot be undone.
+</safety>
+
+<what_it_returns>
+A confirmation message with the dropped table name.
+</what_it_returns>"#;
 }
 
 impl ToolBase for DropTableTool {

--- a/crates/sqlite/src/tools/explain_query.rs
+++ b/crates/sqlite/src/tools/explain_query.rs
@@ -17,7 +17,29 @@ pub(crate) struct ExplainQueryTool;
 
 impl ExplainQueryTool {
     const NAME: &'static str = "explain_query";
-    const DESCRIPTION: &'static str = "Return the execution plan for a SQL query.";
+    const DESCRIPTION: &'static str = r#"Return the execution plan for a SQL query to diagnose performance. Use this tool instead of running EXPLAIN directly through read_query — it provides structured output via EXPLAIN QUERY PLAN.
+
+<usecase>
+Use when:
+- A query runs slowly and you need to understand why
+- Understanding how SQLite will scan tables and use indexes
+- Deciding whether to add an index
+</usecase>
+
+<when_not_to_use>
+- Running actual queries → use read_query or write_query
+- Checking table structure → use get_table_schema
+</when_not_to_use>
+
+<examples>
+✓ "Why is my SELECT on orders slow?" → explain_query(query="SELECT ...")
+✓ "How will SQLite execute this join?" → explain_query
+✗ "Run this SELECT" → use read_query
+</examples>
+
+<what_it_returns>
+A JSON array of EXPLAIN QUERY PLAN rows showing how SQLite will scan tables, use indexes, and order operations.
+</what_it_returns>"#;
 }
 
 impl ToolBase for ExplainQueryTool {

--- a/crates/sqlite/src/tools/get_table_schema.rs
+++ b/crates/sqlite/src/tools/get_table_schema.rs
@@ -19,8 +19,24 @@ pub(crate) struct GetTableSchemaTool;
 
 impl GetTableSchemaTool {
     const NAME: &'static str = "get_table_schema";
-    const DESCRIPTION: &'static str =
-        "Get column definitions (type, nullable, key, default) and foreign key\nrelationships for a table.";
+    const DESCRIPTION: &'static str = r#"Get column definitions and foreign key relationships for a table. Requires `table_name` — call `list_tables` first.
+
+<usecase>
+ALWAYS call this before writing queries to understand:
+- Column names and data types
+- Which columns are nullable, primary keys, or have defaults
+- Foreign key relationships for writing JOINs
+</usecase>
+
+<examples>
+✓ "What columns does the orders table have?" → get_table_schema(table_name="orders")
+✓ Before writing a SELECT → get_table_schema first to confirm column names
+✓ "How are users and orders related?" → check foreign keys in both tables
+</examples>
+
+<what_it_returns>
+A JSON object with table_name and columns keyed by column name, each containing type, nullable, key, default, and foreign_key info.
+</what_it_returns>"#;
 }
 
 impl ToolBase for GetTableSchemaTool {

--- a/crates/sqlite/src/tools/list_tables.rs
+++ b/crates/sqlite/src/tools/list_tables.rs
@@ -18,7 +18,24 @@ pub(crate) struct ListTablesTool;
 
 impl ListTablesTool {
     const NAME: &'static str = "list_tables";
-    const DESCRIPTION: &'static str = "List all tables in the connected `SQLite` database.";
+    const DESCRIPTION: &'static str = r#"List all tables in the connected SQLite database. Use this tool to discover what tables are available before using other tools.
+
+<usecase>
+ALWAYS call this tool FIRST when:
+- You need to explore what tables exist in the database
+- You need a table name for get_table_schema or query tools
+- The user asks what data is available
+</usecase>
+
+<examples>
+✓ "What tables are in this database?"
+✓ "Does a users table exist?" → list_tables to check
+✗ "Show me the columns of users" → use get_table_schema instead
+</examples>
+
+<what_it_returns>
+A sorted JSON array of table name strings.
+</what_it_returns>"#;
 }
 
 impl ToolBase for ListTablesTool {

--- a/crates/sqlite/src/tools/read_query.rs
+++ b/crates/sqlite/src/tools/read_query.rs
@@ -18,7 +18,31 @@ pub(crate) struct ReadQueryTool;
 
 impl ReadQueryTool {
     const NAME: &'static str = "read_query";
-    const DESCRIPTION: &'static str = "Execute a read-only SQL query (SELECT, SHOW, DESCRIBE, USE, EXPLAIN).";
+    const DESCRIPTION: &'static str = r#"Execute a read-only SQL query. Allowed statements: SELECT.
+
+<usecase>
+Use when:
+- Querying data from tables (SELECT with WHERE, JOIN, GROUP BY, etc.)
+- Aggregations: COUNT, SUM, AVG, GROUP BY, HAVING
+- Checking data existence or counts
+</usecase>
+
+<when_not_to_use>
+- Data changes (INSERT, UPDATE, DELETE) → use write_query
+- Query performance analysis → use explain_query
+- Discovering tables or columns → use list_tables or get_table_schema
+</when_not_to_use>
+
+<examples>
+✓ "SELECT * FROM users WHERE status = 'active'"
+✓ "SELECT COUNT(*) FROM orders GROUP BY region"
+✗ "INSERT INTO users ..." → use write_query
+✗ "EXPLAIN SELECT ..." → use explain_query for structured analysis
+</examples>
+
+<what_it_returns>
+A JSON array of row objects, each keyed by column name.
+</what_it_returns>"#;
 }
 
 impl ToolBase for ReadQueryTool {

--- a/crates/sqlite/src/tools/write_query.rs
+++ b/crates/sqlite/src/tools/write_query.rs
@@ -17,7 +17,30 @@ pub(crate) struct WriteQueryTool;
 
 impl WriteQueryTool {
     const NAME: &'static str = "write_query";
-    const DESCRIPTION: &'static str = "Execute a write SQL query (INSERT, UPDATE, DELETE, CREATE, ALTER, DROP).";
+    const DESCRIPTION: &'static str = r#"Execute a write SQL query (INSERT, UPDATE, DELETE, CREATE, ALTER, DROP).
+
+<usecase>
+Use when:
+- Inserting, updating, or deleting rows
+- Creating or altering tables, indexes, views, or other schema objects
+- Any data modification operation
+</usecase>
+
+<when_not_to_use>
+- Read-only queries (SELECT) → use read_query
+- Query performance analysis → use explain_query
+</when_not_to_use>
+
+<examples>
+✓ "INSERT INTO users (name, email) VALUES ('Alice', 'alice@example.com')"
+✓ "UPDATE orders SET status = 'shipped' WHERE id = 42"
+✓ "CREATE TABLE logs (id INTEGER PRIMARY KEY, message TEXT)"
+✗ "SELECT * FROM users" → use read_query
+</examples>
+
+<what_it_returns>
+A JSON array of affected/returning row objects, each keyed by column name.
+</what_it_returns>"#;
 }
 
 impl ToolBase for WriteQueryTool {

--- a/tests/approval/snapshots/approval_mysql__list_tools.snap
+++ b/tests/approval/snapshots/approval_mysql__list_tools.snap
@@ -1,12 +1,12 @@
 ---
 source: tests/approval/mysql.rs
-assertion_line: 41
+assertion_line: 42
 expression: tools
 ---
 [
   {
     "name": "create_database",
-    "description": "Create a new database.",
+    "description": "Create a new database on the connected server.\n\n<usecase>\nUse when:\n- Setting up a new database for a project or application\n- The user asks to create a database\n</usecase>\n\n<examples>\n✓ \"Create a database called analytics\" → create_database(database_name=\"analytics\")\n✗ \"Create a table\" → use write_query with CREATE TABLE\n</examples>\n\n<important>\nDatabase names must contain only alphanumeric characters and underscores.\nIf the database already exists, returns a message indicating so without error.\n</important>\n\n<what_it_returns>\nA confirmation message with the created database name.\n</what_it_returns>",
     "inputSchema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "description": "Request for the `create_database` tool.",
@@ -46,7 +46,7 @@ expression: tools
   },
   {
     "name": "drop_database",
-    "description": "Drop an existing database. Cannot drop the currently connected database.",
+    "description": "Drop an existing database from the connected server.\n\n<usecase>\nUse when:\n- Removing a database that is no longer needed\n- Cleaning up test or temporary databases\n</usecase>\n\n<examples>\n✓ \"Drop the test_db database\" → drop_database(database_name=\"test_db\")\n✗ \"Drop a table\" → use drop_table instead\n</examples>\n\n<safety>\nIMPORTANT: This permanently deletes the database and ALL its data. This action cannot be undone.\nCannot drop the database you are currently connected to.\n</safety>\n\n<what_it_returns>\nA confirmation message with the dropped database name.\n</what_it_returns>",
     "inputSchema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "description": "Request for the `drop_database` tool.",
@@ -86,7 +86,7 @@ expression: tools
   },
   {
     "name": "drop_table",
-    "description": "Drop a table from a database.",
+    "description": "Drop a table from a database.\n\n<usecase>\nUse when:\n- Removing a table that is no longer needed\n- Cleaning up test or temporary tables\n</usecase>\n\n<examples>\n✓ \"Drop the temp_logs table from mydb\" → drop_table(database_name=\"mydb\", table_name=\"temp_logs\")\n✗ \"Delete rows from a table\" → use write_query with DELETE\n✗ \"Drop a database\" → use drop_database instead\n</examples>\n\n<safety>\nIMPORTANT: This permanently deletes the table and ALL its data. This action cannot be undone.\nIf the table has foreign key dependencies, the drop will fail — resolve dependencies first.\n</safety>\n\n<what_it_returns>\nA confirmation message with the dropped table name.\n</what_it_returns>",
     "inputSchema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "description": "Request for the `drop_table` tool.",
@@ -131,7 +131,7 @@ expression: tools
   },
   {
     "name": "explain_query",
-    "description": "Return the execution plan for a SQL query.",
+    "description": "Return the execution plan for a SQL query to diagnose performance. Use this tool instead of running EXPLAIN directly through read_query — it provides structured output.\n\n<usecase>\nUse when:\n- A query runs slowly and you need to understand why\n- Investigating performance bottlenecks\n- Planning index creation to optimize queries\n- Analyzing join methods, table scan strategies, and sort operations\n</usecase>\n\n<when_not_to_use>\n- Running actual queries → use read_query or write_query\n- Checking table structure → use get_table_schema\n</when_not_to_use>\n\n<examples>\n✓ \"Why is my SELECT on orders slow?\" → explain_query(query=\"SELECT ...\")\n✓ \"Should I add an index?\" → explain_query with analyze=true\n✗ \"Run this SELECT\" → use read_query\n</examples>\n\n<safety>\nSet `analyze` to true for actual execution statistics (EXPLAIN ANALYZE).\nIMPORTANT: EXPLAIN ANALYZE actually executes the query! In read-only mode, only read-only statements are allowed with analyze.\nWhen analyze is false, returns EXPLAIN FORMAT=JSON output without executing.\n</safety>\n\n<what_it_returns>\nA JSON array of execution plan rows showing access methods, join types, row estimates, and costs.\n</what_it_returns>",
     "inputSchema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "description": "Request for the `explain_query` tool.",
@@ -180,7 +180,7 @@ expression: tools
   },
   {
     "name": "get_table_schema",
-    "description": "Get column definitions (type, nullable, key, default) and foreign key\nrelationships for a table. Requires `database_name` and `table_name`.",
+    "description": "Get column definitions and foreign key relationships for a table. Requires `database_name` and `table_name` — call `list_databases` and `list_tables` first.\n\n<usecase>\nALWAYS call this before writing queries to understand:\n- Column names and data types\n- Which columns are nullable, primary keys, or have defaults\n- Foreign key relationships for writing JOINs\n</usecase>\n\n<examples>\n✓ \"What columns does the orders table have?\" → get_table_schema(database_name=\"mydb\", table_name=\"orders\")\n✓ Before writing a SELECT → get_table_schema first to confirm column names\n✓ \"How are users and orders related?\" → check foreign keys in both tables\n</examples>\n\n<what_it_returns>\nA JSON object with table_name and columns keyed by column name, each containing type, nullable, key, default, and foreign_key info.\n</what_it_returns>",
     "inputSchema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "description": "Request for the `get_table_schema` tool.",
@@ -229,7 +229,7 @@ expression: tools
   },
   {
     "name": "list_databases",
-    "description": "List all accessible databases on the connected database server.\nCall this first to discover available database names.",
+    "description": "List all accessible databases on the connected server. Use this tool to discover what databases are available before using other tools.\n\n<usecase>\nALWAYS call this tool FIRST when:\n- You need to explore what databases exist on the server\n- You need a database name for list_tables, get_table_schema, or query tools\n- The user asks what data is available\n</usecase>\n\n<examples>\n✓ \"What databases are on this server?\"\n✓ \"Show me what's available\" → call list_databases first\n</examples>\n\n<what_it_returns>\nA sorted JSON array of database name strings.\n</what_it_returns>",
     "inputSchema": {
       "properties": {},
       "type": "object"
@@ -261,7 +261,7 @@ expression: tools
   },
   {
     "name": "list_tables",
-    "description": "List all tables in a specific database.\nRequires `database_name` from `list_databases`.",
+    "description": "List all tables in a specific database. Requires `database_name` — call `list_databases` first to discover available databases.\n\n<usecase>\nUse when:\n- Exploring a database to find relevant tables\n- Verifying a table exists before querying or inspecting it\n- The user asks what tables are in a database\n</usecase>\n\n<examples>\n✓ \"What tables are in the mydb database?\" → list_tables(database_name=\"mydb\")\n✓ \"Does a users table exist?\" → list_tables to check\n✗ \"Show me the columns of users\" → use get_table_schema instead\n</examples>\n\n<what_it_returns>\nA sorted JSON array of table name strings.\n</what_it_returns>",
     "inputSchema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "description": "Request for the `list_tables` tool.",
@@ -304,7 +304,7 @@ expression: tools
   },
   {
     "name": "read_query",
-    "description": "Execute a read-only SQL query (SELECT, SHOW, DESCRIBE, USE, EXPLAIN).",
+    "description": "Execute a read-only SQL query. Allowed statements: SELECT, SHOW, DESCRIBE, USE, EXPLAIN.\n\n<usecase>\nUse when:\n- Querying data from tables (SELECT with WHERE, JOIN, GROUP BY, etc.)\n- Aggregations: COUNT, SUM, AVG, GROUP BY, HAVING\n- Listing server variables or status (SHOW)\n- Viewing table structure (DESCRIBE)\n- Switching database context (USE)\n</usecase>\n\n<when_not_to_use>\n- Data changes (INSERT, UPDATE, DELETE) → use write_query\n- Query performance analysis → use explain_query\n- Discovering tables or columns → use list_tables or get_table_schema\n</when_not_to_use>\n\n<examples>\n✓ \"SELECT * FROM users WHERE status = 'active'\"\n✓ \"SELECT COUNT(*) FROM orders GROUP BY region\"\n✓ \"SHOW TABLES\" or \"DESCRIBE users\"\n✗ \"INSERT INTO users ...\" → use write_query\n✗ \"EXPLAIN SELECT ...\" → use explain_query for structured analysis\n</examples>\n\n<what_it_returns>\nA JSON array of row objects, each keyed by column name.\n</what_it_returns>",
     "inputSchema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "description": "Request for the `read_query` and `write_query` tools.",
@@ -348,7 +348,7 @@ expression: tools
   },
   {
     "name": "write_query",
-    "description": "Execute a write SQL query (INSERT, UPDATE, DELETE, CREATE, ALTER, DROP).",
+    "description": "Execute a write SQL query (INSERT, UPDATE, DELETE, CREATE, ALTER, DROP).\n\n<usecase>\nUse when:\n- Inserting, updating, or deleting rows\n- Creating or altering tables, indexes, views, or other schema objects\n- Any data modification operation\n</usecase>\n\n<when_not_to_use>\n- Read-only queries (SELECT, SHOW) → use read_query\n- Query performance analysis → use explain_query\n- Creating/dropping entire databases → use create_database or drop_database\n</when_not_to_use>\n\n<examples>\n✓ \"INSERT INTO users (name, email) VALUES ('Alice', 'alice@example.com')\"\n✓ \"UPDATE orders SET status = 'shipped' WHERE id = 42\"\n✓ \"CREATE TABLE logs (id INT PRIMARY KEY, message TEXT)\"\n✗ \"SELECT * FROM users\" → use read_query\n</examples>\n\n<what_it_returns>\nA JSON array of affected/returning row objects, each keyed by column name.\n</what_it_returns>",
     "inputSchema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "description": "Request for the `read_query` and `write_query` tools.",

--- a/tests/approval/snapshots/approval_mysql__list_tools_read_only.snap
+++ b/tests/approval/snapshots/approval_mysql__list_tools_read_only.snap
@@ -1,12 +1,12 @@
 ---
 source: tests/approval/mysql.rs
-assertion_line: 50
+assertion_line: 51
 expression: tools
 ---
 [
   {
     "name": "explain_query",
-    "description": "Return the execution plan for a SQL query.",
+    "description": "Return the execution plan for a SQL query to diagnose performance. Use this tool instead of running EXPLAIN directly through read_query — it provides structured output.\n\n<usecase>\nUse when:\n- A query runs slowly and you need to understand why\n- Investigating performance bottlenecks\n- Planning index creation to optimize queries\n- Analyzing join methods, table scan strategies, and sort operations\n</usecase>\n\n<when_not_to_use>\n- Running actual queries → use read_query or write_query\n- Checking table structure → use get_table_schema\n</when_not_to_use>\n\n<examples>\n✓ \"Why is my SELECT on orders slow?\" → explain_query(query=\"SELECT ...\")\n✓ \"Should I add an index?\" → explain_query with analyze=true\n✗ \"Run this SELECT\" → use read_query\n</examples>\n\n<safety>\nSet `analyze` to true for actual execution statistics (EXPLAIN ANALYZE).\nIMPORTANT: EXPLAIN ANALYZE actually executes the query! In read-only mode, only read-only statements are allowed with analyze.\nWhen analyze is false, returns EXPLAIN FORMAT=JSON output without executing.\n</safety>\n\n<what_it_returns>\nA JSON array of execution plan rows showing access methods, join types, row estimates, and costs.\n</what_it_returns>",
     "inputSchema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "description": "Request for the `explain_query` tool.",
@@ -55,7 +55,7 @@ expression: tools
   },
   {
     "name": "get_table_schema",
-    "description": "Get column definitions (type, nullable, key, default) and foreign key\nrelationships for a table. Requires `database_name` and `table_name`.",
+    "description": "Get column definitions and foreign key relationships for a table. Requires `database_name` and `table_name` — call `list_databases` and `list_tables` first.\n\n<usecase>\nALWAYS call this before writing queries to understand:\n- Column names and data types\n- Which columns are nullable, primary keys, or have defaults\n- Foreign key relationships for writing JOINs\n</usecase>\n\n<examples>\n✓ \"What columns does the orders table have?\" → get_table_schema(database_name=\"mydb\", table_name=\"orders\")\n✓ Before writing a SELECT → get_table_schema first to confirm column names\n✓ \"How are users and orders related?\" → check foreign keys in both tables\n</examples>\n\n<what_it_returns>\nA JSON object with table_name and columns keyed by column name, each containing type, nullable, key, default, and foreign_key info.\n</what_it_returns>",
     "inputSchema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "description": "Request for the `get_table_schema` tool.",
@@ -104,7 +104,7 @@ expression: tools
   },
   {
     "name": "list_databases",
-    "description": "List all accessible databases on the connected database server.\nCall this first to discover available database names.",
+    "description": "List all accessible databases on the connected server. Use this tool to discover what databases are available before using other tools.\n\n<usecase>\nALWAYS call this tool FIRST when:\n- You need to explore what databases exist on the server\n- You need a database name for list_tables, get_table_schema, or query tools\n- The user asks what data is available\n</usecase>\n\n<examples>\n✓ \"What databases are on this server?\"\n✓ \"Show me what's available\" → call list_databases first\n</examples>\n\n<what_it_returns>\nA sorted JSON array of database name strings.\n</what_it_returns>",
     "inputSchema": {
       "properties": {},
       "type": "object"
@@ -136,7 +136,7 @@ expression: tools
   },
   {
     "name": "list_tables",
-    "description": "List all tables in a specific database.\nRequires `database_name` from `list_databases`.",
+    "description": "List all tables in a specific database. Requires `database_name` — call `list_databases` first to discover available databases.\n\n<usecase>\nUse when:\n- Exploring a database to find relevant tables\n- Verifying a table exists before querying or inspecting it\n- The user asks what tables are in a database\n</usecase>\n\n<examples>\n✓ \"What tables are in the mydb database?\" → list_tables(database_name=\"mydb\")\n✓ \"Does a users table exist?\" → list_tables to check\n✗ \"Show me the columns of users\" → use get_table_schema instead\n</examples>\n\n<what_it_returns>\nA sorted JSON array of table name strings.\n</what_it_returns>",
     "inputSchema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "description": "Request for the `list_tables` tool.",
@@ -179,7 +179,7 @@ expression: tools
   },
   {
     "name": "read_query",
-    "description": "Execute a read-only SQL query (SELECT, SHOW, DESCRIBE, USE, EXPLAIN).",
+    "description": "Execute a read-only SQL query. Allowed statements: SELECT, SHOW, DESCRIBE, USE, EXPLAIN.\n\n<usecase>\nUse when:\n- Querying data from tables (SELECT with WHERE, JOIN, GROUP BY, etc.)\n- Aggregations: COUNT, SUM, AVG, GROUP BY, HAVING\n- Listing server variables or status (SHOW)\n- Viewing table structure (DESCRIBE)\n- Switching database context (USE)\n</usecase>\n\n<when_not_to_use>\n- Data changes (INSERT, UPDATE, DELETE) → use write_query\n- Query performance analysis → use explain_query\n- Discovering tables or columns → use list_tables or get_table_schema\n</when_not_to_use>\n\n<examples>\n✓ \"SELECT * FROM users WHERE status = 'active'\"\n✓ \"SELECT COUNT(*) FROM orders GROUP BY region\"\n✓ \"SHOW TABLES\" or \"DESCRIBE users\"\n✗ \"INSERT INTO users ...\" → use write_query\n✗ \"EXPLAIN SELECT ...\" → use explain_query for structured analysis\n</examples>\n\n<what_it_returns>\nA JSON array of row objects, each keyed by column name.\n</what_it_returns>",
     "inputSchema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "description": "Request for the `read_query` and `write_query` tools.",

--- a/tests/approval/snapshots/approval_mysql__server_info.snap
+++ b/tests/approval/snapshots/approval_mysql__server_info.snap
@@ -1,6 +1,6 @@
 ---
 source: tests/approval/mysql.rs
-assertion_line: 30
+assertion_line: 31
 expression: info
 ---
 {
@@ -15,5 +15,5 @@ expression: info
     "description": "Database MCP Server for MySQL and MariaDB",
     "websiteUrl": "https://database.haymon.ai"
   },
-  "instructions": "## Workflow\n\n1. Call `list_databases` to discover available databases.\n2. Call `list_tables` with a `database_name` to see its tables.\n3. Call `get_table_schema` with `database_name` and `table_name` to inspect columns, types, and foreign keys before writing queries.\n4. Use `read_query` for read-only SQL (SELECT, SHOW, DESCRIBE, USE, EXPLAIN).\n5. Use `write_query` for data changes (INSERT, UPDATE, DELETE, CREATE, ALTER, DROP).\n6. Use `create_database` to create a new database.\n7. Use `drop_database` to drop an existing database.\n\n## Constraints\n\n- The `write_query`, `create_database`, and `drop_database` tools are hidden when read-only mode is active.\n- Multi-statement queries are not supported. Send one statement per request."
+  "instructions": "## Workflow\n\n1. Call `list_databases` to discover available databases.\n2. Call `list_tables` with a `database_name` to see its tables.\n3. Call `get_table_schema` with `database_name` and `table_name` to inspect columns, types, and foreign keys before writing queries.\n4. Use `read_query` for read-only SQL (SELECT, SHOW, DESCRIBE, USE, EXPLAIN).\n5. Use `write_query` for data changes (INSERT, UPDATE, DELETE, CREATE, ALTER, DROP).\n6. Use `explain_query` to analyze query execution plans and diagnose slow queries.\n7. Use `create_database` to create a new database.\n8. Use `drop_database` to drop an existing database.\n9. Use `drop_table` to remove a table from a database.\n\n## Constraints\n\n- The `write_query`, `create_database`, `drop_database`, and `drop_table` tools are hidden when read-only mode is active.\n- Multi-statement queries are not supported. Send one statement per request."
 }

--- a/tests/approval/snapshots/approval_postgres__list_tools.snap
+++ b/tests/approval/snapshots/approval_postgres__list_tools.snap
@@ -1,12 +1,12 @@
 ---
 source: tests/approval/postgres.rs
-assertion_line: 44
+assertion_line: 43
 expression: tools
 ---
 [
   {
     "name": "create_database",
-    "description": "Create a new database.",
+    "description": "Create a new database on the connected server.\n\n<usecase>\nUse when:\n- Setting up a new database for a project or application\n- The user asks to create a database\n</usecase>\n\n<examples>\n✓ \"Create a database called analytics\" → create_database(database_name=\"analytics\")\n✗ \"Create a table\" → use write_query with CREATE TABLE\n</examples>\n\n<important>\nDatabase names must contain only alphanumeric characters and underscores.\n</important>\n\n<what_it_returns>\nA confirmation message with the created database name.\n</what_it_returns>",
     "inputSchema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "description": "Request for the `create_database` tool.",
@@ -46,7 +46,7 @@ expression: tools
   },
   {
     "name": "drop_database",
-    "description": "Drop an existing database. Cannot drop the currently connected database.",
+    "description": "Drop an existing database from the connected server.\n\n<usecase>\nUse when:\n- Removing a database that is no longer needed\n- Cleaning up test or temporary databases\n</usecase>\n\n<examples>\n✓ \"Drop the test_db database\" → drop_database(database_name=\"test_db\")\n✗ \"Drop a table\" → use drop_table instead\n</examples>\n\n<safety>\nIMPORTANT: This permanently deletes the database and ALL its data. This action cannot be undone.\nCannot drop the database you are currently connected to.\n</safety>\n\n<what_it_returns>\nA confirmation message with the dropped database name.\n</what_it_returns>",
     "inputSchema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "description": "Request for the `drop_database` tool.",
@@ -86,7 +86,7 @@ expression: tools
   },
   {
     "name": "drop_table",
-    "description": "Drop a table from a database. Checks for foreign key dependencies\nvia the database engine — use `cascade` to force on `PostgreSQL`.",
+    "description": "Drop a table from a database. Checks for foreign key dependencies via the database engine.\n\n<usecase>\nUse when:\n- Removing a table that is no longer needed\n- Cleaning up test or temporary tables\n</usecase>\n\n<examples>\n✓ \"Drop the temp_logs table\" → drop_table(database_name=\"mydb\", table_name=\"temp_logs\")\n✓ \"Force drop with dependencies\" → drop_table(..., cascade=true)\n✗ \"Delete rows from a table\" → use write_query with DELETE\n✗ \"Drop a database\" → use drop_database instead\n</examples>\n\n<safety>\nIMPORTANT: This permanently deletes the table and ALL its data. This action cannot be undone.\nSet `cascade` to true to also drop dependent foreign key constraints.\nWithout cascade, the drop will fail if other tables reference this one.\n</safety>\n\n<what_it_returns>\nA confirmation message with the dropped table name.\n</what_it_returns>",
     "inputSchema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "description": "Request for the `drop_table` tool.",
@@ -136,7 +136,7 @@ expression: tools
   },
   {
     "name": "explain_query",
-    "description": "Return the execution plan for a SQL query.",
+    "description": "Return the execution plan for a SQL query to diagnose performance. Use this tool instead of running EXPLAIN directly through read_query — it provides structured JSON output. Accepts an optional `database_name` to explain queries against a different database.\n\n<usecase>\nUse when:\n- A query runs slowly and you need to understand why\n- Investigating performance bottlenecks\n- Planning index creation to optimize queries\n- Analyzing join methods, table scan strategies, and sort operations\n</usecase>\n\n<when_not_to_use>\n- Running actual queries → use read_query or write_query\n- Checking table structure → use get_table_schema\n</when_not_to_use>\n\n<examples>\n✓ \"Why is my SELECT on orders slow?\" → explain_query(query=\"SELECT ...\")\n✓ \"Should I add an index?\" → explain_query with analyze=true\n✗ \"Run this SELECT\" → use read_query\n</examples>\n\n<safety>\nSet `analyze` to true for actual execution statistics (EXPLAIN ANALYZE).\nIMPORTANT: EXPLAIN ANALYZE actually executes the query! In read-only mode, only read-only statements are allowed with analyze.\nWhen analyze is false, returns EXPLAIN (FORMAT JSON) output without executing.\n</safety>\n\n<what_it_returns>\nA JSON array of execution plan rows showing access methods, join types, row estimates, and costs.\n</what_it_returns>",
     "inputSchema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "description": "Request for the `explain_query` tool.",
@@ -185,7 +185,7 @@ expression: tools
   },
   {
     "name": "get_table_schema",
-    "description": "Get column definitions (type, nullable, key, default) and foreign key\nrelationships for a table. Requires `database_name` and `table_name`.",
+    "description": "Get column definitions and foreign key relationships for a table. Requires `database_name` and `table_name` — call `list_databases` and `list_tables` first.\n\n<usecase>\nALWAYS call this before writing queries to understand:\n- Column names and data types\n- Which columns are nullable, primary keys, or have defaults\n- Foreign key relationships for writing JOINs\n</usecase>\n\n<examples>\n✓ \"What columns does the orders table have?\" → get_table_schema(database_name=\"mydb\", table_name=\"orders\")\n✓ Before writing a SELECT → get_table_schema first to confirm column names\n✓ \"How are users and orders related?\" → check foreign keys in both tables\n</examples>\n\n<what_it_returns>\nA JSON object with table_name and columns keyed by column name, each containing type, nullable, key, default, and foreign_key info.\n</what_it_returns>",
     "inputSchema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "description": "Request for the `get_table_schema` tool.",
@@ -234,7 +234,7 @@ expression: tools
   },
   {
     "name": "list_databases",
-    "description": "List all accessible databases on the connected database server.\nCall this first to discover available database names.",
+    "description": "List all accessible databases on the connected server. Use this tool to discover what databases are available before using other tools.\n\n<usecase>\nALWAYS call this tool FIRST when:\n- You need to explore what databases exist on the server\n- You need a database name for list_tables, get_table_schema, or query tools\n- The user asks what data is available\n</usecase>\n\n<examples>\n✓ \"What databases are on this server?\"\n✓ \"Show me what's available\" → call list_databases first\n</examples>\n\n<what_it_returns>\nA sorted JSON array of database name strings.\n</what_it_returns>",
     "inputSchema": {
       "properties": {},
       "type": "object"
@@ -266,7 +266,7 @@ expression: tools
   },
   {
     "name": "list_tables",
-    "description": "List all tables in a specific database.\nRequires `database_name` from `list_databases`.",
+    "description": "List all tables in a specific database. Requires `database_name` — call `list_databases` first to discover available databases.\n\n<usecase>\nUse when:\n- Exploring a database to find relevant tables\n- Verifying a table exists before querying or inspecting it\n- The user asks what tables are in a database\n</usecase>\n\n<examples>\n✓ \"What tables are in the mydb database?\" → list_tables(database_name=\"mydb\")\n✓ \"Does a users table exist?\" → list_tables to check\n✗ \"Show me the columns of users\" → use get_table_schema instead\n</examples>\n\n<what_it_returns>\nA sorted JSON array of table name strings.\n</what_it_returns>",
     "inputSchema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "description": "Request for the `list_tables` tool.",
@@ -309,7 +309,7 @@ expression: tools
   },
   {
     "name": "read_query",
-    "description": "Execute a read-only SQL query (SELECT, SHOW, DESCRIBE, USE, EXPLAIN).",
+    "description": "Execute a read-only SQL query. Allowed statements: SELECT, SHOW, EXPLAIN. Accepts an optional `database_name` to query across databases without reconnecting.\n\n<usecase>\nUse when:\n- Querying data from tables (SELECT with WHERE, JOIN, GROUP BY, etc.)\n- Aggregations: COUNT, SUM, AVG, GROUP BY, HAVING\n- Listing server configuration parameters (SHOW)\n</usecase>\n\n<when_not_to_use>\n- Data changes (INSERT, UPDATE, DELETE) → use write_query\n- Query performance analysis → use explain_query\n- Discovering tables or columns → use list_tables or get_table_schema\n</when_not_to_use>\n\n<examples>\n✓ \"SELECT * FROM users WHERE status = 'active'\"\n✓ \"SELECT COUNT(*) FROM orders GROUP BY region\"\n✓ \"SHOW server_version\"\n✗ \"INSERT INTO users ...\" → use write_query\n✗ \"EXPLAIN SELECT ...\" → use explain_query for structured analysis\n</examples>\n\n<what_it_returns>\nA JSON array of row objects, each keyed by column name.\n</what_it_returns>",
     "inputSchema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "description": "Request for the `read_query` and `write_query` tools.",
@@ -353,7 +353,7 @@ expression: tools
   },
   {
     "name": "write_query",
-    "description": "Execute a write SQL query (INSERT, UPDATE, DELETE, CREATE, ALTER, DROP).",
+    "description": "Execute a write SQL query (INSERT, UPDATE, DELETE, CREATE, ALTER, DROP).\n\n<usecase>\nUse when:\n- Inserting, updating, or deleting rows\n- Creating or altering tables, indexes, views, or other schema objects\n- Any data modification operation\n</usecase>\n\n<when_not_to_use>\n- Read-only queries (SELECT, SHOW) → use read_query\n- Query performance analysis → use explain_query\n- Creating/dropping entire databases → use create_database or drop_database\n</when_not_to_use>\n\n<examples>\n✓ \"INSERT INTO users (name, email) VALUES ('Alice', 'alice@example.com')\"\n✓ \"UPDATE orders SET status = 'shipped' WHERE id = 42\"\n✓ \"CREATE TABLE logs (id SERIAL PRIMARY KEY, message TEXT)\"\n✗ \"SELECT * FROM users\" → use read_query\n</examples>\n\n<what_it_returns>\nA JSON array of affected/returning row objects, each keyed by column name.\n</what_it_returns>",
     "inputSchema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "description": "Request for the `read_query` and `write_query` tools.",

--- a/tests/approval/snapshots/approval_postgres__list_tools_read_only.snap
+++ b/tests/approval/snapshots/approval_postgres__list_tools_read_only.snap
@@ -1,12 +1,12 @@
 ---
 source: tests/approval/postgres.rs
-assertion_line: 53
+assertion_line: 52
 expression: tools
 ---
 [
   {
     "name": "explain_query",
-    "description": "Return the execution plan for a SQL query.",
+    "description": "Return the execution plan for a SQL query to diagnose performance. Use this tool instead of running EXPLAIN directly through read_query — it provides structured JSON output. Accepts an optional `database_name` to explain queries against a different database.\n\n<usecase>\nUse when:\n- A query runs slowly and you need to understand why\n- Investigating performance bottlenecks\n- Planning index creation to optimize queries\n- Analyzing join methods, table scan strategies, and sort operations\n</usecase>\n\n<when_not_to_use>\n- Running actual queries → use read_query or write_query\n- Checking table structure → use get_table_schema\n</when_not_to_use>\n\n<examples>\n✓ \"Why is my SELECT on orders slow?\" → explain_query(query=\"SELECT ...\")\n✓ \"Should I add an index?\" → explain_query with analyze=true\n✗ \"Run this SELECT\" → use read_query\n</examples>\n\n<safety>\nSet `analyze` to true for actual execution statistics (EXPLAIN ANALYZE).\nIMPORTANT: EXPLAIN ANALYZE actually executes the query! In read-only mode, only read-only statements are allowed with analyze.\nWhen analyze is false, returns EXPLAIN (FORMAT JSON) output without executing.\n</safety>\n\n<what_it_returns>\nA JSON array of execution plan rows showing access methods, join types, row estimates, and costs.\n</what_it_returns>",
     "inputSchema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "description": "Request for the `explain_query` tool.",
@@ -55,7 +55,7 @@ expression: tools
   },
   {
     "name": "get_table_schema",
-    "description": "Get column definitions (type, nullable, key, default) and foreign key\nrelationships for a table. Requires `database_name` and `table_name`.",
+    "description": "Get column definitions and foreign key relationships for a table. Requires `database_name` and `table_name` — call `list_databases` and `list_tables` first.\n\n<usecase>\nALWAYS call this before writing queries to understand:\n- Column names and data types\n- Which columns are nullable, primary keys, or have defaults\n- Foreign key relationships for writing JOINs\n</usecase>\n\n<examples>\n✓ \"What columns does the orders table have?\" → get_table_schema(database_name=\"mydb\", table_name=\"orders\")\n✓ Before writing a SELECT → get_table_schema first to confirm column names\n✓ \"How are users and orders related?\" → check foreign keys in both tables\n</examples>\n\n<what_it_returns>\nA JSON object with table_name and columns keyed by column name, each containing type, nullable, key, default, and foreign_key info.\n</what_it_returns>",
     "inputSchema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "description": "Request for the `get_table_schema` tool.",
@@ -104,7 +104,7 @@ expression: tools
   },
   {
     "name": "list_databases",
-    "description": "List all accessible databases on the connected database server.\nCall this first to discover available database names.",
+    "description": "List all accessible databases on the connected server. Use this tool to discover what databases are available before using other tools.\n\n<usecase>\nALWAYS call this tool FIRST when:\n- You need to explore what databases exist on the server\n- You need a database name for list_tables, get_table_schema, or query tools\n- The user asks what data is available\n</usecase>\n\n<examples>\n✓ \"What databases are on this server?\"\n✓ \"Show me what's available\" → call list_databases first\n</examples>\n\n<what_it_returns>\nA sorted JSON array of database name strings.\n</what_it_returns>",
     "inputSchema": {
       "properties": {},
       "type": "object"
@@ -136,7 +136,7 @@ expression: tools
   },
   {
     "name": "list_tables",
-    "description": "List all tables in a specific database.\nRequires `database_name` from `list_databases`.",
+    "description": "List all tables in a specific database. Requires `database_name` — call `list_databases` first to discover available databases.\n\n<usecase>\nUse when:\n- Exploring a database to find relevant tables\n- Verifying a table exists before querying or inspecting it\n- The user asks what tables are in a database\n</usecase>\n\n<examples>\n✓ \"What tables are in the mydb database?\" → list_tables(database_name=\"mydb\")\n✓ \"Does a users table exist?\" → list_tables to check\n✗ \"Show me the columns of users\" → use get_table_schema instead\n</examples>\n\n<what_it_returns>\nA sorted JSON array of table name strings.\n</what_it_returns>",
     "inputSchema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "description": "Request for the `list_tables` tool.",
@@ -179,7 +179,7 @@ expression: tools
   },
   {
     "name": "read_query",
-    "description": "Execute a read-only SQL query (SELECT, SHOW, DESCRIBE, USE, EXPLAIN).",
+    "description": "Execute a read-only SQL query. Allowed statements: SELECT, SHOW, EXPLAIN. Accepts an optional `database_name` to query across databases without reconnecting.\n\n<usecase>\nUse when:\n- Querying data from tables (SELECT with WHERE, JOIN, GROUP BY, etc.)\n- Aggregations: COUNT, SUM, AVG, GROUP BY, HAVING\n- Listing server configuration parameters (SHOW)\n</usecase>\n\n<when_not_to_use>\n- Data changes (INSERT, UPDATE, DELETE) → use write_query\n- Query performance analysis → use explain_query\n- Discovering tables or columns → use list_tables or get_table_schema\n</when_not_to_use>\n\n<examples>\n✓ \"SELECT * FROM users WHERE status = 'active'\"\n✓ \"SELECT COUNT(*) FROM orders GROUP BY region\"\n✓ \"SHOW server_version\"\n✗ \"INSERT INTO users ...\" → use write_query\n✗ \"EXPLAIN SELECT ...\" → use explain_query for structured analysis\n</examples>\n\n<what_it_returns>\nA JSON array of row objects, each keyed by column name.\n</what_it_returns>",
     "inputSchema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "description": "Request for the `read_query` and `write_query` tools.",

--- a/tests/approval/snapshots/approval_postgres__server_info.snap
+++ b/tests/approval/snapshots/approval_postgres__server_info.snap
@@ -1,6 +1,6 @@
 ---
 source: tests/approval/postgres.rs
-assertion_line: 33
+assertion_line: 32
 expression: info
 ---
 {
@@ -15,5 +15,5 @@ expression: info
     "description": "Database MCP Server for PostgreSQL",
     "websiteUrl": "https://database.haymon.ai"
   },
-  "instructions": "## Workflow\n\n1. Call `list_databases` to discover available databases.\n2. Call `list_tables` with a `database_name` to see its tables.\n3. Call `get_table_schema` with `database_name` and `table_name` to inspect columns, types, and foreign keys before writing queries.\n4. Use `read_query` for read-only SQL (SELECT, SHOW, EXPLAIN).\n5. Use `write_query` for data changes (INSERT, UPDATE, DELETE, CREATE, ALTER, DROP).\n6. Use `create_database` to create a new database.\n7. Use `drop_database` to drop an existing database.\n\nTools accept an optional `database_name` parameter to query across databases without reconnecting.\n\n## Constraints\n\n- The `write_query`, `create_database`, and `drop_database` tools are hidden when read-only mode is active.\n- Multi-statement queries are not supported. Send one statement per request."
+  "instructions": "## Workflow\n\n1. Call `list_databases` to discover available databases.\n2. Call `list_tables` with a `database_name` to see its tables.\n3. Call `get_table_schema` with `database_name` and `table_name` to inspect columns, types, and foreign keys before writing queries.\n4. Use `read_query` for read-only SQL (SELECT, SHOW, EXPLAIN).\n5. Use `write_query` for data changes (INSERT, UPDATE, DELETE, CREATE, ALTER, DROP).\n6. Use `explain_query` to analyze query execution plans and diagnose slow queries.\n7. Use `create_database` to create a new database.\n8. Use `drop_database` to drop an existing database.\n9. Use `drop_table` to remove a table from a database (supports `cascade` for foreign key dependencies).\n\nTools accept an optional `database_name` parameter to query across databases without reconnecting.\n\n## Constraints\n\n- The `write_query`, `create_database`, `drop_database`, and `drop_table` tools are hidden when read-only mode is active.\n- Multi-statement queries are not supported. Send one statement per request."
 }

--- a/tests/approval/snapshots/approval_sqlite__list_tools.snap
+++ b/tests/approval/snapshots/approval_sqlite__list_tools.snap
@@ -1,12 +1,12 @@
 ---
 source: tests/approval/sqlite.rs
-assertion_line: 36
+assertion_line: 37
 expression: tools
 ---
 [
   {
     "name": "drop_table",
-    "description": "Drop a table from the database.",
+    "description": "Drop a table from the database.\n\n<usecase>\nUse when:\n- Removing a table that is no longer needed\n- Cleaning up test or temporary tables\n</usecase>\n\n<examples>\n✓ \"Drop the temp_logs table\" → drop_table(table_name=\"temp_logs\")\n✗ \"Delete rows from a table\" → use write_query with DELETE\n</examples>\n\n<safety>\nIMPORTANT: This permanently deletes the table and ALL its data. This action cannot be undone.\n</safety>\n\n<what_it_returns>\nA confirmation message with the dropped table name.\n</what_it_returns>",
     "inputSchema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "description": "Request for the `drop_table` tool.",
@@ -46,7 +46,7 @@ expression: tools
   },
   {
     "name": "explain_query",
-    "description": "Return the execution plan for a SQL query.",
+    "description": "Return the execution plan for a SQL query to diagnose performance. Use this tool instead of running EXPLAIN directly through read_query — it provides structured output via EXPLAIN QUERY PLAN.\n\n<usecase>\nUse when:\n- A query runs slowly and you need to understand why\n- Understanding how SQLite will scan tables and use indexes\n- Deciding whether to add an index\n</usecase>\n\n<when_not_to_use>\n- Running actual queries → use read_query or write_query\n- Checking table structure → use get_table_schema\n</when_not_to_use>\n\n<examples>\n✓ \"Why is my SELECT on orders slow?\" → explain_query(query=\"SELECT ...\")\n✓ \"How will SQLite execute this join?\" → explain_query\n✗ \"Run this SELECT\" → use read_query\n</examples>\n\n<what_it_returns>\nA JSON array of EXPLAIN QUERY PLAN rows showing how SQLite will scan tables, use indexes, and order operations.\n</what_it_returns>",
     "inputSchema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "description": "Request for the `explain_query` tool.",
@@ -85,7 +85,7 @@ expression: tools
   },
   {
     "name": "get_table_schema",
-    "description": "Get column definitions (type, nullable, key, default) and foreign key\nrelationships for a table.",
+    "description": "Get column definitions and foreign key relationships for a table. Requires `table_name` — call `list_tables` first.\n\n<usecase>\nALWAYS call this before writing queries to understand:\n- Column names and data types\n- Which columns are nullable, primary keys, or have defaults\n- Foreign key relationships for writing JOINs\n</usecase>\n\n<examples>\n✓ \"What columns does the orders table have?\" → get_table_schema(table_name=\"orders\")\n✓ Before writing a SELECT → get_table_schema first to confirm column names\n✓ \"How are users and orders related?\" → check foreign keys in both tables\n</examples>\n\n<what_it_returns>\nA JSON object with table_name and columns keyed by column name, each containing type, nullable, key, default, and foreign_key info.\n</what_it_returns>",
     "inputSchema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "description": "Request for the `get_table_schema` tool.",
@@ -129,7 +129,7 @@ expression: tools
   },
   {
     "name": "list_tables",
-    "description": "List all tables in the connected `SQLite` database.",
+    "description": "List all tables in the connected SQLite database. Use this tool to discover what tables are available before using other tools.\n\n<usecase>\nALWAYS call this tool FIRST when:\n- You need to explore what tables exist in the database\n- You need a table name for get_table_schema or query tools\n- The user asks what data is available\n</usecase>\n\n<examples>\n✓ \"What tables are in this database?\"\n✓ \"Does a users table exist?\" → list_tables to check\n✗ \"Show me the columns of users\" → use get_table_schema instead\n</examples>\n\n<what_it_returns>\nA sorted JSON array of table name strings.\n</what_it_returns>",
     "inputSchema": {
       "properties": {},
       "type": "object"
@@ -161,7 +161,7 @@ expression: tools
   },
   {
     "name": "read_query",
-    "description": "Execute a read-only SQL query (SELECT, SHOW, DESCRIBE, USE, EXPLAIN).",
+    "description": "Execute a read-only SQL query. Allowed statements: SELECT.\n\n<usecase>\nUse when:\n- Querying data from tables (SELECT with WHERE, JOIN, GROUP BY, etc.)\n- Aggregations: COUNT, SUM, AVG, GROUP BY, HAVING\n- Checking data existence or counts\n</usecase>\n\n<when_not_to_use>\n- Data changes (INSERT, UPDATE, DELETE) → use write_query\n- Query performance analysis → use explain_query\n- Discovering tables or columns → use list_tables or get_table_schema\n</when_not_to_use>\n\n<examples>\n✓ \"SELECT * FROM users WHERE status = 'active'\"\n✓ \"SELECT COUNT(*) FROM orders GROUP BY region\"\n✗ \"INSERT INTO users ...\" → use write_query\n✗ \"EXPLAIN SELECT ...\" → use explain_query for structured analysis\n</examples>\n\n<what_it_returns>\nA JSON array of row objects, each keyed by column name.\n</what_it_returns>",
     "inputSchema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "description": "Request for the `read_query` and `write_query` tools.",
@@ -200,7 +200,7 @@ expression: tools
   },
   {
     "name": "write_query",
-    "description": "Execute a write SQL query (INSERT, UPDATE, DELETE, CREATE, ALTER, DROP).",
+    "description": "Execute a write SQL query (INSERT, UPDATE, DELETE, CREATE, ALTER, DROP).\n\n<usecase>\nUse when:\n- Inserting, updating, or deleting rows\n- Creating or altering tables, indexes, views, or other schema objects\n- Any data modification operation\n</usecase>\n\n<when_not_to_use>\n- Read-only queries (SELECT) → use read_query\n- Query performance analysis → use explain_query\n</when_not_to_use>\n\n<examples>\n✓ \"INSERT INTO users (name, email) VALUES ('Alice', 'alice@example.com')\"\n✓ \"UPDATE orders SET status = 'shipped' WHERE id = 42\"\n✓ \"CREATE TABLE logs (id INTEGER PRIMARY KEY, message TEXT)\"\n✗ \"SELECT * FROM users\" → use read_query\n</examples>\n\n<what_it_returns>\nA JSON array of affected/returning row objects, each keyed by column name.\n</what_it_returns>",
     "inputSchema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "description": "Request for the `read_query` and `write_query` tools.",

--- a/tests/approval/snapshots/approval_sqlite__list_tools_read_only.snap
+++ b/tests/approval/snapshots/approval_sqlite__list_tools_read_only.snap
@@ -1,12 +1,12 @@
 ---
 source: tests/approval/sqlite.rs
-assertion_line: 45
+assertion_line: 46
 expression: tools
 ---
 [
   {
     "name": "explain_query",
-    "description": "Return the execution plan for a SQL query.",
+    "description": "Return the execution plan for a SQL query to diagnose performance. Use this tool instead of running EXPLAIN directly through read_query — it provides structured output via EXPLAIN QUERY PLAN.\n\n<usecase>\nUse when:\n- A query runs slowly and you need to understand why\n- Understanding how SQLite will scan tables and use indexes\n- Deciding whether to add an index\n</usecase>\n\n<when_not_to_use>\n- Running actual queries → use read_query or write_query\n- Checking table structure → use get_table_schema\n</when_not_to_use>\n\n<examples>\n✓ \"Why is my SELECT on orders slow?\" → explain_query(query=\"SELECT ...\")\n✓ \"How will SQLite execute this join?\" → explain_query\n✗ \"Run this SELECT\" → use read_query\n</examples>\n\n<what_it_returns>\nA JSON array of EXPLAIN QUERY PLAN rows showing how SQLite will scan tables, use indexes, and order operations.\n</what_it_returns>",
     "inputSchema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "description": "Request for the `explain_query` tool.",
@@ -45,7 +45,7 @@ expression: tools
   },
   {
     "name": "get_table_schema",
-    "description": "Get column definitions (type, nullable, key, default) and foreign key\nrelationships for a table.",
+    "description": "Get column definitions and foreign key relationships for a table. Requires `table_name` — call `list_tables` first.\n\n<usecase>\nALWAYS call this before writing queries to understand:\n- Column names and data types\n- Which columns are nullable, primary keys, or have defaults\n- Foreign key relationships for writing JOINs\n</usecase>\n\n<examples>\n✓ \"What columns does the orders table have?\" → get_table_schema(table_name=\"orders\")\n✓ Before writing a SELECT → get_table_schema first to confirm column names\n✓ \"How are users and orders related?\" → check foreign keys in both tables\n</examples>\n\n<what_it_returns>\nA JSON object with table_name and columns keyed by column name, each containing type, nullable, key, default, and foreign_key info.\n</what_it_returns>",
     "inputSchema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "description": "Request for the `get_table_schema` tool.",
@@ -89,7 +89,7 @@ expression: tools
   },
   {
     "name": "list_tables",
-    "description": "List all tables in the connected `SQLite` database.",
+    "description": "List all tables in the connected SQLite database. Use this tool to discover what tables are available before using other tools.\n\n<usecase>\nALWAYS call this tool FIRST when:\n- You need to explore what tables exist in the database\n- You need a table name for get_table_schema or query tools\n- The user asks what data is available\n</usecase>\n\n<examples>\n✓ \"What tables are in this database?\"\n✓ \"Does a users table exist?\" → list_tables to check\n✗ \"Show me the columns of users\" → use get_table_schema instead\n</examples>\n\n<what_it_returns>\nA sorted JSON array of table name strings.\n</what_it_returns>",
     "inputSchema": {
       "properties": {},
       "type": "object"
@@ -121,7 +121,7 @@ expression: tools
   },
   {
     "name": "read_query",
-    "description": "Execute a read-only SQL query (SELECT, SHOW, DESCRIBE, USE, EXPLAIN).",
+    "description": "Execute a read-only SQL query. Allowed statements: SELECT.\n\n<usecase>\nUse when:\n- Querying data from tables (SELECT with WHERE, JOIN, GROUP BY, etc.)\n- Aggregations: COUNT, SUM, AVG, GROUP BY, HAVING\n- Checking data existence or counts\n</usecase>\n\n<when_not_to_use>\n- Data changes (INSERT, UPDATE, DELETE) → use write_query\n- Query performance analysis → use explain_query\n- Discovering tables or columns → use list_tables or get_table_schema\n</when_not_to_use>\n\n<examples>\n✓ \"SELECT * FROM users WHERE status = 'active'\"\n✓ \"SELECT COUNT(*) FROM orders GROUP BY region\"\n✗ \"INSERT INTO users ...\" → use write_query\n✗ \"EXPLAIN SELECT ...\" → use explain_query for structured analysis\n</examples>\n\n<what_it_returns>\nA JSON array of row objects, each keyed by column name.\n</what_it_returns>",
     "inputSchema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "description": "Request for the `read_query` and `write_query` tools.",

--- a/tests/approval/snapshots/approval_sqlite__server_info.snap
+++ b/tests/approval/snapshots/approval_sqlite__server_info.snap
@@ -1,6 +1,6 @@
 ---
 source: tests/approval/sqlite.rs
-assertion_line: 25
+assertion_line: 26
 expression: info
 ---
 {
@@ -15,5 +15,5 @@ expression: info
     "description": "Database MCP Server for SQLite",
     "websiteUrl": "https://database.haymon.ai"
   },
-  "instructions": "## Workflow\n\n1. Call `list_tables` to discover tables in the connected database.\n2. Call `get_table_schema` with a `table_name` to inspect columns, types, and foreign keys before writing queries.\n3. Use `read_query` for read-only SQL (SELECT, EXPLAIN).\n4. Use `write_query` for data changes (INSERT, UPDATE, DELETE, CREATE, ALTER, DROP).\n\n## Constraints\n\n- The `write_query` tool is hidden when read-only mode is active.\n- Multi-statement queries are not supported. Send one statement per request."
+  "instructions": "## Workflow\n\n1. Call `list_tables` to discover tables in the connected database.\n2. Call `get_table_schema` with a `table_name` to inspect columns, types, and foreign keys before writing queries.\n3. Use `read_query` for read-only SQL (SELECT).\n4. Use `write_query` for data changes (INSERT, UPDATE, DELETE, CREATE, ALTER, DROP).\n5. Use `explain_query` to analyze query execution plans and diagnose slow queries.\n6. Use `drop_table` to remove a table from the database.\n\n## Constraints\n\n- The `write_query` and `drop_table` tools are hidden when read-only mode is active.\n- Multi-statement queries are not supported. Send one statement per request."
 }


### PR DESCRIPTION
## Summary

- Enhance all 24 tool descriptions across MySQL, PostgreSQL, and SQLite with structured XML-tagged sections (`<usecase>`, `<when_not_to_use>`, `<examples>`, `<safety>`, `<what_it_returns>`)
- Fix backend-specific inaccuracies: SQLite `read_query` no longer claims SHOW/DESCRIBE/USE support; PostgreSQL no longer claims DESCRIBE/USE
- Add missing `explain_query` and `drop_table` to all three handler instructions
- Remove unit test for description content (covered by approval snapshot tests)
- Use raw string literals (`r#"..."#`) for cleaner multi-line descriptions

## Test plan

- [x] `cargo fmt`
- [x] `cargo clippy --workspace --tests -- -D warnings`
- [x] `cargo test --workspace --lib --bins` — 112 unit tests pass
- [x] `./tests/run.sh` — 249 integration + approval tests pass across MariaDB, MySQL, PostgreSQL, SQLite