### PR TITLE
feat(release): add macOS and Windows builds

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -25,6 +25,15 @@ jobs:
           - target: aarch64-unknown-linux-gnu
             os: ubuntu-latest
             artifact: database-mcp
+          - target: x86_64-apple-darwin
+            os: macos-latest
+            artifact: database-mcp
+          - target: aarch64-apple-darwin
+            os: macos-latest
+            artifact: database-mcp
+          - target: x86_64-pc-windows-msvc
+            os: windows-latest
+            artifact: database-mcp.exe
     steps:
       - uses: actions/checkout@v6
       - uses: dtolnay/rust-toolchain@stable
@@ -34,7 +43,7 @@ jobs:
         with:
           key: ${{ matrix.target }}
 
-      - name: Install cross-compilation tools
+      - name: Install cross-compilation tools (Linux ARM)
         if: matrix.target == 'aarch64-unknown-linux-gnu'
         run: |
           sudo apt-get update
@@ -45,15 +54,22 @@ jobs:
         env:
           CARGO_TARGET_AARCH64_UNKNOWN_LINUX_GNU_LINKER: aarch64-linux-gnu-gcc
 
-      - name: Package artifact
+      - name: Package artifact (Unix)
+        if: runner.os != 'Windows'
         run: |
           cd target/${{ matrix.target }}/release
           tar czf ../../../database-mcp-${{ matrix.target }}.tar.gz ${{ matrix.artifact }}
 
+      - name: Package artifact (Windows)
+        if: runner.os == 'Windows'
+        shell: pwsh
+        run: |
+          Compress-Archive -Path target/${{ matrix.target }}/release/${{ matrix.artifact }} -DestinationPath database-mcp-${{ matrix.target }}.zip
+
       - uses: actions/upload-artifact@v7
         with:
           name: database-mcp-${{ matrix.target }}
-          path: database-mcp-${{ matrix.target }}.tar.gz
+          path: database-mcp-${{ matrix.target }}.*
 
   release:
     name: Create Release
@@ -77,7 +93,9 @@ jobs:
         uses: softprops/action-gh-release@v2
         with:
           body: ${{ steps.changelog.outputs.stdout }}
-          files: artifacts/*.tar.gz
+          files: |
+            artifacts/*.tar.gz
+            artifacts/*.zip
 
   ghcr-io:
     name: Publish to ghcr.io

--- a/docs/content/docs/installation.mdx
+++ b/docs/content/docs/installation.mdx
@@ -27,11 +27,48 @@ tar xzf database-mcp-aarch64-unknown-linux-gnu.tar.gz
 sudo mv database-mcp /usr/local/bin/
 ```
 
+### macOS
+
+**Apple Silicon (M1/M2/M3/M4)**:
+
+```bash
+curl -LO https://github.com/haymon-ai/database/releases/latest/download/database-mcp-aarch64-apple-darwin.tar.gz
+tar xzf database-mcp-aarch64-apple-darwin.tar.gz
+sudo mv database-mcp /usr/local/bin/
+```
+
+**Intel**:
+
+```bash
+curl -LO https://github.com/haymon-ai/database/releases/latest/download/database-mcp-x86_64-apple-darwin.tar.gz
+tar xzf database-mcp-x86_64-apple-darwin.tar.gz
+sudo mv database-mcp /usr/local/bin/
+```
+
+### Windows
+
+**x86_64**:
+
+Download the latest release:
+
+```powershell
+Invoke-WebRequest -Uri https://github.com/haymon-ai/database/releases/latest/download/database-mcp-x86_64-pc-windows-msvc.zip -OutFile database-mcp.zip
+Expand-Archive database-mcp.zip -DestinationPath .
+```
+
+Move `database-mcp.exe` to a directory on your PATH, or run it directly from the extracted location.
+
+Verify the installation:
+
+```powershell
+database-mcp.exe --help
+```
+
 ---
 
 For older versions or other assets, see the [GitHub Releases](https://github.com/haymon-ai/database/releases) page.
 
-Verify the installation:
+Verify the installation (Linux/macOS):
 
 ```bash
 database-mcp --help
@@ -127,7 +164,7 @@ database-mcp --help
 
 | Method | Ease of Install | Auto Updates | Version Flexibility | Prerequisites | Platform Coverage |
 |--------|----------------|--------------|--------------------|--------------|--------------------|
-| Docker | `docker pull` | Pull latest tag | Any release tag | Docker | Linux (x86_64, aarch64) |
-| Prebuilt Binary | Simple download | None | Any release | None | Linux (x86_64, aarch64) |
+| Docker | `docker pull` | Pull latest tag | Any release tag | Docker | Linux, macOS, Windows |
+| Prebuilt Binary | Simple download | None | Any release | None | Linux, macOS, Windows |
 | Cargo Install | One command | `cargo install` to update | Any published version | Rust toolchain | All platforms Rust supports |
 | Build from Source | Multiple steps | Manual (git pull + rebuild) | Any commit/branch | Git + Rust toolchain | All platforms Rust supports |


### PR DESCRIPTION
## Summary

- Expand the release workflow build matrix from 2 Linux targets to 5 cross-platform targets: Linux (x86_64, aarch64), macOS (Intel, Apple Silicon), and Windows (x86_64)
- Use conditional packaging steps: `.tar.gz` for Linux/macOS, `.zip` for Windows
- Update installation docs with macOS and Windows download instructions and comparison table

Closes #96

## Test plan

- [ ] Push a test tag and verify all 5 build jobs complete in the release workflow
- [ ] Verify macOS `.tar.gz` and Windows `.zip` artifacts appear on the GitHub Release
- [ ] Verify existing Linux `.tar.gz` artifacts are unchanged
- [ ] Review installation docs for correct download URLs and extraction commands