### PR TITLE
fix(temporal): decode date/time columns instead of returning null

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2325,7 +2325,6 @@ dependencies = [
  "base64",
  "serde_json",
  "sqlx",
- "tracing",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2145,6 +2145,7 @@ checksum = "ee6798b1838b6a0f69c007c133b8df5866302197e404e8b6ee8ed3e3a5e68dc6"
 dependencies = [
  "base64",
  "bytes",
+ "chrono",
  "crc",
  "crossbeam-queue",
  "either",
@@ -2222,6 +2223,7 @@ dependencies = [
  "bitflags",
  "byteorder",
  "bytes",
+ "chrono",
  "crc",
  "digest",
  "dotenvy",
@@ -2263,6 +2265,7 @@ dependencies = [
  "base64",
  "bitflags",
  "byteorder",
+ "chrono",
  "crc",
  "dotenvy",
  "etcetera",
@@ -2297,6 +2300,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2d12fe70b2c1b4401038055f90f151b78208de1f9f89a7dbfd41587a10c3eea"
 dependencies = [
  "atoi",
+ "chrono",
  "flume",
  "futures-channel",
  "futures-core",
@@ -2321,6 +2325,7 @@ dependencies = [
  "base64",
  "serde_json",
  "sqlx",
+ "tracing",
 ]
 
 [[package]]

--- a/crates/sqlx-to-json/Cargo.toml
+++ b/crates/sqlx-to-json/Cargo.toml
@@ -10,7 +10,8 @@ repository.workspace = true
 [dependencies]
 base64 = { workspace = true }
 serde_json = { workspace = true }
-sqlx = { workspace = true, features = ["mysql", "postgres", "sqlite"] }
+sqlx = { workspace = true, features = ["mysql", "postgres", "sqlite", "chrono"] }
+tracing = { workspace = true }
 
 [lints]
 workspace = true

--- a/crates/sqlx-to-json/Cargo.toml
+++ b/crates/sqlx-to-json/Cargo.toml
@@ -11,7 +11,6 @@ repository.workspace = true
 base64 = { workspace = true }
 serde_json = { workspace = true }
 sqlx = { workspace = true, features = ["mysql", "postgres", "sqlite", "chrono"] }
-tracing = { workspace = true }
 
 [lints]
 workspace = true

--- a/crates/sqlx-to-json/src/mysql.rs
+++ b/crates/sqlx-to-json/src/mysql.rs
@@ -2,12 +2,15 @@
 //!
 //! Uses `column.type_info().name()` to pick the right Rust type for each column.
 //! `MySQL` 9 reports `information_schema` text columns as `VARBINARY`; these
-//! are decoded as UTF-8 strings rather than base64.
+//! are decoded as UTF-8 strings rather than base64. Temporal types (`DATE`,
+//! `TIME`, `DATETIME`, `TIMESTAMP`) are decoded via sqlx's `chrono` integration
+//! and serialized as naive ISO 8601 strings (no timezone offset).
 
 use base64::Engine as _;
 use base64::engine::general_purpose::STANDARD as BASE64;
 use serde_json::{Map, Value};
 use sqlx::mysql::MySqlRow;
+use sqlx::types::chrono::{DateTime, NaiveDate, NaiveDateTime, NaiveTime, Utc};
 use sqlx::{Column, Row, TypeInfo, ValueRef};
 
 use crate::RowExt;
@@ -53,7 +56,43 @@ impl RowExt for MySqlRow {
 
                     "BLOB" | "TINYBLOB" | "MEDIUMBLOB" | "LONGBLOB" | "BIT" | "GEOMETRY" => bytes_to_json(self, idx),
 
-                    // All other types (VARCHAR, TEXT, DATE, TIME, ENUM, etc.) → String
+                    "DATE" => self.try_get::<NaiveDate, _>(idx).map_or_else(
+                        |e| {
+                            warn_decode_failure(column.name(), type_name, &e);
+                            Value::Null
+                        },
+                        |v| Value::String(v.format("%Y-%m-%d").to_string()),
+                    ),
+
+                    "TIME" => self.try_get::<NaiveTime, _>(idx).map_or_else(
+                        |e| {
+                            warn_decode_failure(column.name(), type_name, &e);
+                            Value::Null
+                        },
+                        |v| Value::String(v.format("%H:%M:%S%.f").to_string()),
+                    ),
+
+                    "DATETIME" => self.try_get::<NaiveDateTime, _>(idx).map_or_else(
+                        |e| {
+                            warn_decode_failure(column.name(), type_name, &e);
+                            Value::Null
+                        },
+                        |v| Value::String(v.format("%Y-%m-%dT%H:%M:%S%.f").to_string()),
+                    ),
+
+                    // sqlx-mysql's NaiveDateTime decoder only accepts ColumnType::Datetime,
+                    // not Timestamp. DateTime<Utc> accepts both; we then strip the zone
+                    // via naive_utc() so the wire shape matches FR-004 (no Z, no offset)
+                    // and data-model.md §2.2's rule that MySQL TIMESTAMP is naive-on-the-wire.
+                    "TIMESTAMP" => self.try_get::<DateTime<Utc>, _>(idx).map_or_else(
+                        |e| {
+                            warn_decode_failure(column.name(), type_name, &e);
+                            Value::Null
+                        },
+                        |v| Value::String(v.naive_utc().format("%Y-%m-%dT%H:%M:%S%.f").to_string()),
+                    ),
+
+                    // All other types (VARCHAR, TEXT, ENUM, etc.) → String
                     _ => self
                         .try_get::<String, _>(idx)
                         .map_or_else(|_| bytes_to_json(self, idx), Value::String),
@@ -72,4 +111,14 @@ fn bytes_to_json(row: &MySqlRow, idx: usize) -> Value {
     row.try_get::<Vec<u8>, _>(idx).map_or(Value::Null, |bytes| {
         String::from_utf8(bytes.clone()).map_or_else(|_| Value::String(BASE64.encode(&bytes)), Value::String)
     })
+}
+
+/// Emits a `WARN`-level tracing event when a column value fails to decode.
+fn warn_decode_failure(column: &str, db_type: &str, err: &sqlx::Error) {
+    tracing::warn!(
+        column,
+        db_type,
+        error = %err,
+        "failed to decode column value"
+    );
 }

--- a/crates/sqlx-to-json/src/mysql.rs
+++ b/crates/sqlx-to-json/src/mysql.rs
@@ -56,41 +56,24 @@ impl RowExt for MySqlRow {
 
                     "BLOB" | "TINYBLOB" | "MEDIUMBLOB" | "LONGBLOB" | "BIT" | "GEOMETRY" => bytes_to_json(self, idx),
 
-                    "DATE" => self.try_get::<NaiveDate, _>(idx).map_or_else(
-                        |e| {
-                            warn_decode_failure(column.name(), type_name, &e);
-                            Value::Null
-                        },
-                        |v| Value::String(v.format("%Y-%m-%d").to_string()),
-                    ),
+                    "DATE" => self
+                        .try_get::<NaiveDate, _>(idx)
+                        .map_or(Value::Null, |v| Value::String(v.format("%Y-%m-%d").to_string())),
 
-                    "TIME" => self.try_get::<NaiveTime, _>(idx).map_or_else(
-                        |e| {
-                            warn_decode_failure(column.name(), type_name, &e);
-                            Value::Null
-                        },
-                        |v| Value::String(v.format("%H:%M:%S%.f").to_string()),
-                    ),
+                    "TIME" => self
+                        .try_get::<NaiveTime, _>(idx)
+                        .map_or(Value::Null, |v| Value::String(v.format("%H:%M:%S%.f").to_string())),
 
-                    "DATETIME" => self.try_get::<NaiveDateTime, _>(idx).map_or_else(
-                        |e| {
-                            warn_decode_failure(column.name(), type_name, &e);
-                            Value::Null
-                        },
-                        |v| Value::String(v.format("%Y-%m-%dT%H:%M:%S%.f").to_string()),
-                    ),
+                    "DATETIME" => self.try_get::<NaiveDateTime, _>(idx).map_or(Value::Null, |v| {
+                        Value::String(v.format("%Y-%m-%dT%H:%M:%S%.f").to_string())
+                    }),
 
                     // sqlx-mysql's NaiveDateTime decoder only accepts ColumnType::Datetime,
                     // not Timestamp. DateTime<Utc> accepts both; we then strip the zone
-                    // via naive_utc() so the wire shape matches FR-004 (no Z, no offset)
-                    // and data-model.md §2.2's rule that MySQL TIMESTAMP is naive-on-the-wire.
-                    "TIMESTAMP" => self.try_get::<DateTime<Utc>, _>(idx).map_or_else(
-                        |e| {
-                            warn_decode_failure(column.name(), type_name, &e);
-                            Value::Null
-                        },
-                        |v| Value::String(v.naive_utc().format("%Y-%m-%dT%H:%M:%S%.f").to_string()),
-                    ),
+                    // via naive_utc() so the wire shape matches the naive ISO 8601 form.
+                    "TIMESTAMP" => self.try_get::<DateTime<Utc>, _>(idx).map_or(Value::Null, |v| {
+                        Value::String(v.naive_utc().format("%Y-%m-%dT%H:%M:%S%.f").to_string())
+                    }),
 
                     // All other types (VARCHAR, TEXT, ENUM, etc.) → String
                     _ => self
@@ -111,14 +94,4 @@ fn bytes_to_json(row: &MySqlRow, idx: usize) -> Value {
     row.try_get::<Vec<u8>, _>(idx).map_or(Value::Null, |bytes| {
         String::from_utf8(bytes.clone()).map_or_else(|_| Value::String(BASE64.encode(&bytes)), Value::String)
     })
-}
-
-/// Emits a `WARN`-level tracing event when a column value fails to decode.
-fn warn_decode_failure(column: &str, db_type: &str, err: &sqlx::Error) {
-    tracing::warn!(
-        column,
-        db_type,
-        error = %err,
-        "failed to decode column value"
-    );
 }

--- a/crates/sqlx-to-json/src/mysql.rs
+++ b/crates/sqlx-to-json/src/mysql.rs
@@ -58,21 +58,22 @@ impl RowExt for MySqlRow {
 
                     "DATE" => self
                         .try_get::<NaiveDate, _>(idx)
-                        .map_or(Value::Null, |v| Value::String(v.format("%Y-%m-%d").to_string())),
+                        .map_or(Value::Null, |v| Value::String(v.to_string())),
 
                     "TIME" => self
                         .try_get::<NaiveTime, _>(idx)
-                        .map_or(Value::Null, |v| Value::String(v.format("%H:%M:%S%.f").to_string())),
+                        .map_or(Value::Null, |v| Value::String(v.to_string())),
 
-                    "DATETIME" => self.try_get::<NaiveDateTime, _>(idx).map_or(Value::Null, |v| {
-                        Value::String(v.format("%Y-%m-%dT%H:%M:%S%.f").to_string())
-                    }),
+                    "DATETIME" => self
+                        .try_get::<NaiveDateTime, _>(idx)
+                        .map_or(Value::Null, |v| Value::String(format!("{}T{}", v.date(), v.time()))),
 
                     // sqlx-mysql's NaiveDateTime decoder only accepts ColumnType::Datetime,
                     // not Timestamp. DateTime<Utc> accepts both; we then strip the zone
                     // via naive_utc() so the wire shape matches the naive ISO 8601 form.
                     "TIMESTAMP" => self.try_get::<DateTime<Utc>, _>(idx).map_or(Value::Null, |v| {
-                        Value::String(v.naive_utc().format("%Y-%m-%dT%H:%M:%S%.f").to_string())
+                        let n = v.naive_utc();
+                        Value::String(format!("{}T{}", n.date(), n.time()))
                     }),
 
                     // All other types (VARCHAR, TEXT, ENUM, etc.) → String

--- a/crates/sqlx-to-json/src/postgres.rs
+++ b/crates/sqlx-to-json/src/postgres.rs
@@ -3,12 +3,15 @@
 //! Type names are normalized to uppercase because sqlx may return either case
 //! depending on the query context. Integer types use size-specific Rust types
 //! (`i16`, `i32`, `i64`) because sqlx enforces strict type matching for
-//! `PostgreSQL`.
+//! `PostgreSQL`. Temporal types (`DATE`, `TIME`, `TIMESTAMP`, `TIMESTAMPTZ`)
+//! are decoded via sqlx's `chrono` integration and serialized as RFC 3339
+//! strings; `TIMESTAMPTZ` is normalized to UTC and emitted with a `Z` suffix.
 
 use base64::Engine as _;
 use base64::engine::general_purpose::STANDARD as BASE64;
 use serde_json::{Map, Value};
 use sqlx::postgres::PgRow;
+use sqlx::types::chrono::{DateTime, NaiveDate, NaiveDateTime, NaiveTime, Utc};
 use sqlx::{Column, Row, TypeInfo, ValueRef};
 
 use crate::RowExt;
@@ -52,6 +55,38 @@ impl RowExt for PgRow {
 
                     "JSON" | "JSONB" => self.try_get::<Value, _>(idx).unwrap_or(Value::Null),
 
+                    "DATE" => self.try_get::<NaiveDate, _>(idx).map_or_else(
+                        |e| {
+                            warn_decode_failure(column.name(), &type_name, &e);
+                            Value::Null
+                        },
+                        |v| Value::String(v.format("%Y-%m-%d").to_string()),
+                    ),
+
+                    "TIME" => self.try_get::<NaiveTime, _>(idx).map_or_else(
+                        |e| {
+                            warn_decode_failure(column.name(), &type_name, &e);
+                            Value::Null
+                        },
+                        |v| Value::String(v.format("%H:%M:%S%.f").to_string()),
+                    ),
+
+                    "TIMESTAMP" => self.try_get::<NaiveDateTime, _>(idx).map_or_else(
+                        |e| {
+                            warn_decode_failure(column.name(), &type_name, &e);
+                            Value::Null
+                        },
+                        |v| Value::String(v.format("%Y-%m-%dT%H:%M:%S%.f").to_string()),
+                    ),
+
+                    "TIMESTAMPTZ" => self.try_get::<DateTime<Utc>, _>(idx).map_or_else(
+                        |e| {
+                            warn_decode_failure(column.name(), &type_name, &e);
+                            Value::Null
+                        },
+                        |v| Value::String(v.format("%Y-%m-%dT%H:%M:%S%.fZ").to_string()),
+                    ),
+
                     _ => self.try_get::<String, _>(idx).map_or(Value::Null, Value::String),
                 }
             };
@@ -61,4 +96,14 @@ impl RowExt for PgRow {
 
         Value::Object(map)
     }
+}
+
+/// Emits a `WARN`-level tracing event when a column value fails to decode.
+fn warn_decode_failure(column: &str, db_type: &str, err: &sqlx::Error) {
+    tracing::warn!(
+        column,
+        db_type,
+        error = %err,
+        "failed to decode column value"
+    );
 }

--- a/crates/sqlx-to-json/src/postgres.rs
+++ b/crates/sqlx-to-json/src/postgres.rs
@@ -55,37 +55,21 @@ impl RowExt for PgRow {
 
                     "JSON" | "JSONB" => self.try_get::<Value, _>(idx).unwrap_or(Value::Null),
 
-                    "DATE" => self.try_get::<NaiveDate, _>(idx).map_or_else(
-                        |e| {
-                            warn_decode_failure(column.name(), &type_name, &e);
-                            Value::Null
-                        },
-                        |v| Value::String(v.format("%Y-%m-%d").to_string()),
-                    ),
+                    "DATE" => self
+                        .try_get::<NaiveDate, _>(idx)
+                        .map_or(Value::Null, |v| Value::String(v.format("%Y-%m-%d").to_string())),
 
-                    "TIME" => self.try_get::<NaiveTime, _>(idx).map_or_else(
-                        |e| {
-                            warn_decode_failure(column.name(), &type_name, &e);
-                            Value::Null
-                        },
-                        |v| Value::String(v.format("%H:%M:%S%.f").to_string()),
-                    ),
+                    "TIME" => self
+                        .try_get::<NaiveTime, _>(idx)
+                        .map_or(Value::Null, |v| Value::String(v.format("%H:%M:%S%.f").to_string())),
 
-                    "TIMESTAMP" => self.try_get::<NaiveDateTime, _>(idx).map_or_else(
-                        |e| {
-                            warn_decode_failure(column.name(), &type_name, &e);
-                            Value::Null
-                        },
-                        |v| Value::String(v.format("%Y-%m-%dT%H:%M:%S%.f").to_string()),
-                    ),
+                    "TIMESTAMP" => self.try_get::<NaiveDateTime, _>(idx).map_or(Value::Null, |v| {
+                        Value::String(v.format("%Y-%m-%dT%H:%M:%S%.f").to_string())
+                    }),
 
-                    "TIMESTAMPTZ" => self.try_get::<DateTime<Utc>, _>(idx).map_or_else(
-                        |e| {
-                            warn_decode_failure(column.name(), &type_name, &e);
-                            Value::Null
-                        },
-                        |v| Value::String(v.format("%Y-%m-%dT%H:%M:%S%.fZ").to_string()),
-                    ),
+                    "TIMESTAMPTZ" => self.try_get::<DateTime<Utc>, _>(idx).map_or(Value::Null, |v| {
+                        Value::String(v.format("%Y-%m-%dT%H:%M:%S%.fZ").to_string())
+                    }),
 
                     _ => self.try_get::<String, _>(idx).map_or(Value::Null, Value::String),
                 }
@@ -96,14 +80,4 @@ impl RowExt for PgRow {
 
         Value::Object(map)
     }
-}
-
-/// Emits a `WARN`-level tracing event when a column value fails to decode.
-fn warn_decode_failure(column: &str, db_type: &str, err: &sqlx::Error) {
-    tracing::warn!(
-        column,
-        db_type,
-        error = %err,
-        "failed to decode column value"
-    );
 }

--- a/crates/sqlx-to-json/src/postgres.rs
+++ b/crates/sqlx-to-json/src/postgres.rs
@@ -57,18 +57,19 @@ impl RowExt for PgRow {
 
                     "DATE" => self
                         .try_get::<NaiveDate, _>(idx)
-                        .map_or(Value::Null, |v| Value::String(v.format("%Y-%m-%d").to_string())),
+                        .map_or(Value::Null, |v| Value::String(v.to_string())),
 
                     "TIME" => self
                         .try_get::<NaiveTime, _>(idx)
-                        .map_or(Value::Null, |v| Value::String(v.format("%H:%M:%S%.f").to_string())),
+                        .map_or(Value::Null, |v| Value::String(v.to_string())),
 
-                    "TIMESTAMP" => self.try_get::<NaiveDateTime, _>(idx).map_or(Value::Null, |v| {
-                        Value::String(v.format("%Y-%m-%dT%H:%M:%S%.f").to_string())
-                    }),
+                    "TIMESTAMP" => self
+                        .try_get::<NaiveDateTime, _>(idx)
+                        .map_or(Value::Null, |v| Value::String(format!("{}T{}", v.date(), v.time()))),
 
                     "TIMESTAMPTZ" => self.try_get::<DateTime<Utc>, _>(idx).map_or(Value::Null, |v| {
-                        Value::String(v.format("%Y-%m-%dT%H:%M:%S%.fZ").to_string())
+                        let n = v.naive_utc();
+                        Value::String(format!("{}T{}Z", n.date(), n.time()))
                     }),
 
                     _ => self.try_get::<String, _>(idx).map_or(Value::Null, Value::String),

--- a/tests/functional/mysql.rs
+++ b/tests/functional/mysql.rs
@@ -1710,12 +1710,13 @@ async fn test_read_query_non_select_show_tables_single_page() {
         without_cursor.rows, with_cursor.rows,
         "cursor must be silently ignored for non-SELECT statements"
     );
-    // SHOW TABLES in `app` returns all 4 seeded tables even with page_size=2.
+    // SHOW TABLES in `app` returns all 5 seeded tables (users, posts, tags,
+    // post_tags, temporal_demo) even with page_size=2.
     let rows = &without_cursor.rows;
     assert_eq!(
         rows.len(),
-        4,
-        "SHOW TABLES must not be paginated: expected all 4 seeded tables, got {}",
+        5,
+        "SHOW TABLES must not be paginated: expected all 5 seeded tables, got {}",
         rows.len()
     );
 }
@@ -1743,4 +1744,28 @@ async fn test_read_query_non_select_describe_users_single_page() {
         "DESCRIBE users must return all columns, got {}",
         rows.len()
     );
+}
+
+#[tokio::test]
+async fn test_read_query_returns_non_null_temporal_columns() {
+    // Feature 038: MySQL temporal columns must round-trip as ISO 8601 strings.
+    // MySQL has no TIMESTAMPTZ analog, so the zoned bucket is exercised on
+    // PostgreSQL only; here all four columns are naive (no offset, no Z).
+    let handler = handler(false);
+
+    let response = handler
+        .read_query(ReadQueryRequest {
+            query: "SELECT `date`, `time`, `datetime`, `timestamp` FROM temporal WHERE id = 1".into(),
+            database_name: "app".into(),
+            cursor: None,
+        })
+        .await
+        .expect("temporal SELECT should succeed");
+
+    let arr = &response.rows;
+    assert_eq!(arr.len(), 1, "temporal seeds exactly one row");
+    assert_eq!(arr[0]["date"], "2026-04-20", "DATE → YYYY-MM-DD");
+    assert_eq!(arr[0]["time"], "14:30:00", "TIME → HH:MM:SS");
+    assert_eq!(arr[0]["datetime"], "2026-04-20T14:30:00", "DATETIME → naive ISO 8601");
+    assert_eq!(arr[0]["timestamp"], "2026-04-20T14:30:00", "TIMESTAMP → naive ISO 8601");
 }

--- a/tests/functional/postgres.rs
+++ b/tests/functional/postgres.rs
@@ -1613,3 +1613,32 @@ async fn test_read_query_non_select_explain_single_page() {
     assert!(response.next_cursor.is_none(), "EXPLAIN must not paginate");
     assert!(!&response.rows.is_empty(), "EXPLAIN must return plan rows");
 }
+
+#[tokio::test]
+async fn test_read_query_returns_non_null_temporal_columns() {
+    // Feature 038: PG temporal columns must round-trip as RFC 3339 strings,
+    // with TIMESTAMPTZ normalized to UTC and emitted with a trailing Z.
+    let handler = handler(false);
+
+    let response = handler
+        .read_query(ReadQueryRequest {
+            query: r#"SELECT "date", "time", "timestamp", "timestamptz" FROM temporal WHERE id = 1"#.into(),
+            database_name: "app".into(),
+            cursor: None,
+        })
+        .await
+        .expect("temporal SELECT should succeed");
+
+    let arr = &response.rows;
+    assert_eq!(arr.len(), 1, "temporal seeds exactly one row");
+    assert_eq!(arr[0]["date"], "2026-04-20", "DATE → YYYY-MM-DD");
+    assert_eq!(arr[0]["time"], "14:30:00", "TIME → HH:MM:SS");
+    assert_eq!(
+        arr[0]["timestamp"], "2026-04-20T14:30:00",
+        "TIMESTAMP (naive) → no Z, no offset (FR-004)"
+    );
+    assert_eq!(
+        arr[0]["timestamptz"], "2026-04-20T12:30:00Z",
+        "TIMESTAMPTZ → UTC-normalized from +02:00, with Z suffix (FR-004 / Q2)"
+    );
+}

--- a/tests/functional/sqlite.rs
+++ b/tests/functional/sqlite.rs
@@ -1018,3 +1018,28 @@ async fn test_read_query_non_select_single_page_with_cursor_ignored() {
         "cursor must be silently ignored for non-SELECT statements"
     );
 }
+
+#[tokio::test]
+async fn test_read_query_temporal_columns_preserved() {
+    // Feature 038: SQLite stores temporal values as TEXT verbatim. This test
+    // is a regression guard ensuring the existing TEXT decode path keeps
+    // returning the exact stored text (no formatting applied by the server).
+    let handler = handler(false);
+
+    let response = handler
+        .read_query(ReadQueryRequest {
+            query: "SELECT date, time, timestamp FROM temporal WHERE id = 1".into(),
+            cursor: None,
+        })
+        .await
+        .expect("temporal SELECT should succeed");
+
+    let arr = &response.rows;
+    assert_eq!(arr.len(), 1, "temporal seeds exactly one row");
+    assert_eq!(arr[0]["date"], "2026-04-20");
+    assert_eq!(arr[0]["time"], "14:30:00");
+    // Note the space (not T) between date and time — SQLite stores the
+    // literal text we inserted; this is the existing behavior we are
+    // explicitly asserting does not regress.
+    assert_eq!(arr[0]["timestamp"], "2026-04-20 14:30:00");
+}

--- a/tests/seed/mysql.sql
+++ b/tests/seed/mysql.sql
@@ -63,6 +63,18 @@ INSERT INTO `app`.`post_tags` (`post_id`, `tag_id`) VALUES
     (3, 3),
     (3, 1);
 
+CREATE TABLE `app`.`temporal` (
+    `id` INT AUTO_INCREMENT PRIMARY KEY,
+    `date` DATE NOT NULL,
+    `time` TIME NOT NULL,
+    `datetime` DATETIME NOT NULL,
+    `timestamp` TIMESTAMP NOT NULL
+) ENGINE=InnoDB;
+
+-- Sample data: 1 temporal row
+INSERT INTO `app`.`temporal` (`id`, `date`, `time`, `datetime`, `timestamp`) VALUES
+    (1, '2026-04-20', '14:30:00', '2026-04-20 14:30:00', '2026-04-20 14:30:00');
+
 -- analytics database
 
 DROP DATABASE IF EXISTS `analytics`;

--- a/tests/seed/postgres.sql
+++ b/tests/seed/postgres.sql
@@ -66,6 +66,18 @@ INSERT INTO post_tags (post_id, tag_id) VALUES
     (3, 3),
     (3, 1);
 
+CREATE TABLE temporal (
+    id SERIAL PRIMARY KEY,
+    "date" DATE NOT NULL,
+    "time" TIME NOT NULL,
+    "timestamp" TIMESTAMP NOT NULL,
+    "timestamptz" TIMESTAMPTZ NOT NULL
+);
+
+-- Sample data: 1 temporal row
+INSERT INTO temporal (id, "date", "time", "timestamp", "timestamptz") VALUES
+    (1, '2026-04-20', '14:30:00', '2026-04-20 14:30:00', '2026-04-20 14:30:00+02:00');
+
 -- analytics database
 
 DROP DATABASE IF EXISTS analytics;

--- a/tests/seed/sqlite.sql
+++ b/tests/seed/sqlite.sql
@@ -58,3 +58,14 @@ INSERT INTO post_tags (post_id, tag_id) VALUES
     (2, 1),
     (3, 3),
     (3, 1);
+
+CREATE TABLE IF NOT EXISTS temporal (
+    id INTEGER PRIMARY KEY,
+    date DATE NOT NULL,
+    time TIME NOT NULL,
+    timestamp TIMESTAMP NOT NULL
+);
+
+-- Sample data: 1 temporal row
+INSERT INTO temporal (id, date, time, timestamp) VALUES
+    (1, '2026-04-20', '14:30:00', '2026-04-20 14:30:00');


### PR DESCRIPTION
## Summary

- PostgreSQL and MySQL/MariaDB temporal columns (`DATE`, `TIME`, `TIMESTAMP`, `TIMESTAMPTZ`, `DATETIME`) previously fell through to a `try_get::<String>` arm that sqlx silently rejected, mapping the failure to JSON `null` and hiding every audit timestamp like `created_at`. They now decode via the sqlx `chrono` feature into typed values and serialize as RFC 3339 / ISO 8601 strings (TIMESTAMPTZ normalized to UTC with `Z`; naive types without offset).
- SQLite is unaffected (it stores temporals as TEXT verbatim) and gets a regression test only.
- New `temporal` fixture table seeded on each backend so the round-trip can be asserted deterministically.

## Test plan

- [x] `cargo fmt --all`
- [x] `cargo clippy --workspace --tests -- -D warnings`
- [x] `cargo test --workspace --lib --bins`
- [x] `./tests/run.sh` — 340/340 across mariadb_12, mysql_9, postgres_18, sqlite
- [ ] Manually verify on a real MCP client that `SELECT id, name, created_at FROM users` now returns non-null `created_at` values