### PR TITLE
ci: centralize cargo-audit config and add pre-bump hook

### DIFF
--- a/.cargo/audit.toml
+++ b/.cargo/audit.toml
@@ -1,0 +1,10 @@
+[advisories]
+ignore = [
+    # rsa: Marvin timing side-channel (PKCS#1 v1.5). Transitive dep via
+    # sqlx-mysql; no fixed release upstream.
+    "RUSTSEC-2023-0071",
+    # rand: unsound only with a custom `log` logger that calls `rand::rng()`
+    # during reseed. Not applicable here; rand 0.8.5 is a transitive dep and
+    # we don't ship such a logger.
+    "RUSTSEC-2026-0097",
+]

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -19,11 +19,3 @@ jobs:
     steps:
       - uses: actions/checkout@v6
       - uses: actions-rust-lang/audit@v1
-        with:
-          # Ignored advisories — keep in sync with the list below.
-          #   RUSTSEC-2023-0071: rsa Marvin timing sidechannel. Transitive via
-          #     sqlx-mysql; no fixed release upstream.
-          #   RUSTSEC-2026-0097: rand unsound only with a custom `log` logger
-          #     that calls `rand::rng()` during reseed. Not applicable here;
-          #     rand 0.8.5 is a transitive dep and we don't ship such a logger.
-          ignore: RUSTSEC-2023-0071,RUSTSEC-2026-0097

--- a/cog.toml
+++ b/cog.toml
@@ -6,6 +6,7 @@ skip_ci = "[skip ci]"
 
 # Pre-bump: quality gates + Cargo.toml version update
 pre_bump_hooks = [
+    "cargo audit",
     "cargo fmt --all --check",
     "taplo fmt --check",
     "cargo clippy --workspace --tests -- -D warnings",


### PR DESCRIPTION
## Summary
- Moves advisory ignore list (RUSTSEC-2023-0071, RUSTSEC-2026-0097) from inline workflow config to `.cargo/audit.toml` — the standard cargo-audit config file
- Removes the `ignore` parameter from the `actions-rust-lang/audit` GitHub Action step (it auto-discovers `.cargo/audit.toml`)
- Adds `cargo audit` as the first `pre_bump_hook` in `cog.toml` to gate releases on passing security audit

## Test plan
- [ ] CI Security workflow passes without inline `ignore` parameter
- [ ] `cargo audit` runs locally and respects `.cargo/audit.toml` ignores
- [ ] `cog bump --dry-run` executes the audit hook before other checks