### PR TITLE
fix(tools): omit input_schema for list_databases

### DIFF
--- a/crates/mysql/src/tools/list_databases.rs
+++ b/crates/mysql/src/tools/list_databases.rs
@@ -6,7 +6,6 @@ use std::sync::Arc;
 use database_mcp_server::AppError;
 use database_mcp_server::types::ListDatabasesResponse;
 use database_mcp_sql::Connection as _;
-use rmcp::handler::server::common::schema_for_empty_input;
 use rmcp::handler::server::router::tool::{AsyncTool, ToolBase};
 use rmcp::model::{ErrorData, JsonObject, ToolAnnotations};
 
@@ -50,7 +49,7 @@ impl ToolBase for ListDatabasesTool {
     }
 
     fn input_schema() -> Option<Arc<JsonObject>> {
-        Some(schema_for_empty_input())
+        None
     }
 
     fn annotations() -> Option<ToolAnnotations> {

--- a/crates/postgres/src/tools/list_databases.rs
+++ b/crates/postgres/src/tools/list_databases.rs
@@ -6,7 +6,6 @@ use std::sync::Arc;
 use database_mcp_server::AppError;
 use database_mcp_server::types::ListDatabasesResponse;
 use database_mcp_sql::Connection as _;
-use rmcp::handler::server::common::schema_for_empty_input;
 use rmcp::handler::server::router::tool::{AsyncTool, ToolBase};
 use rmcp::model::{ErrorData, JsonObject, ToolAnnotations};
 use serde_json::Value;
@@ -51,7 +50,7 @@ impl ToolBase for ListDatabasesTool {
     }
 
     fn input_schema() -> Option<Arc<JsonObject>> {
-        Some(schema_for_empty_input())
+        None
     }
 
     fn annotations() -> Option<ToolAnnotations> {


### PR DESCRIPTION
## Summary
- `list_databases` is a parameter-less tool but was advertising a schema generated by `schema_for_empty_input()`
- Return `None` from `input_schema()` in both the MySQL and Postgres tool implementations so clients see the tool as truly parameter-less
- No behavioral change inside the handler — only the advertised MCP tool metadata

## Test plan
- [x] `./tests/run.sh --type approval` (all 4 backends, 12/12 pass)
- [x] `cargo fmt --check` / `cargo clippy --workspace --tests -- -D warnings` (run before pushing)
- [x] Snapshots verified unchanged — the fix does not alter `list_tools` output shape