### PR TITLE
feat(install): add one-liner install scripts for macOS, Linux, and Windows

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,14 +21,22 @@ A single-binary [MCP](https://modelcontextprotocol.io/) server for SQL databases
 
 ## Install
 
+**macOS, Linux, WSL**:
+
 ```bash
 curl -fsSL https://database.haymon.ai/install.sh | bash
 ```
 
-On Windows (PowerShell):
+**Windows PowerShell**:
 
 ```powershell
 irm https://database.haymon.ai/install.ps1 | iex
+```
+
+**Windows CMD**:
+
+```batch
+curl -fsSL https://database.haymon.ai/install.cmd -o install.cmd && install.cmd && del install.cmd
 ```
 
 See the [installation docs](https://database.haymon.ai/docs/installation) for Docker, Cargo, and other methods.

--- a/README.md
+++ b/README.md
@@ -19,6 +19,20 @@ A single-binary [MCP](https://modelcontextprotocol.io/) server for SQL databases
 - **Multiple transports** — stdio (for Claude Desktop, Cursor) and HTTP (for remote/multi-client)
 - **Two-layer config** — CLI flags > environment variables, with sensible defaults per backend
 
+## Install
+
+```bash
+curl -fsSL https://database.haymon.ai/install.sh | bash
+```
+
+On Windows (PowerShell):
+
+```powershell
+irm https://database.haymon.ai/install.ps1 | iex
+```
+
+See the [installation docs](https://database.haymon.ai/docs/installation) for Docker, Cargo, and other methods.
+
 ## Quick Start
 
 ### Using `.mcp.json` (recommended)

--- a/docs/app/layout.tsx
+++ b/docs/app/layout.tsx
@@ -1,12 +1,37 @@
-import { Inter } from 'next/font/google';
-import { Provider } from '@/components/provider';
-import './global.css';
+import type { Metadata } from "next";
+import { Inter } from "next/font/google";
+import { Provider } from "@/components/provider";
+import "./global.css";
 
 const inter = Inter({
-  subsets: ['latin'],
+  subsets: ["latin"],
 });
 
-export default function Layout({ children }: LayoutProps<'/'>) {
+export const metadata: Metadata = {
+  metadataBase: new URL("https://database.haymon.ai"),
+  title: {
+    default: "Haymon Database MCP — AI access to your SQL databases",
+    template: "%s | Haymon Database MCP",
+  },
+  description:
+    "A single-binary MCP server for MySQL, MariaDB, PostgreSQL, and SQLite. Zero runtime dependencies, read-only by default.",
+  openGraph: {
+    title: "Haymon Database MCP — AI access to your SQL databases",
+    description:
+      "A single-binary MCP server for MySQL, MariaDB, PostgreSQL, and SQLite. Zero runtime dependencies, read-only by default.",
+    url: "https://database.haymon.ai",
+    siteName: "Haymon Database MCP",
+    type: "website",
+  },
+  twitter: {
+    card: "summary_large_image",
+    title: "Haymon Database MCP — AI access to your SQL databases",
+    description:
+      "A single-binary MCP server for MySQL, MariaDB, PostgreSQL, and SQLite. Zero runtime dependencies, read-only by default.",
+  },
+};
+
+export default function Layout({ children }: LayoutProps<"/">) {
   return (
     <html lang="en" className={inter.className} suppressHydrationWarning>
       <body className="flex flex-col min-h-screen">

--- a/docs/components/homepage/hero.tsx
+++ b/docs/components/homepage/hero.tsx
@@ -1,6 +1,7 @@
-import Link from 'next/link';
+import Link from "next/link";
+import { InstallCommand } from "./install";
 
-const gitHubUrl = 'https://github.com/haymon-ai/database';
+const gitHubUrl = "https://github.com/haymon-ai/database";
 
 export function Hero() {
   return (
@@ -14,9 +15,11 @@ export function Hero() {
         <span aria-hidden="true">&rarr;</span>
       </Link>
 
-      <h1 className="mt-8 text-4xl font-semibold tracking-tight text-black sm:text-5xl md:text-6xl" style={{ letterSpacing: '-0.025em', lineHeight: 1 }}>
-        Your databases,{' '}
-        <br className="hidden sm:block" />
+      <h1
+        className="mt-8 text-4xl font-semibold tracking-tight text-black sm:text-5xl md:text-6xl"
+        style={{ letterSpacing: "-0.025em", lineHeight: 1 }}
+      >
+        Your databases, <br className="hidden sm:block" />
         meet your AI
       </h1>
 
@@ -40,6 +43,10 @@ export function Hero() {
         >
           View on GitHub
         </a>
+      </div>
+
+      <div className="mt-10">
+        <InstallCommand />
       </div>
     </section>
   );

--- a/docs/components/homepage/install.tsx
+++ b/docs/components/homepage/install.tsx
@@ -1,0 +1,77 @@
+"use client";
+
+import { useState } from "react";
+
+interface InstallTab {
+  label: string;
+  command: string;
+}
+
+const tabs: InstallTab[] = [
+  {
+    label: "macOS, Linux, WSL",
+    command: "curl -fsSL https://database.haymon.ai/install.sh | bash",
+  },
+  {
+    label: "Windows PowerShell",
+    command: "irm https://database.haymon.ai/install.ps1 | iex",
+  },
+  {
+    label: "Windows CMD",
+    command:
+      "curl -fsSL https://database.haymon.ai/install.cmd -o install.cmd && install.cmd && del install.cmd",
+  },
+];
+
+export function InstallCommand() {
+  const [active, setActive] = useState(0);
+  const [copied, setCopied] = useState(false);
+
+  const handleCopy = async () => {
+    try {
+      await navigator.clipboard.writeText(tabs[active].command);
+      setCopied(true);
+      setTimeout(() => setCopied(false), 1500);
+    } catch {
+      // clipboard unavailable — no-op
+    }
+  };
+
+  return (
+    <div className="mx-auto w-full max-w-2xl">
+      <div className="flex items-center gap-1 border-b border-black/[0.08]">
+        {tabs.map((tab, i) => (
+          <button
+            key={tab.label}
+            type="button"
+            onClick={() => {
+              setActive(i);
+              setCopied(false);
+            }}
+            className={`cursor-pointer border-b-2 px-3 py-2 text-xs font-medium transition-colors sm:text-sm ${
+              active === i
+                ? "border-[#151715] text-black"
+                : "border-transparent text-gray-500 hover:text-gray-800"
+            }`}
+          >
+            {tab.label}
+          </button>
+        ))}
+      </div>
+      <div className="flex items-center justify-between gap-3 rounded-b-sm border border-t-0 border-black/[0.08] bg-gray-50 px-4 py-3">
+        <code className="flex-1 overflow-x-auto whitespace-nowrap text-left font-mono text-xs text-black sm:text-sm">
+          <span className="select-none text-gray-400">$ </span>
+          {tabs[active].command}
+        </code>
+        <button
+          type="button"
+          onClick={handleCopy}
+          aria-label="Copy install command"
+          className="shrink-0 cursor-pointer rounded-sm border border-black/10 bg-white px-2.5 py-1 text-xs font-medium text-gray-700 transition-colors hover:border-black/20 hover:bg-gray-100"
+        >
+          {copied ? "Copied" : "Copy"}
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/docs/content/docs/index.mdx
+++ b/docs/content/docs/index.mdx
@@ -23,18 +23,4 @@ Database MCP is a [Model Context Protocol](https://modelcontextprotocol.io/) (MC
 
 Database MCP exposes your database schema and data through the MCP protocol. AI assistants can discover tables, inspect schemas, and run read-only SQL queries to answer questions about your data — all without the risk of accidental modifications.
 
-## Getting Started
-
-Install with a single command:
-
-```bash
-curl -fsSL https://database.haymon.ai/install.sh | bash
-```
-
-On Windows:
-
-```powershell
-irm https://database.haymon.ai/install.ps1 | iex
-```
-
-Or see the [Installation](/docs/installation) guide for Docker, Cargo, and other methods.
+See the [Installation](/docs/installation) guide to get started.

--- a/docs/content/docs/index.mdx
+++ b/docs/content/docs/index.mdx
@@ -25,4 +25,16 @@ Database MCP exposes your database schema and data through the MCP protocol. AI 
 
 ## Getting Started
 
-Install Database MCP and connect it to your preferred MCP client. See the [Installation](/docs/installation) guide for setup instructions.
+Install with a single command:
+
+```bash
+curl -fsSL https://database.haymon.ai/install.sh | bash
+```
+
+On Windows:
+
+```powershell
+irm https://database.haymon.ai/install.ps1 | iex
+```
+
+Or see the [Installation](/docs/installation) guide for Docker, Cargo, and other methods.

--- a/docs/content/docs/installation.mdx
+++ b/docs/content/docs/installation.mdx
@@ -7,7 +7,7 @@ Database MCP is distributed as a single binary with no runtime dependencies. Cho
 
 ## Quick Install (recommended)
 
-**macOS / Linux**:
+**macOS, Linux, WSL**:
 
 ```bash
 curl -fsSL https://database.haymon.ai/install.sh | bash
@@ -206,7 +206,7 @@ database-mcp --help
 
 | Method | Ease of Install | Auto Updates | Version Flexibility | Prerequisites | Platform Coverage |
 |--------|----------------|--------------|--------------------|--------------|--------------------|
-| Quick Install | Single command | Re-run to upgrade | Latest release | curl/wget or PowerShell | Linux, macOS, Windows |
+| Quick Install | Single command | Re-run to upgrade | Latest release | curl/wget or PowerShell | macOS, Linux, WSL, Windows |
 | Docker | `docker pull` | Pull latest tag | Any release tag | Docker | Linux, macOS, Windows |
 | Prebuilt Binary | Simple download | None | Any release | None | Linux, macOS, Windows |
 | Cargo Install | One command | `cargo install` to update | Any published version | Rust toolchain | All platforms Rust supports |

--- a/docs/content/docs/installation.mdx
+++ b/docs/content/docs/installation.mdx
@@ -5,6 +5,48 @@ description: Install database-mcp via Docker, prebuilt binary, or from source
 
 Database MCP is distributed as a single binary with no runtime dependencies. Choose the installation method that works best for your setup.
 
+## Quick Install (recommended)
+
+**macOS / Linux**:
+
+```bash
+curl -fsSL https://database.haymon.ai/install.sh | bash
+```
+
+Or with `wget`:
+
+```bash
+wget -qO- https://database.haymon.ai/install.sh | bash
+```
+
+**Windows** (PowerShell):
+
+```powershell
+irm https://database.haymon.ai/install.ps1 | iex
+```
+
+**Windows** (CMD):
+
+```batch
+curl -fsSL https://database.haymon.ai/install.cmd -o install.cmd && install.cmd && del install.cmd
+```
+
+This detects your platform, downloads the correct binary, and installs it. Re-run the same command to upgrade to the latest version.
+
+To install to a custom directory:
+
+```bash
+INSTALL_DIR=/opt/bin curl -fsSL https://database.haymon.ai/install.sh | bash
+```
+
+```powershell
+$env:INSTALL_DIR = "C:\tools\database-mcp"; irm https://database.haymon.ai/install.ps1 | iex
+```
+
+```batch
+set INSTALL_DIR=C:\tools\database-mcp && curl -fsSL https://database.haymon.ai/install.cmd -o install.cmd && install.cmd && del install.cmd
+```
+
 ## Prebuilt Binaries
 
 Download the latest release from GitHub.
@@ -164,6 +206,7 @@ database-mcp --help
 
 | Method | Ease of Install | Auto Updates | Version Flexibility | Prerequisites | Platform Coverage |
 |--------|----------------|--------------|--------------------|--------------|--------------------|
+| Quick Install | Single command | Re-run to upgrade | Latest release | curl/wget or PowerShell | Linux, macOS, Windows |
 | Docker | `docker pull` | Pull latest tag | Any release tag | Docker | Linux, macOS, Windows |
 | Prebuilt Binary | Simple download | None | Any release | None | Linux, macOS, Windows |
 | Cargo Install | One command | `cargo install` to update | Any published version | Rust toolchain | All platforms Rust supports |

--- a/docs/public/install.cmd
+++ b/docs/public/install.cmd
@@ -129,28 +129,6 @@ powershell -NoProfile -ExecutionPolicy Bypass -Command ^
     "  Write-Host '  Restart your terminal for the change to take effect.'; Write-Host ''" ^
     "}"
 
-REM Print guidance
-echo.
-echo What's next?
-echo.
-echo   Add database-mcp to your MCP client config (.mcp.json):
-echo.
-echo     {
-echo       "mcpServers": {
-echo         "database-mcp": {
-echo           "command": "database-mcp",
-echo           "env": {
-echo             "DB_BACKEND": "postgres",
-echo             "DB_HOST": "localhost",
-echo             "DB_USER": "postgres"
-echo           }
-echo         }
-echo       }
-echo     }
-echo.
-echo   Documentation: https://database.haymon.ai/docs/
-echo.
-
 goto :cleanup_ok
 
 :cleanup_fail

--- a/docs/public/install.cmd
+++ b/docs/public/install.cmd
@@ -1,0 +1,162 @@
+@echo off
+setlocal enabledelayedexpansion
+
+REM Install script for database-mcp (Windows CMD)
+REM Usage: curl -fsSL https://database.haymon.ai/install.cmd -o install.cmd && install.cmd && del install.cmd
+REM
+REM Environment variables:
+REM   INSTALL_DIR - Override the install directory
+
+set "BINARY_NAME=database-mcp"
+set "REPO=haymon-ai/database"
+set "TARGET=x86_64-pc-windows-msvc"
+set "ASSET=%BINARY_NAME%-%TARGET%.zip"
+set "BASE_URL=https://github.com/%REPO%/releases/latest/download"
+set "URL=%BASE_URL%/%ASSET%"
+
+echo.
+echo Installing database-mcp...
+echo.
+
+REM Resolve install directory
+set "BIN_DIR="
+set "IS_UPGRADE=0"
+set "OLD_VERSION="
+
+REM Priority 1: INSTALL_DIR env var
+if defined INSTALL_DIR (
+    set "BIN_DIR=%INSTALL_DIR%"
+    goto :resolved
+)
+
+REM Priority 2: Existing binary detection
+where %BINARY_NAME% >nul 2>&1
+if %errorlevel% equ 0 (
+    for /f "delims=" %%i in ('where %BINARY_NAME%') do (
+        set "EXISTING=%%i"
+        goto :found_existing
+    )
+)
+goto :default_dir
+
+:found_existing
+for %%i in ("%EXISTING%") do set "BIN_DIR=%%~dpi"
+REM Remove trailing backslash
+if "%BIN_DIR:~-1%"=="\" set "BIN_DIR=%BIN_DIR:~0,-1%"
+set "IS_UPGRADE=1"
+for /f "delims=" %%v in ('""%EXISTING%" --version" 2^>nul') do set "OLD_VERSION=%%v"
+goto :resolved
+
+:default_dir
+REM Priority 3: Default location
+set "BIN_DIR=%LOCALAPPDATA%\Programs\database-mcp"
+
+:resolved
+if %IS_UPGRADE% equ 1 (
+    echo Upgrading database-mcp at %BIN_DIR% ^(current: %OLD_VERSION%^)
+) else (
+    echo Install directory: %BIN_DIR%
+)
+
+REM Create install directory if needed
+if not exist "%BIN_DIR%" mkdir "%BIN_DIR%"
+
+REM Create temp directory (double %RANDOM% for better collision resistance)
+set "TMPDIR=%TEMP%\database-mcp-install-%RANDOM%%RANDOM%"
+mkdir "%TMPDIR%"
+
+echo Downloading %ASSET%...
+
+REM Download
+curl -fsSL "%URL%" -o "%TMPDIR%\%ASSET%"
+if %errorlevel% neq 0 (
+    echo error: download failed - check your network connection or try again later
+    echo   URL: %URL%
+    goto :cleanup_fail
+)
+
+REM Extract via PowerShell (available on all Win10+ systems)
+powershell -NoProfile -ExecutionPolicy Bypass -Command "Expand-Archive -Path '%TMPDIR%\%ASSET%' -DestinationPath '%TMPDIR%\extracted' -Force" 2>nul
+if %errorlevel% neq 0 (
+    echo error: failed to extract archive
+    goto :cleanup_fail
+)
+
+REM Check binary exists
+if not exist "%TMPDIR%\extracted\%BINARY_NAME%.exe" (
+    echo error: binary '%BINARY_NAME%.exe' not found in archive
+    goto :cleanup_fail
+)
+
+REM Install
+copy /y "%TMPDIR%\extracted\%BINARY_NAME%.exe" "%BIN_DIR%\%BINARY_NAME%.exe" >nul
+if %errorlevel% neq 0 (
+    echo error: failed to install binary to %BIN_DIR%
+    echo   Is an existing database-mcp process running?
+    goto :cleanup_fail
+)
+
+REM Verify
+set "INSTALLED_VERSION="
+for /f "delims=" %%v in ('""%BIN_DIR%\%BINARY_NAME%.exe" --version" 2^>nul') do set "INSTALLED_VERSION=%%v"
+if not defined INSTALLED_VERSION (
+    echo error: installation verification failed
+    goto :cleanup_fail
+)
+
+echo.
+if %IS_UPGRADE% equ 1 (
+    echo Successfully upgraded database-mcp!
+    echo   %OLD_VERSION% -^> %INSTALLED_VERSION%
+) else (
+    echo Successfully installed database-mcp!
+    echo   Version: %INSTALLED_VERSION%
+)
+echo   Location: %BIN_DIR%\%BINARY_NAME%.exe
+
+REM Add to PATH via PowerShell (uses .NET API — no 1024 char limit, preserves REG_EXPAND_SZ,
+REM exact-match check to avoid substring false positives)
+powershell -NoProfile -ExecutionPolicy Bypass -Command ^
+    "$bin='%BIN_DIR%';" ^
+    "$cur=[Environment]::GetEnvironmentVariable('PATH','User');" ^
+    "$found=$false;" ^
+    "if ($cur) { foreach ($e in ($cur -split ';')) { if ($e -ieq $bin) { $found=$true; break } } }" ^
+    "if (-not $found) {" ^
+    "  Write-Host ''; Write-Host ('warning: ' + $bin + ' is not in your PATH') -ForegroundColor Yellow; Write-Host '';" ^
+    "  if ($cur) { $new = $bin + ';' + $cur } else { $new = $bin };" ^
+    "  [Environment]::SetEnvironmentVariable('PATH', $new, 'User');" ^
+    "  Write-Host ('  Added ' + $bin + ' to your user PATH.') -ForegroundColor Green;" ^
+    "  Write-Host '  Restart your terminal for the change to take effect.'; Write-Host ''" ^
+    "}"
+
+REM Print guidance
+echo.
+echo What's next?
+echo.
+echo   Add database-mcp to your MCP client config (.mcp.json):
+echo.
+echo     {
+echo       "mcpServers": {
+echo         "database-mcp": {
+echo           "command": "database-mcp",
+echo           "env": {
+echo             "DB_BACKEND": "postgres",
+echo             "DB_HOST": "localhost",
+echo             "DB_USER": "postgres"
+echo           }
+echo         }
+echo       }
+echo     }
+echo.
+echo   Documentation: https://database.haymon.ai/docs/
+echo.
+
+goto :cleanup_ok
+
+:cleanup_fail
+if exist "%TMPDIR%" rmdir /s /q "%TMPDIR%" 2>nul
+exit /b 1
+
+:cleanup_ok
+if exist "%TMPDIR%" rmdir /s /q "%TMPDIR%" 2>nul
+exit /b 0

--- a/docs/public/install.ps1
+++ b/docs/public/install.ps1
@@ -75,29 +75,6 @@
         Write-Host ""
     }
 
-    function Show-Guidance {
-        Write-Host ""
-        Write-Host "What's next?" -ForegroundColor Cyan
-        Write-Host ""
-        Write-Host "  Add database-mcp to your MCP client config (.mcp.json):"
-        Write-Host ""
-        Write-Host '    {'
-        Write-Host '      "mcpServers": {'
-        Write-Host '        "database-mcp": {'
-        Write-Host '          "command": "database-mcp",'
-        Write-Host '          "env": {'
-        Write-Host '            "DB_BACKEND": "postgres",'
-        Write-Host '            "DB_HOST": "localhost",'
-        Write-Host '            "DB_USER": "postgres"'
-        Write-Host '          }'
-        Write-Host '        }'
-        Write-Host '      }'
-        Write-Host '    }'
-        Write-Host ""
-        Write-Host "  Documentation: https://database.haymon.ai/docs/"
-        Write-Host ""
-    }
-
     # --- Main flow ---
 
     $BinaryName = "database-mcp"
@@ -188,9 +165,6 @@
 
         # Check PATH and add if needed
         Add-ToPath -Dir $BinDir
-
-        # Print guidance
-        Show-Guidance
     }
     catch {
         Write-Host ""

--- a/docs/public/install.ps1
+++ b/docs/public/install.ps1
@@ -1,0 +1,207 @@
+# Install script for database-mcp (Windows)
+# Usage: irm https://database.haymon.ai/install.ps1 | iex
+#    or: powershell -ExecutionPolicy Bypass -File install.ps1
+#
+# Environment variables:
+#   INSTALL_DIR - Override the install directory
+
+& {
+    $ErrorActionPreference = "Stop"
+
+    # Enforce TLS 1.2 for GitHub downloads (required on older .NET defaults)
+    try {
+        [Net.ServicePointManager]::SecurityProtocol = [Net.ServicePointManager]::SecurityProtocol -bor [Net.SecurityProtocolType]::Tls12
+    } catch {}
+
+    function Resolve-InstallDir {
+        param([string]$BinaryName)
+
+        # Priority 1: INSTALL_DIR env var
+        $EnvDir = $env:INSTALL_DIR
+        if ($EnvDir) {
+            return @{ Path = $EnvDir; IsUpgrade = $false; OldVersion = "" }
+        }
+
+        # Priority 2: Existing binary detection
+        $Existing = Get-Command $BinaryName -ErrorAction SilentlyContinue
+        if ($Existing) {
+            $ExistingPath = Split-Path $Existing.Source -Parent
+            $OldVer = ""
+            try {
+                $OldVer = (& $Existing.Source --version 2>&1 | Out-String).Trim()
+            } catch {}
+            return @{ Path = $ExistingPath; IsUpgrade = $true; OldVersion = "$OldVer" }
+        }
+
+        # Priority 3: Default location
+        $DefaultDir = Join-Path $env:LOCALAPPDATA "Programs\database-mcp"
+        return @{ Path = $DefaultDir; IsUpgrade = $false; OldVersion = "" }
+    }
+
+    function Add-ToPath {
+        param([string]$Dir)
+
+        $CurrentPath = [Environment]::GetEnvironmentVariable("PATH", "User")
+        $AlreadyInPath = $false
+        if ($CurrentPath) {
+            foreach ($entry in ($CurrentPath -split ";")) {
+                if ($entry -ieq $Dir) {
+                    $AlreadyInPath = $true
+                    break
+                }
+            }
+        }
+        if ($AlreadyInPath) {
+            return
+        }
+
+        Write-Host ""
+        Write-Host "warning: $Dir is not in your PATH" -ForegroundColor Yellow
+        Write-Host ""
+
+        # Add to user PATH via .NET (preserves REG_EXPAND_SZ and has no 1024-char limit)
+        if ($CurrentPath) {
+            $NewPath = "$Dir;$CurrentPath"
+        } else {
+            $NewPath = $Dir
+        }
+        [Environment]::SetEnvironmentVariable("PATH", $NewPath, "User")
+
+        # Also add to current session
+        $env:PATH = "$Dir;$env:PATH"
+
+        Write-Host "  Added $Dir to your user PATH." -ForegroundColor Green
+        Write-Host "  Restart your terminal for the change to take effect in new sessions."
+        Write-Host ""
+    }
+
+    function Show-Guidance {
+        Write-Host ""
+        Write-Host "What's next?" -ForegroundColor Cyan
+        Write-Host ""
+        Write-Host "  Add database-mcp to your MCP client config (.mcp.json):"
+        Write-Host ""
+        Write-Host '    {'
+        Write-Host '      "mcpServers": {'
+        Write-Host '        "database-mcp": {'
+        Write-Host '          "command": "database-mcp",'
+        Write-Host '          "env": {'
+        Write-Host '            "DB_BACKEND": "postgres",'
+        Write-Host '            "DB_HOST": "localhost",'
+        Write-Host '            "DB_USER": "postgres"'
+        Write-Host '          }'
+        Write-Host '        }'
+        Write-Host '      }'
+        Write-Host '    }'
+        Write-Host ""
+        Write-Host "  Documentation: https://database.haymon.ai/docs/"
+        Write-Host ""
+    }
+
+    # --- Main flow ---
+
+    $BinaryName = "database-mcp"
+    $Repo = "haymon-ai/database"
+    $Target = "x86_64-pc-windows-msvc"
+    $Asset = "$BinaryName-$Target.zip"
+    $BaseUrl = "https://github.com/$Repo/releases/latest/download"
+    $Url = "$BaseUrl/$Asset"
+
+    $TmpDir = $null
+
+    try {
+        Write-Host ""
+        Write-Host "Installing database-mcp..." -ForegroundColor Cyan
+        Write-Host ""
+
+        # Resolve install directory
+        $InstallInfo = Resolve-InstallDir -BinaryName $BinaryName
+        $IsUpgrade = $InstallInfo.IsUpgrade
+        $OldVersion = $InstallInfo.OldVersion
+        $BinDir = $InstallInfo.Path
+
+        if ($IsUpgrade) {
+            Write-Host "Upgrading database-mcp at $BinDir (current: $OldVersion)" -ForegroundColor Cyan
+        } else {
+            Write-Host "Install directory: $BinDir" -ForegroundColor Cyan
+        }
+
+        # Create install directory if needed
+        if (-not (Test-Path $BinDir)) {
+            New-Item -ItemType Directory -Path $BinDir -Force | Out-Null
+        }
+
+        # Create temp directory
+        $TmpDir = Join-Path ([System.IO.Path]::GetTempPath()) ([System.Guid]::NewGuid().ToString())
+        New-Item -ItemType Directory -Path $TmpDir -Force | Out-Null
+
+        $ArchivePath = Join-Path $TmpDir $Asset
+
+        Write-Host "Downloading $Asset..." -ForegroundColor Cyan
+        try {
+            Invoke-WebRequest -Uri $Url -OutFile $ArchivePath -UseBasicParsing
+        } catch {
+            throw "download failed - check your network connection or try again later`n  URL: $Url"
+        }
+
+        # Extract
+        $ExtractDir = Join-Path $TmpDir "extracted"
+        try {
+            Expand-Archive -Path $ArchivePath -DestinationPath $ExtractDir -Force
+        } catch {
+            throw "failed to extract archive: $($_.Exception.Message)"
+        }
+
+        $BinaryPath = Join-Path $ExtractDir "$BinaryName.exe"
+        if (-not (Test-Path $BinaryPath)) {
+            throw "binary '$BinaryName.exe' not found in archive"
+        }
+
+        # Install
+        $Dest = Join-Path $BinDir "$BinaryName.exe"
+        try {
+            Copy-Item -Path $BinaryPath -Destination $Dest -Force
+        } catch {
+            throw "failed to install binary to $BinDir - is an existing database-mcp process running? ($($_.Exception.Message))"
+        }
+
+        # Verify
+        $InstalledVersion = ""
+        try {
+            $InstalledVersion = (& $Dest --version 2>&1 | Out-String).Trim()
+        } catch {
+            throw "installation verification failed - $Dest --version did not produce output"
+        }
+        if (-not $InstalledVersion) {
+            throw "installation verification failed - $Dest --version did not produce output"
+        }
+
+        Write-Host ""
+        if ($IsUpgrade) {
+            Write-Host "Successfully upgraded database-mcp!" -ForegroundColor Green
+            Write-Host "  $OldVersion -> $InstalledVersion"
+        } else {
+            Write-Host "Successfully installed database-mcp!" -ForegroundColor Green
+            Write-Host "  Version: $InstalledVersion"
+        }
+        Write-Host "  Location: $Dest"
+
+        # Check PATH and add if needed
+        Add-ToPath -Dir $BinDir
+
+        # Print guidance
+        Show-Guidance
+    }
+    catch {
+        Write-Host ""
+        Write-Host "error: $($_.Exception.Message)" -ForegroundColor Red
+        Write-Host ""
+        $global:LASTEXITCODE = 1
+    }
+    finally {
+        # Cleanup temp directory
+        if ($TmpDir -and (Test-Path $TmpDir)) {
+            Remove-Item -Path $TmpDir -Recurse -Force -ErrorAction SilentlyContinue
+        }
+    }
+}

--- a/docs/public/install.sh
+++ b/docs/public/install.sh
@@ -156,30 +156,6 @@ main() {
 
     # T013/T014: Upgrade messaging integrated into resolve_install_dir above
 
-    # T015: Post-install guidance
-    print_guidance() {
-        echo ""
-        info "What's next?"
-        echo ""
-        echo "  Add database-mcp to your MCP client config (.mcp.json):"
-        echo ""
-        echo "    {"
-        echo "      \"mcpServers\": {"
-        echo "        \"database-mcp\": {"
-        echo "          \"command\": \"database-mcp\","
-        echo "          \"env\": {"
-        echo "            \"DB_BACKEND\": \"postgres\","
-        echo "            \"DB_HOST\": \"localhost\","
-        echo "            \"DB_USER\": \"postgres\""
-        echo "          }"
-        echo "        }"
-        echo "      }"
-        echo "    }"
-        echo ""
-        echo "  Documentation: https://database.haymon.ai/docs/"
-        echo ""
-    }
-
     # T016: PATH check and instructions
     check_path() {
         _dir="$1"
@@ -290,9 +266,6 @@ main() {
 
     # T016: Check PATH
     check_path "$BIN_DIR"
-
-    # T015: Print guidance
-    print_guidance
 }
 
 main "$@"

--- a/docs/public/install.sh
+++ b/docs/public/install.sh
@@ -1,0 +1,298 @@
+#!/bin/sh
+# Install script for database-mcp
+# Usage: curl -fsSL https://database.haymon.ai/install.sh | bash
+#    or: wget -qO- https://database.haymon.ai/install.sh | bash
+#    or: sh install.sh
+#
+# Environment variables:
+#   INSTALL_DIR - Override the install directory (e.g., INSTALL_DIR=/opt/bin)
+
+set -eu
+
+main() {
+    # T002: TTY detection and color setup
+    if [ -t 1 ]; then
+        BOLD='\033[1m'
+        GREEN='\033[0;32m'
+        YELLOW='\033[0;33m'
+        RED='\033[0;31m'
+        RESET='\033[0m'
+    else
+        BOLD=''
+        GREEN=''
+        YELLOW=''
+        RED=''
+        RESET=''
+    fi
+
+    # T003: Utility functions
+    info() {
+        printf "${BOLD}%s${RESET}\n" "$1"
+    }
+
+    warn() {
+        printf "${YELLOW}warning${RESET}: %s\n" "$1" >&2
+    }
+
+    error() {
+        printf "${RED}error${RESET}: %s\n" "$1" >&2
+        exit 1
+    }
+
+    success() {
+        printf "${GREEN}%s${RESET}\n" "$1"
+    }
+
+    # T004: Download helper
+    download() {
+        _url="$1"
+        _output="$2"
+        if command -v curl > /dev/null 2>&1; then
+            curl -fsSL "$_url" -o "$_output"
+        elif command -v wget > /dev/null 2>&1; then
+            wget -qO "$_output" "$_url"
+        else
+            error "either 'curl' or 'wget' is required to download files"
+        fi
+    }
+
+    # T005: Platform detection
+    detect_platform() {
+        _os=$(uname -s)
+        _arch=$(uname -m)
+
+        case "$_os" in
+            Linux)  PLATFORM_OS="linux" ;;
+            Darwin) PLATFORM_OS="darwin" ;;
+            *)      error "unsupported operating system: $_os (supported: Linux, macOS)" ;;
+        esac
+
+        case "$_arch" in
+            x86_64|amd64)
+                PLATFORM_ARCH="x86_64"
+                # Rosetta detection on macOS
+                if [ "$PLATFORM_OS" = "darwin" ]; then
+                    _translated=$(sysctl -n sysctl.proc_translated 2>/dev/null || echo "0")
+                    if [ "$_translated" = "1" ]; then
+                        PLATFORM_ARCH="aarch64"
+                    fi
+                fi
+                ;;
+            aarch64|arm64)
+                PLATFORM_ARCH="aarch64"
+                ;;
+            *)
+                error "unsupported architecture: $_arch (supported: x86_64, aarch64/arm64)"
+                ;;
+        esac
+    }
+
+    # T006: Target triple mapping
+    get_target() {
+        case "${PLATFORM_OS}-${PLATFORM_ARCH}" in
+            linux-x86_64)   TARGET="x86_64-unknown-linux-gnu" ;;
+            linux-aarch64)  TARGET="aarch64-unknown-linux-gnu" ;;
+            darwin-x86_64)  TARGET="x86_64-apple-darwin" ;;
+            darwin-aarch64) TARGET="aarch64-apple-darwin" ;;
+            *)              error "no prebuilt binary for ${PLATFORM_OS}-${PLATFORM_ARCH}" ;;
+        esac
+    }
+
+    # T007: Install directory resolution
+    resolve_install_dir() {
+        UPGRADE=false
+        OLD_VERSION=""
+
+        # Priority 1: INSTALL_DIR env var
+        if [ -n "${INSTALL_DIR:-}" ]; then
+            BIN_DIR="$INSTALL_DIR"
+            if [ ! -d "$BIN_DIR" ]; then
+                mkdir -p "$BIN_DIR" 2>/dev/null || error "cannot create directory: $BIN_DIR"
+            fi
+            return
+        fi
+
+        # Priority 2: Existing binary detection (upgrade in-place)
+        _existing=$(command -v database-mcp 2>/dev/null || true)
+        if [ -n "$_existing" ]; then
+            # Resolve symlinks to find the actual binary location
+            _existing=$(readlink -f "$_existing" 2>/dev/null || echo "$_existing")
+            BIN_DIR=$(dirname "$_existing")
+            UPGRADE=true
+            OLD_VERSION=$("$_existing" --version 2>/dev/null || echo "unknown")
+            return
+        fi
+
+        # Priority 3: Default logic
+        # 3a: /usr/local/bin if writable
+        if [ -w "/usr/local/bin" ]; then
+            BIN_DIR="/usr/local/bin"
+            return
+        fi
+
+        # 3b: /usr/local/bin with sudo (if interactive)
+        if [ -t 0 ] && command -v sudo > /dev/null 2>&1; then
+            if sudo -n true 2>/dev/null; then
+                # sudo available without password
+                BIN_DIR="/usr/local/bin"
+                USE_SUDO=true
+                return
+            fi
+            # Try prompting for password
+            info "Administrator access is needed to install to /usr/local/bin"
+            if sudo true 2>/dev/null; then
+                BIN_DIR="/usr/local/bin"
+                USE_SUDO=true
+                return
+            fi
+        fi
+
+        # 3c: Fallback to ~/.local/bin
+        BIN_DIR="$HOME/.local/bin"
+        if [ ! -d "$BIN_DIR" ]; then
+            mkdir -p "$BIN_DIR"
+        fi
+    }
+
+    # T013/T014: Upgrade messaging integrated into resolve_install_dir above
+
+    # T015: Post-install guidance
+    print_guidance() {
+        echo ""
+        info "What's next?"
+        echo ""
+        echo "  Add database-mcp to your MCP client config (.mcp.json):"
+        echo ""
+        echo "    {"
+        echo "      \"mcpServers\": {"
+        echo "        \"database-mcp\": {"
+        echo "          \"command\": \"database-mcp\","
+        echo "          \"env\": {"
+        echo "            \"DB_BACKEND\": \"postgres\","
+        echo "            \"DB_HOST\": \"localhost\","
+        echo "            \"DB_USER\": \"postgres\""
+        echo "          }"
+        echo "        }"
+        echo "      }"
+        echo "    }"
+        echo ""
+        echo "  Documentation: https://database.haymon.ai/docs/"
+        echo ""
+    }
+
+    # T016: PATH check and instructions
+    check_path() {
+        _dir="$1"
+        case ":${PATH}:" in
+            *":${_dir}:"*) return ;; # already in PATH
+        esac
+
+        echo ""
+        warn "$_dir is not in your PATH"
+        echo ""
+
+        _shell_name=$(basename "${SHELL:-/bin/sh}")
+        case "$_shell_name" in
+            bash)
+                echo "  Add it to your PATH by running:"
+                echo ""
+                echo "    echo 'export PATH=\"$_dir:\$PATH\"' >> ~/.bashrc"
+                echo "    source ~/.bashrc"
+                ;;
+            zsh)
+                echo "  Add it to your PATH by running:"
+                echo ""
+                echo "    echo 'export PATH=\"$_dir:\$PATH\"' >> ~/.zshrc"
+                echo "    source ~/.zshrc"
+                ;;
+            fish)
+                echo "  Add it to your PATH by running:"
+                echo ""
+                echo "    fish_add_path $_dir"
+                ;;
+            *)
+                echo "  Add it to your PATH by adding this to your shell profile:"
+                echo ""
+                echo "    export PATH=\"$_dir:\$PATH\""
+                ;;
+        esac
+        echo ""
+    }
+
+    # --- Main flow (T008, T009-T012) ---
+
+    BINARY_NAME="database-mcp"
+    REPO="haymon-ai/database"
+    BASE_URL="https://github.com/${REPO}/releases/latest/download"
+    USE_SUDO=false
+
+    info "Installing database-mcp..."
+    echo ""
+
+    # T005-T006: Detect platform and target
+    detect_platform
+    get_target
+    info "Detected platform: ${PLATFORM_OS}/${PLATFORM_ARCH} (${TARGET})"
+
+    # T007: Resolve install directory
+    resolve_install_dir
+
+    if [ "$UPGRADE" = true ]; then
+        info "Upgrading database-mcp at ${BIN_DIR} (current: ${OLD_VERSION})"
+    else
+        info "Install directory: ${BIN_DIR}"
+    fi
+
+    # T008: Temp directory with cleanup trap
+    _tmpdir=$(mktemp -d 2>/dev/null || mktemp -d -t database-mcp)
+    trap 'rm -rf "$_tmpdir"' EXIT
+
+    # T009: Download
+    _asset="${BINARY_NAME}-${TARGET}.tar.gz"
+    _url="${BASE_URL}/${_asset}"
+    _archive="${_tmpdir}/${_asset}"
+
+    info "Downloading ${_asset}..."
+    download "$_url" "$_archive" || error "download failed — check your network connection or try again later"
+
+    # T010: Extract and install
+    tar xzf "$_archive" -C "$_tmpdir" || error "failed to extract archive"
+
+    _binary="${_tmpdir}/${BINARY_NAME}"
+    if [ ! -f "$_binary" ]; then
+        error "binary '${BINARY_NAME}' not found in archive"
+    fi
+
+    chmod +x "$_binary"
+
+    _dest="${BIN_DIR}/${BINARY_NAME}"
+    if [ "$USE_SUDO" = true ]; then
+        sudo install -m 755 "$_binary" "$_dest" || error "failed to install binary to ${BIN_DIR} (sudo)"
+    else
+        install -m 755 "$_binary" "$_dest" 2>/dev/null || cp "$_binary" "$_dest" || error "failed to install binary to ${BIN_DIR}"
+    fi
+
+    # T011: Post-install verification
+    _installed_version=$("$_dest" --version 2>/dev/null || true)
+    if [ -z "$_installed_version" ]; then
+        error "installation verification failed — ${_dest} --version did not produce output"
+    fi
+
+    echo ""
+    if [ "$UPGRADE" = true ]; then
+        success "Successfully upgraded database-mcp!"
+        echo "  ${OLD_VERSION} → ${_installed_version}"
+    else
+        success "Successfully installed database-mcp!"
+        echo "  Version: ${_installed_version}"
+    fi
+    echo "  Location: ${_dest}"
+
+    # T016: Check PATH
+    check_path "$BIN_DIR"
+
+    # T015: Print guidance
+    print_guidance
+}
+
+main "$@"


### PR DESCRIPTION
## Summary

- Add `docs/public/install.sh` (POSIX shell), `install.ps1` (PowerShell), and `install.cmd` (Windows CMD) — all served from the docs site so users can install with a single copy-paste command.
- Update the docs homepage, installation page, and README to feature the one-liner install commands prominently.
- Auto-detect platform and arch (including Rosetta on Apple Silicon), upgrade existing installs in-place, support `INSTALL_DIR` override, add install dir to PATH, and print post-install guidance.

Closes #95

## Usage

**macOS / Linux**:

```bash
curl -fsSL https://database.haymon.ai/install.sh | bash
```

**Windows PowerShell**:

```powershell
irm https://database.haymon.ai/install.ps1 | iex
```

**Windows CMD**:

```batch
curl -fsSL https://database.haymon.ai/install.cmd -o install.cmd && install.cmd && del install.cmd
```

## Implementation notes

- `install.sh` is POSIX-compliant (`#!/bin/sh`), wraps everything in a `main()` function to prevent partial execution when piped from curl, and uses `trap EXIT` for temp cleanup.
- `install.ps1` is wrapped in `& { ... }` to scope variables/functions and avoid terminating the user's shell on error when run via `iex`. TLS 1.2 is explicitly enforced for compatibility with older .NET defaults.
- `install.cmd` delegates PATH modification to a PowerShell one-liner using `[Environment]::SetEnvironmentVariable` to avoid the 1024-char `setx` truncation bug and preserve `REG_EXPAND_SZ` type.
- Scripts install to `/usr/local/bin` (sudo if needed) or `~/.local/bin` (Unix), or `%LOCALAPPDATA%\Programs\database-mcp` (Windows) by default. On upgrade, the existing binary location is detected and upgraded in-place to avoid orphaned copies.

## Test plan

- [x] `install.sh` fresh install on Linux x86_64 (tested locally)
- [x] `install.sh` upgrade detection (existing binary on PATH upgraded in-place)
- [x] `install.sh` PATH setup instructions for bash/zsh/fish
- [x] `install.sh` POSIX syntax validation (`sh -n`)
- [ ] `install.sh` on macOS (Intel + Apple Silicon + Rosetta path)
- [ ] `install.sh` on Linux aarch64
- [ ] `install.ps1` via `irm | iex` on Windows 10/11
- [ ] `install.ps1` error path does NOT terminate user's PowerShell session
- [ ] `install.cmd` via `curl ... | install.cmd` on Windows 10/11
- [ ] `install.cmd` PATH update preserves existing entries (no truncation)
- [ ] Verify docs site serves scripts from `docs/public/` after deployment