### PR TITLE
fix(deps): bump rustls-webpki to 0.103.12

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1861,9 +1861,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-webpki"
-version = "0.103.11"
+version = "0.103.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "20a6af516fea4b20eccceaf166e8aa666ac996208e8a644ce3ef5aa783bc7cd4"
+checksum = "8279bb85272c9f10811ae6a6c547ff594d6a7f3c6c6b02ee9726d1d0dcfcdd06"
 dependencies = [
  "ring",
  "rustls-pki-types",


### PR DESCRIPTION
## Summary
- Bumps `rustls-webpki` from 0.103.11 → 0.103.12 via `cargo update`
- Resolves RUSTSEC-2026-0098 (URI name constraints incorrectly accepted)
- Resolves RUSTSEC-2026-0099 (name constraints accepted for wildcard DNS names)

Both advisories are fixed in 0.103.12, so a single lockfile bump closes them.

Closes #110
Closes #111

## Test plan
- [x] `cargo build`
- [ ] `cargo clippy --workspace --tests -- -D warnings`
- [ ] `cargo test --workspace --lib --bins`