### PR TITLE
fix(install): no-op when already on latest version (#106)

### DIFF
--- a/docs/public/install.cmd
+++ b/docs/public/install.cmd
@@ -5,7 +5,16 @@ REM Install script for database-mcp (Windows CMD)
 REM Usage: curl -fsSL https://database.haymon.ai/install.cmd -o install.cmd && install.cmd && del install.cmd
 REM
 REM Environment variables:
-REM   INSTALL_DIR - Override the install directory
+REM   INSTALL_DIR   - Override the install directory
+REM   FORCE_INSTALL - When set to a truthy value (1/true/yes/on/y, case-insensitive)
+REM                   reinstall even if the installed version already matches the
+REM                   latest published release. Without this, re-running the
+REM                   script on an up-to-date install is a no-op (no download,
+REM                   no file writes).
+REM
+REM The script probes https://github.com/haymon-ai/database/releases/latest
+REM (a HEAD request that follows redirects) to learn the latest version. The
+REM no-op path performs zero downloads and zero writes to the install directory.
 
 set "BINARY_NAME=database-mcp"
 set "REPO=haymon-ai/database"
@@ -13,6 +22,7 @@ set "TARGET=x86_64-pc-windows-msvc"
 set "ASSET=%BINARY_NAME%-%TARGET%.zip"
 set "BASE_URL=https://github.com/%REPO%/releases/latest/download"
 set "URL=%BASE_URL%/%ASSET%"
+set "IS_REINSTALL=0"
 
 echo.
 echo Installing database-mcp...
@@ -26,6 +36,16 @@ set "OLD_VERSION="
 REM Priority 1: INSTALL_DIR env var
 if defined INSTALL_DIR (
     set "BIN_DIR=%INSTALL_DIR%"
+    REM If a binary already exists at the override location, treat as an
+    REM upgrade so the no-op check applies to the binary that will actually
+    REM be replaced (spec Edge Cases). Pre-seed OLD_VERSION to `unknown` so
+    REM that if --version fails, downstream code sees a sentinel rather than
+    REM an empty string (the for /f below silently overwrites on success).
+    if exist "%INSTALL_DIR%\%BINARY_NAME%.exe" (
+        set "IS_UPGRADE=1"
+        set "OLD_VERSION=unknown"
+        for /f "delims=" %%v in ('""%INSTALL_DIR%\%BINARY_NAME%.exe" --version" 2^>nul') do set "OLD_VERSION=%%v"
+    )
     goto :resolved
 )
 
@@ -44,6 +64,7 @@ for %%i in ("%EXISTING%") do set "BIN_DIR=%%~dpi"
 REM Remove trailing backslash
 if "%BIN_DIR:~-1%"=="\" set "BIN_DIR=%BIN_DIR:~0,-1%"
 set "IS_UPGRADE=1"
+set "OLD_VERSION=unknown"
 for /f "delims=" %%v in ('""%EXISTING%" --version" 2^>nul') do set "OLD_VERSION=%%v"
 goto :resolved
 
@@ -53,11 +74,90 @@ set "BIN_DIR=%LOCALAPPDATA%\Programs\database-mcp"
 
 :resolved
 if %IS_UPGRADE% equ 1 (
-    echo Upgrading database-mcp at %BIN_DIR% ^(current: %OLD_VERSION%^)
+    echo Found existing database-mcp at %BIN_DIR% ^(%OLD_VERSION%^)
 ) else (
     echo Install directory: %BIN_DIR%
+    goto :prepare_install
 )
 
+REM ---------------------------------------------------------------------------
+REM No-op / force / newer-than-latest check.
+REM Only runs on the upgrade path (an existing binary was detected). Delegates
+REM HTTP + URL parsing + version comparison to a single PowerShell call that
+REM prints one line of the form "<ACTION> <tag>". ACTION is one of:
+REM   NOOP    - installed matches latest, FORCE_INSTALL not set   -> skip install
+REM   FORCE   - installed matches latest, FORCE_INSTALL set       -> reinstall
+REM   NEWER   - installed is newer than latest                    -> warn + install
+REM   UPGRADE - installed is older than latest                    -> normal upgrade
+REM If PowerShell fails or the lookup cannot be performed, the command emits
+REM nothing, ACTION stays empty, and the script falls through to the normal
+REM download-and-install flow (FR-011).
+REM ---------------------------------------------------------------------------
+set "ACTION="
+set "LATEST_VERSION="
+set "DBMCP_OLD_VERSION=%OLD_VERSION%"
+set "DBMCP_FORCE=%FORCE_INSTALL%"
+set "DBMCP_REPO=%REPO%"
+
+REM Write a small helper script to a temp file and invoke it. This keeps the
+REM PowerShell logic readable without relying on the fragile combination of
+REM `for /f`, backquotes, and caret line-continuation.
+set "NOOP_HELPER=%TEMP%\database-mcp-noop-%RANDOM%%RANDOM%.ps1"
+> "%NOOP_HELPER%" echo $ErrorActionPreference='SilentlyContinue'
+>>"%NOOP_HELPER%" echo try { [Net.ServicePointManager]::SecurityProtocol = [Net.ServicePointManager]::SecurityProtocol -bor [Net.SecurityProtocolType]::Tls12 } catch {}
+>>"%NOOP_HELPER%" echo $r = $null
+>>"%NOOP_HELPER%" echo try { $r = Invoke-WebRequest -Uri ('https://github.com/' + $env:DBMCP_REPO + '/releases/latest') -Method Head -MaximumRedirection 5 -UseBasicParsing -TimeoutSec 20 -ErrorAction Stop } catch { exit 0 }
+>>"%NOOP_HELPER%" echo if (-not $r -or -not $r.BaseResponse) { exit 0 }
+>>"%NOOP_HELPER%" echo $u = $null
+>>"%NOOP_HELPER%" echo if ($r.BaseResponse.PSObject.Properties['ResponseUri'] -and $r.BaseResponse.ResponseUri) { $u = $r.BaseResponse.ResponseUri.AbsoluteUri } elseif ($r.BaseResponse.PSObject.Properties['RequestMessage'] -and $r.BaseResponse.RequestMessage -and $r.BaseResponse.RequestMessage.RequestUri) { $u = $r.BaseResponse.RequestMessage.RequestUri.AbsoluteUri }
+>>"%NOOP_HELPER%" echo if (-not $u) { exit 0 }
+>>"%NOOP_HELPER%" echo $tag = $u.TrimEnd('/').Split('/')[-1]
+>>"%NOOP_HELPER%" echo if (-not ($tag -match '^^v?[0-9]')) { exit 0 }
+>>"%NOOP_HELPER%" echo $inst = $env:DBMCP_OLD_VERSION
+>>"%NOOP_HELPER%" echo if (-not $inst) { exit 0 }
+>>"%NOOP_HELPER%" echo $iN = $inst.Trim()
+>>"%NOOP_HELPER%" echo if ($iN.StartsWith('database-mcp ')) { $iN = $iN.Substring('database-mcp '.Length) }
+>>"%NOOP_HELPER%" echo if ($iN.StartsWith('v') -or $iN.StartsWith('V')) { $iN = $iN.Substring(1) }
+>>"%NOOP_HELPER%" echo $lN = $tag
+>>"%NOOP_HELPER%" echo if ($lN.StartsWith('v') -or $lN.StartsWith('V')) { $lN = $lN.Substring(1) }
+>>"%NOOP_HELPER%" echo $truthy = $false
+>>"%NOOP_HELPER%" echo $force = $env:DBMCP_FORCE
+>>"%NOOP_HELPER%" echo if ($force) { $truthy = @('1','true','yes','on','y') -contains $force.ToLowerInvariant() }
+>>"%NOOP_HELPER%" echo if ($iN -eq $lN) { if ($truthy) { Write-Output ('FORCE ' + $tag) } else { Write-Output ('NOOP ' + $tag) }; exit 0 }
+>>"%NOOP_HELPER%" echo try { $iC = $iN.Split('-')[0]; $lC = $lN.Split('-')[0]; if ($iC -notmatch '\.') { $iC = $iC + '.0' }; if ($lC -notmatch '\.') { $lC = $lC + '.0' }; if ([version]$iC -gt [version]$lC) { Write-Output ('NEWER ' + $tag); exit 0 } } catch {}
+>>"%NOOP_HELPER%" echo Write-Output ('UPGRADE ' + $tag)
+
+for /f "usebackq tokens=1,2 delims= " %%a in (`powershell -NoProfile -ExecutionPolicy Bypass -File "%NOOP_HELPER%" 2^>nul`) do (
+    set "ACTION=%%a"
+    set "LATEST_VERSION=%%b"
+)
+del /q "%NOOP_HELPER%" 2>nul
+set "NOOP_HELPER="
+set "DBMCP_OLD_VERSION="
+set "DBMCP_FORCE="
+set "DBMCP_REPO="
+
+if /i "%ACTION%"=="NOOP" (
+    echo.
+    echo Already on latest version ^(%LATEST_VERSION%^). Nothing to do.
+    exit /b 0
+)
+if /i "%ACTION%"=="FORCE" (
+    set "IS_REINSTALL=1"
+    echo FORCE_INSTALL is set - reinstalling %LATEST_VERSION%
+)
+if /i "%ACTION%"=="NEWER" (
+    echo warning: installed version %OLD_VERSION% is newer than the latest release %LATEST_VERSION%.
+    echo          proceeding will replace it with the older release.
+)
+if /i "%ACTION%"=="UPGRADE" (
+    echo Upgrading to %LATEST_VERSION%
+)
+if "%ACTION%"=="" (
+    echo Upgrading database-mcp at %BIN_DIR% ^(current: %OLD_VERSION%^)
+)
+
+:prepare_install
 REM Create install directory if needed
 if not exist "%BIN_DIR%" mkdir "%BIN_DIR%"
 
@@ -105,12 +205,17 @@ if not defined INSTALLED_VERSION (
 )
 
 echo.
-if %IS_UPGRADE% equ 1 (
-    echo Successfully upgraded database-mcp!
-    echo   %OLD_VERSION% -^> %INSTALLED_VERSION%
-) else (
-    echo Successfully installed database-mcp!
+if %IS_REINSTALL% equ 1 (
+    echo Successfully reinstalled database-mcp!
     echo   Version: %INSTALLED_VERSION%
+) else (
+    if %IS_UPGRADE% equ 1 (
+        echo Successfully upgraded database-mcp!
+        echo   %OLD_VERSION% -^> %INSTALLED_VERSION%
+    ) else (
+        echo Successfully installed database-mcp!
+        echo   Version: %INSTALLED_VERSION%
+    )
 )
 echo   Location: %BIN_DIR%\%BINARY_NAME%.exe
 

--- a/docs/public/install.ps1
+++ b/docs/public/install.ps1
@@ -3,15 +3,91 @@
 #    or: powershell -ExecutionPolicy Bypass -File install.ps1
 #
 # Environment variables:
-#   INSTALL_DIR - Override the install directory
+#   INSTALL_DIR   - Override the install directory
+#   FORCE_INSTALL - When set to a truthy value (1/true/yes/on/y, case-insensitive)
+#                   reinstall even if the installed version already matches the
+#                   latest published release. Without this, re-running the
+#                   script on an up-to-date install is a no-op (no download,
+#                   no file writes).
+#
+# The script probes https://github.com/haymon-ai/database/releases/latest
+# (a HEAD request that follows redirects) to learn the latest version. The
+# no-op path performs zero downloads and zero writes to the install directory.
 
 & {
     $ErrorActionPreference = "Stop"
 
-    # Enforce TLS 1.2 for GitHub downloads (required on older .NET defaults)
+    # Enforce TLS 1.2 for GitHub downloads (required on older .NET defaults).
+    # Silent fallthrough is intentional: on older .NET that doesn't expose
+    # Tls12, we can't do anything, and the subsequent Invoke-WebRequest will
+    # fail with a clear error if the connection can't be negotiated.
     try {
         [Net.ServicePointManager]::SecurityProtocol = [Net.ServicePointManager]::SecurityProtocol -bor [Net.SecurityProtocolType]::Tls12
-    } catch {}
+    } catch {
+        $null = $_
+    }
+
+    function Test-Truthy {
+        param([string]$Value)
+        if (-not $Value) { return $false }
+        return @('1','true','yes','on','y') -contains $Value.ToLowerInvariant()
+    }
+
+    function Get-NormalizedVersion {
+        param([string]$Version)
+        if (-not $Version) { return '' }
+        $v = $Version.Trim()
+        if ($v.StartsWith('database-mcp ')) { $v = $v.Substring('database-mcp '.Length) }
+        if ($v.StartsWith('v') -or $v.StartsWith('V')) { $v = $v.Substring(1) }
+        return $v
+    }
+
+    function Resolve-LatestVersion {
+        param([string]$Repo)
+        $LatestUrl = "https://github.com/$Repo/releases/latest"
+        $resp = $null
+        try {
+            # Short timeout: the no-op path should be quick or not at all;
+            # we don't want to hang for 100+ seconds on a broken network.
+            $resp = Invoke-WebRequest -Uri $LatestUrl -Method Head -MaximumRedirection 5 -UseBasicParsing -TimeoutSec 20 -ErrorAction Stop
+        } catch {
+            return $null
+        }
+        if (-not $resp -or -not $resp.BaseResponse) { return $null }
+        # The final redirect target is exposed differently across PowerShell
+        # versions, so try both paths:
+        #   PS 5.1 (Desktop)  -> BaseResponse is HttpWebResponse      -> .ResponseUri
+        #   PS 7+  (Core)     -> BaseResponse is HttpResponseMessage  -> .RequestMessage.RequestUri
+        # Never fall back to $resp.Headers['Location']: that is the FIRST
+        # redirect's target and is incorrect on multi-hop chains.
+        $finalUri = $null
+        if ($resp.BaseResponse.PSObject.Properties['ResponseUri'] -and $resp.BaseResponse.ResponseUri) {
+            $finalUri = $resp.BaseResponse.ResponseUri.AbsoluteUri
+        } elseif ($resp.BaseResponse.PSObject.Properties['RequestMessage'] -and $resp.BaseResponse.RequestMessage -and $resp.BaseResponse.RequestMessage.RequestUri) {
+            $finalUri = $resp.BaseResponse.RequestMessage.RequestUri.AbsoluteUri
+        }
+        if (-not $finalUri) { return $null }
+        $tag = $finalUri.TrimEnd('/').Split('/')[-1]
+        if (-not $tag) { return $null }
+        if ($tag -notmatch '^v?[0-9]') { return $null }
+        return $tag
+    }
+
+    function Test-InstalledNewerThanLatest {
+        param([string]$InstalledNorm, [string]$LatestNorm)
+        if (-not $InstalledNorm -or -not $LatestNorm) { return $false }
+        try {
+            # Split on `-` to drop pre-release/build suffixes (e.g. `0.7.0-dev`).
+            # [version] requires at least major.minor; pad with `.0` if needed.
+            $iCore = $InstalledNorm.Split('-')[0]
+            $lCore = $LatestNorm.Split('-')[0]
+            if ($iCore -notmatch '\.') { $iCore = "$iCore.0" }
+            if ($lCore -notmatch '\.') { $lCore = "$lCore.0" }
+            return ([version]$iCore -gt [version]$lCore)
+        } catch {
+            return $false
+        }
+    }
 
     function Resolve-InstallDir {
         param([string]$BinaryName)
@@ -19,6 +95,20 @@
         # Priority 1: INSTALL_DIR env var
         $EnvDir = $env:INSTALL_DIR
         if ($EnvDir) {
+            # If a binary already exists at the override location, treat as
+            # an upgrade so the no-op check applies to the binary that will
+            # actually be replaced (spec Edge Cases).
+            $candidate = Join-Path $EnvDir "$BinaryName.exe"
+            if (Test-Path -LiteralPath $candidate) {
+                $oldVer = ""
+                try {
+                    $oldVer = (& $candidate --version 2>&1 | Out-String).Trim()
+                } catch {
+                    $oldVer = ""
+                }
+                if (-not $oldVer) { $oldVer = "unknown" }
+                return @{ Path = $EnvDir; IsUpgrade = $true; OldVersion = $oldVer }
+            }
             return @{ Path = $EnvDir; IsUpgrade = $false; OldVersion = "" }
         }
 
@@ -29,7 +119,10 @@
             $OldVer = ""
             try {
                 $OldVer = (& $Existing.Source --version 2>&1 | Out-String).Trim()
-            } catch {}
+            } catch {
+                $OldVer = ""
+            }
+            if (-not $OldVer) { $OldVer = "unknown" }
             return @{ Path = $ExistingPath; IsUpgrade = $true; OldVersion = "$OldVer" }
         }
 
@@ -85,6 +178,7 @@
     $Url = "$BaseUrl/$Asset"
 
     $TmpDir = $null
+    $ForceReinstall = $false
 
     try {
         Write-Host ""
@@ -98,7 +192,36 @@
         $BinDir = $InstallInfo.Path
 
         if ($IsUpgrade) {
-            Write-Host "Upgrading database-mcp at $BinDir (current: $OldVersion)" -ForegroundColor Cyan
+            Write-Host "Found existing database-mcp at $BinDir ($OldVersion)" -ForegroundColor Cyan
+
+            # No-op / force / newer-than-latest check. Only runs when an
+            # existing binary was detected. Skipped entirely if the version
+            # lookup fails, so a network issue never silently claims
+            # "already up to date".
+            $LatestVersion = Resolve-LatestVersion -Repo $Repo
+            if ($LatestVersion -and $OldVersion) {
+                $InstalledNorm = Get-NormalizedVersion $OldVersion
+                $LatestNorm = Get-NormalizedVersion $LatestVersion
+
+                if ($InstalledNorm -eq $LatestNorm -and $InstalledNorm) {
+                    if (Test-Truthy $env:FORCE_INSTALL) {
+                        $ForceReinstall = $true
+                        Write-Host "FORCE_INSTALL is set - reinstalling $LatestVersion" -ForegroundColor Cyan
+                    } else {
+                        Write-Host ""
+                        Write-Host "Already on latest version ($LatestVersion). Nothing to do." -ForegroundColor Green
+                        return
+                    }
+                } else {
+                    if (Test-InstalledNewerThanLatest -InstalledNorm $InstalledNorm -LatestNorm $LatestNorm) {
+                        Write-Host "warning: installed version $OldVersion is newer than the latest release $LatestVersion." -ForegroundColor Yellow
+                        Write-Host "         proceeding will replace it with the older release." -ForegroundColor Yellow
+                    }
+                    Write-Host "Upgrading to $LatestVersion" -ForegroundColor Cyan
+                }
+            } else {
+                Write-Host "Upgrading database-mcp at $BinDir (current: $OldVersion)" -ForegroundColor Cyan
+            }
         } else {
             Write-Host "Install directory: $BinDir" -ForegroundColor Cyan
         }
@@ -154,7 +277,10 @@
         }
 
         Write-Host ""
-        if ($IsUpgrade) {
+        if ($ForceReinstall) {
+            Write-Host "Successfully reinstalled database-mcp!" -ForegroundColor Green
+            Write-Host "  Version: $InstalledVersion"
+        } elseif ($IsUpgrade) {
             Write-Host "Successfully upgraded database-mcp!" -ForegroundColor Green
             Write-Host "  $OldVersion -> $InstalledVersion"
         } else {

--- a/docs/public/install.sh
+++ b/docs/public/install.sh
@@ -5,7 +5,16 @@
 #    or: sh install.sh
 #
 # Environment variables:
-#   INSTALL_DIR - Override the install directory (e.g., INSTALL_DIR=/opt/bin)
+#   INSTALL_DIR   - Override the install directory (e.g., INSTALL_DIR=/opt/bin)
+#   FORCE_INSTALL - When set to a truthy value (1/true/yes/on/y, case-insensitive)
+#                   reinstall even if the installed version already matches the
+#                   latest published release. Without this, re-running the
+#                   script on an up-to-date install is a no-op (no download,
+#                   no file writes).
+#
+# The script probes https://github.com/haymon-ai/database/releases/latest
+# (a HEAD request that follows redirects) to learn the latest version. The
+# no-op path performs zero downloads and zero writes to the install directory.
 
 set -eu
 
@@ -54,6 +63,88 @@ main() {
         else
             error "either 'curl' or 'wget' is required to download files"
         fi
+    }
+
+    # Return 0 if $1 is a truthy env-var value (1/true/yes/on/y, case-insensitive).
+    is_truthy() {
+        case "$1" in
+            1|[Tt][Rr][Uu][Ee]|[Yy][Ee][Ss]|[Oo][Nn]|[Yy]) return 0 ;;
+            *) return 1 ;;
+        esac
+    }
+
+    # Normalise a version string for comparison: trim whitespace, strip
+    # binary-name prefix, strip a leading `v`. Uses `-e ... -e ...` instead of
+    # `;` for BSD sed compatibility (macOS sed is fine with `;` but `-e` is
+    # universally portable).
+    normalize_version() {
+        _v=$(printf '%s' "$1" | sed -e 's/^[[:space:]]*//' -e 's/[[:space:]]*$//')
+        _v=${_v#database-mcp }
+        _v=${_v#v}
+        printf '%s' "$_v"
+    }
+
+    # Portable "is version $1 strictly greater than version $2?" comparator.
+    # Uses pure POSIX shell: no `sort -V` (GNU-only, missing on macOS BSD).
+    # Both inputs must already be normalised (no `v` prefix, no whitespace).
+    # Pre-release / build suffixes are dropped (`0.7.0-dev` -> `0.7.0`) to
+    # match what `Test-InstalledNewerThanLatest` does in install.ps1.
+    version_gt() {
+        _va=${1%%-*}
+        _vb=${2%%-*}
+        # Split on `.` via IFS. Function-local IFS via a subshell would be
+        # cleaner but costs a fork per call; save/restore instead.
+        _ifs_save=$IFS
+        IFS=.
+        # shellcheck disable=SC2086  # intentional word splitting
+        set -- $_va
+        _a1=${1:-0}; _a2=${2:-0}; _a3=${3:-0}
+        # shellcheck disable=SC2086
+        set -- $_vb
+        _b1=${1:-0}; _b2=${2:-0}; _b3=${3:-0}
+        IFS=$_ifs_save
+        # Guard against non-numeric components (e.g. `rc1`) by rejecting the
+        # comparison and returning "not newer" so the caller falls through to
+        # the normal upgrade path without warning.
+        case "${_a1}${_a2}${_a3}${_b1}${_b2}${_b3}" in
+            *[!0-9]*) return 1 ;;
+            *) ;;
+        esac
+        [ "$_a1" -gt "$_b1" ] && return 0
+        [ "$_a1" -lt "$_b1" ] && return 1
+        [ "$_a2" -gt "$_b2" ] && return 0
+        [ "$_a2" -lt "$_b2" ] && return 1
+        [ "$_a3" -gt "$_b3" ] && return 0
+        return 1
+    }
+
+    # Resolve the latest release tag (e.g. `v0.6.2`) by following the
+    # `releases/latest` redirect. Prints the tag on stdout and returns 0 on
+    # success; returns 1 (with no output) if the lookup fails for any reason.
+    # A short connect timeout ensures slow/broken networks fail fast rather
+    # than hanging at curl's default 2-minute connect timeout — the no-op
+    # path is supposed to be quick or not at all.
+    resolve_latest_version() {
+        _latest_url="https://github.com/${REPO}/releases/latest"
+        _final=""
+        if command -v curl > /dev/null 2>&1; then
+            _final=$(curl -fsSLI --connect-timeout 10 --max-time 20 \
+                -o /dev/null -w '%{url_effective}' "$_latest_url" 2>/dev/null) \
+                || return 1
+        elif command -v wget > /dev/null 2>&1; then
+            _final=$(wget --server-response --max-redirect=5 --spider \
+                --timeout=20 --tries=1 "$_latest_url" 2>&1 \
+                | awk '/^[[:space:]]*Location:/ {loc=$2} END {print loc}') \
+                || return 1
+        else
+            return 1
+        fi
+        _tag=${_final##*/}
+        [ -n "$_tag" ] || return 1
+        case "$_tag" in
+            v[0-9]*|[0-9]*) printf '%s' "$_tag"; return 0 ;;
+            *) return 1 ;;
+        esac
     }
 
     # T005: Platform detection
@@ -108,6 +199,13 @@ main() {
             BIN_DIR="$INSTALL_DIR"
             if [ ! -d "$BIN_DIR" ]; then
                 mkdir -p "$BIN_DIR" 2>/dev/null || error "cannot create directory: $BIN_DIR"
+            fi
+            # If a binary already exists at the override location, treat as an
+            # upgrade so the no-op check applies to the binary that will
+            # actually be replaced (spec Edge Cases).
+            if [ -x "$BIN_DIR/$BINARY_NAME" ]; then
+                UPGRADE=true
+                OLD_VERSION=$("$BIN_DIR/$BINARY_NAME" --version 2>/dev/null || echo "unknown")
             fi
             return
         fi
@@ -201,6 +299,7 @@ main() {
     REPO="haymon-ai/database"
     BASE_URL="https://github.com/${REPO}/releases/latest/download"
     USE_SUDO=false
+    FORCE_REINSTALL=false
 
     info "Installing database-mcp..."
     echo ""
@@ -214,7 +313,38 @@ main() {
     resolve_install_dir
 
     if [ "$UPGRADE" = true ]; then
-        info "Upgrading database-mcp at ${BIN_DIR} (current: ${OLD_VERSION})"
+        info "Found existing database-mcp at ${BIN_DIR} (${OLD_VERSION})"
+
+        # No-op / force / newer-than-latest check. Only runs when an existing
+        # binary was detected. Skipped entirely if the version lookup fails,
+        # so a network issue never silently claims "already up to date".
+        _latest_version=$(resolve_latest_version 2>/dev/null || printf '')
+        if [ -n "$_latest_version" ] && [ "$OLD_VERSION" != "unknown" ]; then
+            _installed_norm=$(normalize_version "$OLD_VERSION")
+            _latest_norm=$(normalize_version "$_latest_version")
+
+            if [ "$_installed_norm" = "$_latest_norm" ]; then
+                if is_truthy "${FORCE_INSTALL:-}"; then
+                    FORCE_REINSTALL=true
+                    info "FORCE_INSTALL is set - reinstalling ${_latest_version}"
+                else
+                    success "Already on latest version (${_latest_version}). Nothing to do."
+                    return 0
+                fi
+            else
+                # Versions differ. If the installed side is strictly newer
+                # than the latest, warn loudly before proceeding with a
+                # downgrade (see FR-011a). On non-numeric versions (e.g.
+                # `rc1`) `version_gt` returns "not newer" and we silently
+                # fall through to the normal upgrade path.
+                if version_gt "$_installed_norm" "$_latest_norm"; then
+                    warn "installed ${OLD_VERSION} is newer than the latest release ${_latest_version}; proceeding will downgrade it."
+                fi
+                info "Upgrading to ${_latest_version}"
+            fi
+        else
+            info "Upgrading database-mcp at ${BIN_DIR} (current: ${OLD_VERSION})"
+        fi
     else
         info "Install directory: ${BIN_DIR}"
     fi
@@ -255,7 +385,10 @@ main() {
     fi
 
     echo ""
-    if [ "$UPGRADE" = true ]; then
+    if [ "$FORCE_REINSTALL" = true ]; then
+        success "Successfully reinstalled database-mcp!"
+        echo "  Version: ${_installed_version}"
+    elif [ "$UPGRADE" = true ]; then
         success "Successfully upgraded database-mcp!"
         echo "  ${OLD_VERSION} → ${_installed_version}"
     else


### PR DESCRIPTION
## Summary

Closes #106.

Re-running `install.sh`, `install.ps1`, or `install.cmd` against an already-up-to-date installation now skips the download/extract/replace steps entirely and prints `Already on latest version (vX.Y.Z). Nothing to do.` before exiting `0`. Previously every re-run did a full reinstall of the same version, which was misleading in interactive use and broke CI pipelines that wanted to branch on "upgraded" vs. "no-op".

The check follows the `releases/latest` redirect via a HEAD request (no GitHub API, no rate limit, no extra dependency), normalises both version strings, and compares. On match → exit early with zero downloads and zero filesystem writes. On mismatch → existing upgrade flow. Truly broken version lookups fall through silently rather than claiming a false no-op.

## Behaviour

| Scenario | Result |
|---|---|
| Installed version = latest | `Already on latest version (vX.Y.Z). Nothing to do.` (exit 0, no download) |
| Installed version < latest | Existing upgrade flow → `Successfully upgraded database-mcp!` |
| Installed version > latest (e.g. local dev build) | Yellow warning naming both versions, then downgrade |
| Fresh install (no existing binary) | Existing fresh-install flow, unchanged |
| `FORCE_INSTALL=1` re-run on up-to-date install | `Successfully reinstalled database-mcp!` (distinct from upgrade line for CI) |
| Version lookup fails (network, rate limit) | Fall through to normal install, never silently no-op |
| `INSTALL_DIR` override contains an existing binary | No-op check now applies to it too |

`FORCE_INSTALL` accepts `1`, `true`, `yes`, `on`, `y` (case-insensitive).

## Cross-platform hardening

- **install.ps1 was silently broken on PowerShell 7** — `BaseResponse.ResponseUri` only exists on PS 5.1's `HttpWebResponse`; PS 7 uses `HttpResponseMessage` with `RequestMessage.RequestUri`. Fixed via `PSObject.Properties` introspection to handle both. Verified live on pwsh 7.5.
- **install.sh** uses a portable pure-POSIX `version_gt` instead of `sort -V` (GNU-only, unavailable on macOS BSD).
- **install.cmd** delegates HTTP + version comparison to a tiny PowerShell helper written to `%TEMP%` at runtime, avoiding the fragile combination of `for /f`, backquotes, and caret line-continuation.
- `curl --connect-timeout 10 --max-time 20` / `-TimeoutSec 20` so the probe fails fast on broken networks instead of hanging.
- TLS 1.2 enforced in the CMD-embedded helper too.
- `OLD_VERSION="unknown"` sentinel unified across all three installers for unparseable `--version` output.

## Lint

- `shellcheck -s sh` default: clean
- `shellcheck -s dash`: clean
- `shellcheck -s sh -o all -e SC2250,SC2310,SC2249` (3 documented exclusions): clean
- `pwsh` parse: clean
- PSScriptAnalyzer (minus `PSAvoidUsingWriteHost`, a known false-positive for installer scripts, and `PSUseBOMForUnicodeEncodedFile` since the file is now ASCII-only): clean

## Test plan

- [ ] Linux x86_64 — re-run after fresh install, expect no-op
- [ ] Linux x86_64 — re-run older version installed, expect upgrade
- [ ] Linux x86_64 — `FORCE_INSTALL=1` re-run on up-to-date install, expect reinstall
- [ ] Linux x86_64 — `INSTALL_DIR` override with existing binary, expect no-op
- [ ] macOS — same four scenarios (verifies BSD `sort` / `sed` / `readlink` compatibility)
- [ ] Windows PowerShell 5.1 — re-run fresh → re-run → expect no-op
- [ ] **Windows PowerShell 7** — same (this is the path that was broken pre-fix)
- [ ] Windows CMD — same four scenarios via `install.cmd`