### PR TITLE
feat!: rename to dbmcp

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,5 +1,5 @@
 name: Bug Report
-description: Report a bug or unexpected behavior in database-mcp
+description: Report a bug or unexpected behavior in dbmcp
 labels: ["bug"]
 body:
   - type: markdown
@@ -8,8 +8,8 @@ body:
         Thanks for reporting a bug! Please fill out the form below to help us investigate.
 
         Before submitting, please:
-        - Search [existing issues](https://github.com/haymon-ai/database/issues) for duplicates
-        - Make sure you're using the latest version of database-mcp
+        - Search [existing issues](https://github.com/haymon-ai/dbmcp/issues) for duplicates
+        - Make sure you're using the latest version of dbmcp
 
   - type: checkboxes
     id: prerequisites
@@ -18,14 +18,14 @@ body:
       options:
         - label: I have searched existing issues for duplicates
           required: true
-        - label: I am using the latest version of database-mcp
+        - label: I am using the latest version of dbmcp
           required: true
 
   - type: input
     id: version
     attributes:
       label: Version
-      description: Which version or commit of database-mcp are you using?
+      description: Which version or commit of dbmcp are you using?
       placeholder: "e.g., 0.1.0, git commit abc1234, or latest main"
     validations:
       required: true
@@ -79,7 +79,7 @@ body:
       label: Steps to Reproduce
       description: Steps to reproduce the behavior
       placeholder: |
-        1. Configure database-mcp with '...'
+        1. Configure dbmcp with '...'
         2. Run command '...'
         3. Execute query '...'
         4. See error

--- a/.github/ISSUE_TEMPLATE/docs_report.yml
+++ b/.github/ISSUE_TEMPLATE/docs_report.yml
@@ -8,7 +8,7 @@ body:
         Thanks for helping improve our documentation! Please fill out the form below.
 
         Before submitting, please:
-        - Search [existing issues](https://github.com/haymon-ai/database/issues) for duplicates
+        - Search [existing issues](https://github.com/haymon-ai/dbmcp/issues) for duplicates
 
   - type: checkboxes
     id: prerequisites
@@ -23,7 +23,7 @@ body:
     attributes:
       label: Affected Page or Section
       description: URL or path to the documentation page, or the section name
-      placeholder: "e.g., https://haymon-ai.github.io/database-mcp/... or README.md"
+      placeholder: "e.g., https://haymon-ai.github.io/dbmcp/... or README.md"
     validations:
       required: true
 

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -8,8 +8,8 @@ body:
         Thanks for suggesting a feature! Please fill out the form below.
 
         Before submitting, please:
-        - Search [existing issues](https://github.com/haymon-ai/database/issues) for duplicates
-        - Check [GitHub Discussions](https://github.com/haymon-ai/database/discussions) for related conversations
+        - Search [existing issues](https://github.com/haymon-ai/dbmcp/issues) for duplicates
+        - Check [GitHub Discussions](https://github.com/haymon-ai/dbmcp/discussions) for related conversations
 
   - type: checkboxes
     id: prerequisites

--- a/.github/ISSUE_TEMPLATE/regression_report.yml
+++ b/.github/ISSUE_TEMPLATE/regression_report.yml
@@ -8,8 +8,8 @@ body:
         Thanks for reporting a regression! This template helps us quickly identify what changed.
 
         Before submitting, please:
-        - Search [existing issues](https://github.com/haymon-ai/database/issues) for duplicates
-        - Make sure you're using the latest version of database-mcp
+        - Search [existing issues](https://github.com/haymon-ai/dbmcp/issues) for duplicates
+        - Make sure you're using the latest version of dbmcp
 
   - type: checkboxes
     id: prerequisites
@@ -18,7 +18,7 @@ body:
       options:
         - label: I have searched existing issues for duplicates
           required: true
-        - label: I am using the latest version of database-mcp
+        - label: I am using the latest version of dbmcp
           required: true
 
   - type: input
@@ -80,7 +80,7 @@ body:
       label: Steps to Reproduce
       description: Steps to reproduce the regression
       placeholder: |
-        1. Configure database-mcp with '...'
+        1. Configure dbmcp with '...'
         2. Run command '...'
         3. Execute query '...'
         4. See error

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,19 +21,19 @@ jobs:
         include:
           - target: x86_64-unknown-linux-gnu
             os: ubuntu-latest
-            artifact: database-mcp
+            artifact: dbmcp
           - target: aarch64-unknown-linux-gnu
             os: ubuntu-latest
-            artifact: database-mcp
+            artifact: dbmcp
           - target: x86_64-apple-darwin
             os: macos-latest
-            artifact: database-mcp
+            artifact: dbmcp
           - target: aarch64-apple-darwin
             os: macos-latest
-            artifact: database-mcp
+            artifact: dbmcp
           - target: x86_64-pc-windows-msvc
             os: windows-latest
-            artifact: database-mcp.exe
+            artifact: dbmcp.exe
     steps:
       - uses: actions/checkout@v6
       - uses: dtolnay/rust-toolchain@stable
@@ -58,18 +58,18 @@ jobs:
         if: runner.os != 'Windows'
         run: |
           cd target/${{ matrix.target }}/release
-          tar czf ../../../database-mcp-${{ matrix.target }}.tar.gz ${{ matrix.artifact }}
+          tar czf ../../../dbmcp-${{ matrix.target }}.tar.gz ${{ matrix.artifact }}
 
       - name: Package artifact (Windows)
         if: runner.os == 'Windows'
         shell: pwsh
         run: |
-          Compress-Archive -Path target/${{ matrix.target }}/release/${{ matrix.artifact }} -DestinationPath database-mcp-${{ matrix.target }}.zip
+          Compress-Archive -Path target/${{ matrix.target }}/release/${{ matrix.artifact }} -DestinationPath dbmcp-${{ matrix.target }}.zip
 
       - uses: actions/upload-artifact@v7
         with:
-          name: database-mcp-${{ matrix.target }}
-          path: database-mcp-${{ matrix.target }}.*
+          name: dbmcp-${{ matrix.target }}
+          path: dbmcp-${{ matrix.target }}.*
 
   release:
     name: Create Release
@@ -122,8 +122,8 @@ jobs:
             type=semver,pattern={{major}}.{{minor}}
             type=raw,value=latest
           labels: |
-            io.modelcontextprotocol.server.name=ai.haymon/database
-            org.opencontainers.image.title=database-mcp
+            io.modelcontextprotocol.server.name=ai.haymon/dbmcp
+            org.opencontainers.image.title=dbmcp
             org.opencontainers.image.description=Database MCP server for MySQL, MariaDB, PostgreSQL & SQLite
             org.opencontainers.image.licenses=MIT
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,49 +2,6 @@
 All notable changes to this project will be documented in this file. See [conventional commits](https://www.conventionalcommits.org/) for commit guidelines.
 
 - - -
-## [v0.8.0] - 2026-04-22
-
-### Renamed from `database-mcp` to `dbmcp`
-
-**This release renames the project.** The binary is now `dbmcp`, the MCP
-`serverInfo.name` is now `"dbmcp"`, the GitHub repository is now
-`haymon-ai/dbmcp`, the docs live at `https://dbmcp.haymon.ai`, and the
-published workspace crates are now `dbmcp-*`. There is **no
-`database-mcp` binary shipped in this or any future release** — existing
-`database-mcp` installs keep working indefinitely at version 0.7.0 but
-do not auto-upgrade. Pinned `database-mcp-*` crates on crates.io at
-0.7.0 stay untouched (no yank, no deprecation release).
-
-Under Cargo's pre-1.0 compatibility rules, `0.7.x` → `0.8.0` is a
-breaking-change bump: a dependency specified as `^0.7` will **not**
-resolve to `0.8.0`. This is the intended signal.
-
-#### Migration
-
-| Surface | Before | After |
-| ------- | ------ | ----- |
-| Binary on `PATH` | `database-mcp` | `dbmcp` |
-| MCP client config server key | `"database-mcp"` | `"dbmcp"` |
-| MCP client config `command` | `database-mcp` | `dbmcp` |
-| MCP `serverInfo.name` | `"database-mcp"` | `"dbmcp"` |
-| MCP registry entry | `ai.haymon/database` (deprecated) | `ai.haymon/dbmcp` |
-| GitHub repository | `github.com/haymon-ai/database` (redirects) | `github.com/haymon-ai/dbmcp` |
-| Docs domain | `database.haymon.ai` (301 for ≥12 months) | `dbmcp.haymon.ai` |
-| Docker image | `ghcr.io/haymon-ai/database:0.7.0` | `ghcr.io/haymon-ai/dbmcp:0.8.0` |
-| Release tarball | `database-mcp-{target}.tar.gz` | `dbmcp-{target}.tar.gz` |
-| Release zip | `database-mcp-{target}.zip` | `dbmcp-{target}.zip` |
-| Cargo workspace crates | `database-mcp-{config,server,sql,mysql,postgres,sqlite}` | `dbmcp-{config,server,sql,mysql,postgres,sqlite}` |
-| Cargo root crate | `database-mcp` | `dbmcp` |
-
-CLI flags (`--db-backend`, `--db-host`, …), environment variables
-(`DB_*`, `HTTP_*`, `LOG_LEVEL`), MCP tool names and schemas, supported
-backends, transports, and security constraints are **all unchanged**.
-The `sqlx_to_json` crate is also unchanged.
-
-See commit `feat!: rename to dbmcp` and the [rename spec](specs/042-rename-to-dbmcp/spec.md)
-for the full scope and rationale.
-
-- - -
 ## [v0.7.0](https://github.com/haymon-ai/database-mcp/compare/3026a0304d1cdc444dfe6100f28138b9043d48e5..v0.7.0) - 2026-04-20
 #### Features
 - ![BREAKING](https://img.shields.io/badge/BREAKING-red) (**tools**) cursor pagination for list_* and read_query (#118) - ([30cb5cc](https://github.com/haymon-ai/database-mcp/commit/30cb5cc5ef383df13f2503f0b05a21659fe34854)) - [@athopen](https://github.com/athopen)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,49 @@
 All notable changes to this project will be documented in this file. See [conventional commits](https://www.conventionalcommits.org/) for commit guidelines.
 
 - - -
+## [v0.8.0] - 2026-04-22
+
+### Renamed from `database-mcp` to `dbmcp`
+
+**This release renames the project.** The binary is now `dbmcp`, the MCP
+`serverInfo.name` is now `"dbmcp"`, the GitHub repository is now
+`haymon-ai/dbmcp`, the docs live at `https://dbmcp.haymon.ai`, and the
+published workspace crates are now `dbmcp-*`. There is **no
+`database-mcp` binary shipped in this or any future release** — existing
+`database-mcp` installs keep working indefinitely at version 0.7.0 but
+do not auto-upgrade. Pinned `database-mcp-*` crates on crates.io at
+0.7.0 stay untouched (no yank, no deprecation release).
+
+Under Cargo's pre-1.0 compatibility rules, `0.7.x` → `0.8.0` is a
+breaking-change bump: a dependency specified as `^0.7` will **not**
+resolve to `0.8.0`. This is the intended signal.
+
+#### Migration
+
+| Surface | Before | After |
+| ------- | ------ | ----- |
+| Binary on `PATH` | `database-mcp` | `dbmcp` |
+| MCP client config server key | `"database-mcp"` | `"dbmcp"` |
+| MCP client config `command` | `database-mcp` | `dbmcp` |
+| MCP `serverInfo.name` | `"database-mcp"` | `"dbmcp"` |
+| MCP registry entry | `ai.haymon/database` (deprecated) | `ai.haymon/dbmcp` |
+| GitHub repository | `github.com/haymon-ai/database` (redirects) | `github.com/haymon-ai/dbmcp` |
+| Docs domain | `database.haymon.ai` (301 for ≥12 months) | `dbmcp.haymon.ai` |
+| Docker image | `ghcr.io/haymon-ai/database:0.7.0` | `ghcr.io/haymon-ai/dbmcp:0.8.0` |
+| Release tarball | `database-mcp-{target}.tar.gz` | `dbmcp-{target}.tar.gz` |
+| Release zip | `database-mcp-{target}.zip` | `dbmcp-{target}.zip` |
+| Cargo workspace crates | `database-mcp-{config,server,sql,mysql,postgres,sqlite}` | `dbmcp-{config,server,sql,mysql,postgres,sqlite}` |
+| Cargo root crate | `database-mcp` | `dbmcp` |
+
+CLI flags (`--db-backend`, `--db-host`, …), environment variables
+(`DB_*`, `HTTP_*`, `LOG_LEVEL`), MCP tool names and schemas, supported
+backends, transports, and security constraints are **all unchanged**.
+The `sqlx_to_json` crate is also unchanged.
+
+See commit `feat!: rename to dbmcp` and the [rename spec](specs/042-rename-to-dbmcp/spec.md)
+for the full scope and rationale.
+
+- - -
 ## [v0.7.0](https://github.com/haymon-ai/database-mcp/compare/3026a0304d1cdc444dfe6100f28138b9043d48e5..v0.7.0) - 2026-04-20
 #### Features
 - ![BREAKING](https://img.shields.io/badge/BREAKING-red) (**tools**) cursor pagination for list_* and read_query (#118) - ([30cb5cc](https://github.com/haymon-ai/database-mcp/commit/30cb5cc5ef383df13f2503f0b05a21659fe34854)) - [@athopen](https://github.com/athopen)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -25,17 +25,17 @@ cargo fmt                     # apply formatting
 
 ## Architecture
 
-Cargo workspace: root binary (`database-mcp`) + 7 library crates under `crates/`. Workspace members use `"crates/*"` glob.
+Cargo workspace: root binary (`dbmcp`) + 7 library crates under `crates/`. Workspace members use `"crates/*"` glob.
 
 - **`src/`** — Binary crate. `cli.rs` owns CLI parsing (clap with subcommands), tracing init, and subcommand dispatch. `commands/common.rs` hosts the shared `DatabaseArguments` group, the `TryFrom<&DatabaseArguments> for DatabaseConfig` conversion, and the `create_server` factory. `commands/stdio.rs` and `commands/http.rs` own transport-specific execution; `HttpArguments` is private to `http.rs`.
-- **`crates/config/`** (`database-mcp-config`) — `Config`, `DatabaseConfig`, `HttpConfig` structs, `DatabaseBackend` enum (`Mysql`, `Mariadb`, `Postgres`, `Sqlite` via `clap::ValueEnum`). `DatabaseConfig::validate()` and `HttpConfig::validate()` accumulate errors into `Result<(), Vec<ConfigError>>`.
-- **`crates/backend/`** (`database-mcp-backend`) — Shared `AppError` type, SQL read-only validation (`validation` module), identifier quoting/validation (`identifier` module), and request/response types (`types` module).
-- **`crates/server/`** (`database-mcp-server`) — Shared MCP tool implementations (`tools` module) and `server_info()`. Reused by all three database handler crates.
-- **`crates/mysql/`** (`database-mcp-mysql`) — MySQL/MariaDB backend: connection pooling, query operations, schema introspection, MCP handler via `rmcp::tool_router`.
-- **`crates/postgres/`** (`database-mcp-postgres`) — PostgreSQL backend: per-database connection pool cache (moka), query operations, schema introspection, MCP handler.
-- **`crates/sqlite/`** (`database-mcp-sqlite`) — SQLite backend: single-file connection, query operations, schema introspection, MCP handler.
+- **`crates/config/`** (`dbmcp-config`) — `Config`, `DatabaseConfig`, `HttpConfig` structs, `DatabaseBackend` enum (`Mysql`, `Mariadb`, `Postgres`, `Sqlite` via `clap::ValueEnum`). `DatabaseConfig::validate()` and `HttpConfig::validate()` accumulate errors into `Result<(), Vec<ConfigError>>`.
+- **`crates/backend/`** (`dbmcp-backend`) — Shared `AppError` type, SQL read-only validation (`validation` module), identifier quoting/validation (`identifier` module), and request/response types (`types` module).
+- **`crates/server/`** (`dbmcp-server`) — Shared MCP tool implementations (`tools` module) and `server_info()`. Reused by all three database handler crates.
+- **`crates/mysql/`** (`dbmcp-mysql`) — MySQL/MariaDB backend: connection pooling, query operations, schema introspection, MCP handler via `rmcp::tool_router`.
+- **`crates/postgres/`** (`dbmcp-postgres`) — PostgreSQL backend: per-database connection pool cache (moka), query operations, schema introspection, MCP handler.
+- **`crates/sqlite/`** (`dbmcp-sqlite`) — SQLite backend: single-file connection, query operations, schema introspection, MCP handler.
 - **`crates/sqlx-to-json/`** (`sqlx-to-json`) — `RowExt` trait for type-safe row-to-JSON conversion. Per-backend implementations for `SqliteRow`, `PgRow`, and `MySqlRow`.
-- **Transport**: `stdio` (for Claude Desktop/Cursor) and `http` (Streamable HTTP with CORS via axum + tower-http). A transport subcommand is required — `database-mcp` with no subcommand prints usage help and exits non-zero.
+- **Transport**: `stdio` (for Claude Desktop/Cursor) and `http` (Streamable HTTP with CORS via axum + tower-http). A transport subcommand is required — `dbmcp` with no subcommand prints usage help and exits non-zero.
 
 ## Configuration
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -465,7 +465,7 @@ dependencies = [
 
 [[package]]
 name = "dbmcp"
-version = "0.8.0"
+version = "0.7.0"
 dependencies = [
  "axum",
  "clap",
@@ -488,7 +488,7 @@ dependencies = [
 
 [[package]]
 name = "dbmcp-config"
-version = "0.8.0"
+version = "0.7.0"
 dependencies = [
  "clap",
  "thiserror",
@@ -496,7 +496,7 @@ dependencies = [
 
 [[package]]
 name = "dbmcp-mysql"
-version = "0.8.0"
+version = "0.7.0"
 dependencies = [
  "dbmcp-config",
  "dbmcp-server",
@@ -513,7 +513,7 @@ dependencies = [
 
 [[package]]
 name = "dbmcp-postgres"
-version = "0.8.0"
+version = "0.7.0"
 dependencies = [
  "dbmcp-config",
  "dbmcp-server",
@@ -530,7 +530,7 @@ dependencies = [
 
 [[package]]
 name = "dbmcp-server"
-version = "0.8.0"
+version = "0.7.0"
 dependencies = [
  "base64",
  "rmcp",
@@ -540,7 +540,7 @@ dependencies = [
 
 [[package]]
 name = "dbmcp-sql"
-version = "0.8.0"
+version = "0.7.0"
 dependencies = [
  "rmcp",
  "serde_json",
@@ -553,7 +553,7 @@ dependencies = [
 
 [[package]]
 name = "dbmcp-sqlite"
-version = "0.8.0"
+version = "0.7.0"
 dependencies = [
  "dbmcp-config",
  "dbmcp-server",
@@ -2320,7 +2320,7 @@ dependencies = [
 
 [[package]]
 name = "sqlx_to_json"
-version = "0.8.0"
+version = "0.7.0"
 dependencies = [
  "base64",
  "serde_json",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1859,9 +1859,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-webpki"
-version = "0.103.12"
+version = "0.103.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8279bb85272c9f10811ae6a6c547ff594d6a7f3c6c6b02ee9726d1d0dcfcdd06"
+checksum = "61c429a8649f110dddef65e2a5ad240f747e85f7758a6bccc7e5777bd33f756e"
 dependencies = [
  "ring",
  "rustls-pki-types",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -464,16 +464,16 @@ dependencies = [
 ]
 
 [[package]]
-name = "database-mcp"
-version = "0.7.0"
+name = "dbmcp"
+version = "0.8.0"
 dependencies = [
  "axum",
  "clap",
- "database-mcp-config",
- "database-mcp-mysql",
- "database-mcp-postgres",
- "database-mcp-server",
- "database-mcp-sqlite",
+ "dbmcp-config",
+ "dbmcp-mysql",
+ "dbmcp-postgres",
+ "dbmcp-server",
+ "dbmcp-sqlite",
  "insta",
  "mimalloc",
  "rmcp",
@@ -487,20 +487,20 @@ dependencies = [
 ]
 
 [[package]]
-name = "database-mcp-config"
-version = "0.7.0"
+name = "dbmcp-config"
+version = "0.8.0"
 dependencies = [
  "clap",
  "thiserror",
 ]
 
 [[package]]
-name = "database-mcp-mysql"
-version = "0.7.0"
+name = "dbmcp-mysql"
+version = "0.8.0"
 dependencies = [
- "database-mcp-config",
- "database-mcp-server",
- "database-mcp-sql",
+ "dbmcp-config",
+ "dbmcp-server",
+ "dbmcp-sql",
  "moka",
  "rmcp",
  "serde",
@@ -512,12 +512,12 @@ dependencies = [
 ]
 
 [[package]]
-name = "database-mcp-postgres"
-version = "0.7.0"
+name = "dbmcp-postgres"
+version = "0.8.0"
 dependencies = [
- "database-mcp-config",
- "database-mcp-server",
- "database-mcp-sql",
+ "dbmcp-config",
+ "dbmcp-server",
+ "dbmcp-sql",
  "moka",
  "rmcp",
  "serde",
@@ -529,8 +529,8 @@ dependencies = [
 ]
 
 [[package]]
-name = "database-mcp-server"
-version = "0.7.0"
+name = "dbmcp-server"
+version = "0.8.0"
 dependencies = [
  "base64",
  "rmcp",
@@ -539,8 +539,8 @@ dependencies = [
 ]
 
 [[package]]
-name = "database-mcp-sql"
-version = "0.7.0"
+name = "dbmcp-sql"
+version = "0.8.0"
 dependencies = [
  "rmcp",
  "serde_json",
@@ -552,12 +552,12 @@ dependencies = [
 ]
 
 [[package]]
-name = "database-mcp-sqlite"
-version = "0.7.0"
+name = "dbmcp-sqlite"
+version = "0.8.0"
 dependencies = [
- "database-mcp-config",
- "database-mcp-server",
- "database-mcp-sql",
+ "dbmcp-config",
+ "dbmcp-server",
+ "dbmcp-sql",
  "rmcp",
  "serde",
  "serde_json",
@@ -2320,7 +2320,7 @@ dependencies = [
 
 [[package]]
 name = "sqlx_to_json"
-version = "0.7.0"
+version = "0.8.0"
 dependencies = [
  "base64",
  "serde_json",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ categories = ["database", "command-line-utilities"]
 members = [".", "crates/*"]
 
 [workspace.package]
-version = "0.8.0"
+version = "0.7.0"
 edition = "2024"
 description = "A single-binary MCP server for MySQL, MariaDB, PostgreSQL, and SQLite"
 homepage = "https://dbmcp.haymon.ai"
@@ -22,13 +22,13 @@ repository = "https://github.com/haymon-ai/dbmcp"
 
 [workspace.dependencies]
 # Internal workspace crates
-dbmcp-config = { path = "crates/config", version = "0.8.0" }
-dbmcp-mysql = { path = "crates/mysql", version = "0.8.0" }
-dbmcp-postgres = { path = "crates/postgres", version = "0.8.0" }
-dbmcp-server = { path = "crates/server", version = "0.8.0" }
-dbmcp-sql = { path = "crates/sql", version = "0.8.0" }
-dbmcp-sqlite = { path = "crates/sqlite", version = "0.8.0" }
-sqlx_to_json = { path = "crates/sqlx-to-json", version = "0.8.0" }
+dbmcp-config = { path = "crates/config", version = "0.7.0" }
+dbmcp-mysql = { path = "crates/mysql", version = "0.7.0" }
+dbmcp-postgres = { path = "crates/postgres", version = "0.7.0" }
+dbmcp-server = { path = "crates/server", version = "0.7.0" }
+dbmcp-sql = { path = "crates/sql", version = "0.7.0" }
+dbmcp-sqlite = { path = "crates/sqlite", version = "0.7.0" }
+sqlx_to_json = { path = "crates/sqlx-to-json", version = "0.7.0" }
 
 # External dependencies
 axum = "0.8"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "database-mcp"
+name = "dbmcp"
 version.workspace = true
 edition.workspace = true
 description.workspace = true
@@ -13,22 +13,22 @@ categories = ["database", "command-line-utilities"]
 members = [".", "crates/*"]
 
 [workspace.package]
-version = "0.7.0"
+version = "0.8.0"
 edition = "2024"
 description = "A single-binary MCP server for MySQL, MariaDB, PostgreSQL, and SQLite"
-homepage = "https://database.haymon.ai"
+homepage = "https://dbmcp.haymon.ai"
 license = "MIT"
-repository = "https://github.com/haymon-ai/database"
+repository = "https://github.com/haymon-ai/dbmcp"
 
 [workspace.dependencies]
 # Internal workspace crates
-database-mcp-config = { path = "crates/config", version = "0.7.0" }
-database-mcp-mysql = { path = "crates/mysql", version = "0.7.0" }
-database-mcp-postgres = { path = "crates/postgres", version = "0.7.0" }
-database-mcp-server = { path = "crates/server", version = "0.7.0" }
-database-mcp-sql = { path = "crates/sql", version = "0.7.0" }
-database-mcp-sqlite = { path = "crates/sqlite", version = "0.7.0" }
-sqlx_to_json = { path = "crates/sqlx-to-json", version = "0.7.0" }
+dbmcp-config = { path = "crates/config", version = "0.8.0" }
+dbmcp-mysql = { path = "crates/mysql", version = "0.8.0" }
+dbmcp-postgres = { path = "crates/postgres", version = "0.8.0" }
+dbmcp-server = { path = "crates/server", version = "0.8.0" }
+dbmcp-sql = { path = "crates/sql", version = "0.8.0" }
+dbmcp-sqlite = { path = "crates/sqlite", version = "0.8.0" }
+sqlx_to_json = { path = "crates/sqlx-to-json", version = "0.8.0" }
 
 # External dependencies
 axum = "0.8"
@@ -82,11 +82,11 @@ workspace = true
 [dependencies]
 axum = { workspace = true }
 clap = { workspace = true }
-database-mcp-config = { workspace = true }
-database-mcp-mysql = { workspace = true }
-database-mcp-postgres = { workspace = true }
-database-mcp-server = { workspace = true }
-database-mcp-sqlite = { workspace = true }
+dbmcp-config = { workspace = true }
+dbmcp-mysql = { workspace = true }
+dbmcp-postgres = { workspace = true }
+dbmcp-server = { workspace = true }
+dbmcp-sqlite = { workspace = true }
 mimalloc = { workspace = true }
 rmcp = { workspace = true }
 thiserror = { workspace = true }

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,20 +6,20 @@ ARG VERSION=latest
 RUN apk add --no-cache curl
 
 RUN ARCH=$([ "$TARGETARCH" = "arm64" ] && echo "aarch64-unknown-linux-gnu" || echo "x86_64-unknown-linux-gnu") && \
-    curl -fsSL "https://github.com/haymon-ai/database/releases/download/${VERSION}/database-mcp-${ARCH}.tar.gz" \
+    curl -fsSL "https://github.com/haymon-ai/dbmcp/releases/download/${VERSION}/dbmcp-${ARCH}.tar.gz" \
       | tar xz -C /tmp
 
 FROM gcr.io/distroless/cc-debian12
 
-LABEL org.opencontainers.image.title="database-mcp" \
+LABEL org.opencontainers.image.title="dbmcp" \
       org.opencontainers.image.description="Database MCP server for MySQL, MariaDB, PostgreSQL & SQLite" \
       org.opencontainers.image.licenses="MIT" \
-      org.opencontainers.image.source="https://github.com/haymon-ai/database" \
-      io.modelcontextprotocol.server.name="ai.haymon/database"
+      org.opencontainers.image.source="https://github.com/haymon-ai/dbmcp" \
+      io.modelcontextprotocol.server.name="ai.haymon/dbmcp"
 
-COPY --from=download /tmp/database-mcp /database-mcp
+COPY --from=download /tmp/dbmcp /dbmcp
 
 USER nonroot
 
-ENTRYPOINT ["/database-mcp"]
+ENTRYPOINT ["/dbmcp"]
 CMD ["stdio"]

--- a/README.md
+++ b/README.md
@@ -1,15 +1,15 @@
 # Database MCP
 
-[![CI](https://github.com/haymon-ai/database/actions/workflows/ci.yml/badge.svg)](https://github.com/haymon-ai/database/actions/workflows/ci.yml)
-[![Release](https://img.shields.io/github/v/release/haymon-ai/database)](https://github.com/haymon-ai/database/releases/latest)
+[![CI](https://github.com/haymon-ai/dbmcp/actions/workflows/ci.yml/badge.svg)](https://github.com/haymon-ai/dbmcp/actions/workflows/ci.yml)
+[![Release](https://img.shields.io/github/v/release/haymon-ai/dbmcp)](https://github.com/haymon-ai/dbmcp/releases/latest)
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](LICENSE)
-[![Docs](https://img.shields.io/badge/docs-database.haymon.ai-black)](https://database.haymon.ai/docs/)
+[![Docs](https://img.shields.io/badge/docs-dbmcp.haymon.ai-black)](https://dbmcp.haymon.ai/docs/)
 
 A single-binary [MCP](https://modelcontextprotocol.io/) server for SQL databases. Connect your AI assistant to MySQL/MariaDB, PostgreSQL, or SQLite with zero runtime dependencies.
 
-**[Website](https://database.haymon.ai)** · **[Documentation](https://database.haymon.ai/docs/)** · **[Releases](https://github.com/haymon-ai/database/releases)**
+**[Website](https://dbmcp.haymon.ai)** · **[Documentation](https://dbmcp.haymon.ai/docs/)** · **[Releases](https://github.com/haymon-ai/dbmcp/releases)**
 
-![demo](https://raw.githubusercontent.com/haymon-ai/database/master/docs/public/demo.gif)
+![demo](https://raw.githubusercontent.com/haymon-ai/dbmcp/master/docs/public/demo.gif)
 
 ## Features
 
@@ -24,22 +24,22 @@ A single-binary [MCP](https://modelcontextprotocol.io/) server for SQL databases
 **macOS, Linux, WSL**:
 
 ```bash
-curl -fsSL https://database.haymon.ai/install.sh | bash
+curl -fsSL https://dbmcp.haymon.ai/install.sh | bash
 ```
 
 **Windows PowerShell**:
 
 ```powershell
-irm https://database.haymon.ai/install.ps1 | iex
+irm https://dbmcp.haymon.ai/install.ps1 | iex
 ```
 
 **Windows CMD**:
 
 ```batch
-curl -fsSL https://database.haymon.ai/install.cmd -o install.cmd && install.cmd && del install.cmd
+curl -fsSL https://dbmcp.haymon.ai/install.cmd -o install.cmd && install.cmd && del install.cmd
 ```
 
-See the [installation docs](https://database.haymon.ai/docs/installation) for Docker, Cargo, and other methods.
+See the [installation docs](https://dbmcp.haymon.ai/docs/installation) for Docker, Cargo, and other methods.
 
 ## Quick Start
 
@@ -52,8 +52,8 @@ Add a `.mcp.json` file to your project root. MCP clients read this file and conf
 ```json
 {
   "mcpServers": {
-    "database-mcp": {
-      "command": "database-mcp",
+    "dbmcp": {
+      "command": "dbmcp",
       "args": ["stdio"],
       "env": {
         "DB_BACKEND": "mysql",
@@ -72,13 +72,13 @@ Add a `.mcp.json` file to your project root. MCP clients read this file and conf
 
 ```bash
 # Start the server first
-database-mcp http --db-backend mysql --db-user root --db-name mydb --port 9001
+dbmcp http --db-backend mysql --db-user root --db-name mydb --port 9001
 ```
 
 ```json
 {
   "mcpServers": {
-    "database-mcp": {
+    "dbmcp": {
       "type": "http",
       "url": "http://127.0.0.1:9001/mcp"
     }
@@ -92,22 +92,22 @@ database-mcp http --db-backend mysql --db-user root --db-name mydb --port 9001
 
 ```bash
 # MySQL/MariaDB
-database-mcp stdio --db-backend mysql --db-host localhost --db-user root --db-name mydb
+dbmcp stdio --db-backend mysql --db-host localhost --db-user root --db-name mydb
 
 # PostgreSQL
-database-mcp stdio --db-backend postgres --db-host localhost --db-user postgres --db-name mydb
+dbmcp stdio --db-backend postgres --db-host localhost --db-user postgres --db-name mydb
 
 # SQLite
-database-mcp stdio --db-backend sqlite --db-name ./data.db
+dbmcp stdio --db-backend sqlite --db-name ./data.db
 
 # HTTP transport
-database-mcp http --db-backend mysql --db-user root --db-name mydb --host 0.0.0.0 --port 9001
+dbmcp http --db-backend mysql --db-user root --db-name mydb --host 0.0.0.0 --port 9001
 ```
 
 ### Using environment variables
 
 ```bash
-DB_BACKEND=mysql DB_USER=root DB_NAME=mydb database-mcp stdio
+DB_BACKEND=mysql DB_USER=root DB_NAME=mydb dbmcp stdio
 ```
 
 ## Configuration
@@ -126,7 +126,7 @@ Environment variables are typically set by your MCP client (via `env` or `envFil
 | `http` | Run in HTTP/SSE mode |
 | `version` | Print version information and exit |
 
-A subcommand is required — running `database-mcp` with no subcommand prints usage help and exits with a non-zero status.
+A subcommand is required — running `dbmcp` with no subcommand prints usage help and exits with a non-zero status.
 
 ### Database Options (shared across subcommands)
 
@@ -179,11 +179,11 @@ A subcommand is required — running `database-mcp` with no subcommand prints us
 
 ### listDatabases
 
-Lists accessible databases, paginated via `cursor` / `nextCursor`. See [Cursor Pagination](https://database.haymon.ai/docs/features#cursor-pagination) for iteration details. Not available for SQLite.
+Lists accessible databases, paginated via `cursor` / `nextCursor`. See [Cursor Pagination](https://dbmcp.haymon.ai/docs/features#cursor-pagination) for iteration details. Not available for SQLite.
 
 ### listTables
 
-Lists tables in a database, paginated via `cursor` / `nextCursor`. Requires `database`. See [Cursor Pagination](https://database.haymon.ai/docs/features#cursor-pagination) for iteration details.
+Lists tables in a database, paginated via `cursor` / `nextCursor`. Requires `database`. See [Cursor Pagination](https://dbmcp.haymon.ai/docs/features#cursor-pagination) for iteration details.
 
 ### getTableSchema
 
@@ -191,7 +191,7 @@ Returns column definitions (type, nullable, key, default, extra) and foreign key
 
 ### readQuery
 
-Executes a read-only SQL query (SELECT, SHOW, DESCRIBE, USE, EXPLAIN). Always enforces SQL validation as defence-in-depth. Parameters: `query`, `database`, `cursor`. `SELECT` results paginate via `cursor` / `nextCursor`; `SHOW`, `DESCRIBE`, `USE`, and `EXPLAIN` return a single page and ignore `cursor`. See [Cursor Pagination](https://database.haymon.ai/docs/features#cursor-pagination) for iteration details.
+Executes a read-only SQL query (SELECT, SHOW, DESCRIBE, USE, EXPLAIN). Always enforces SQL validation as defence-in-depth. Parameters: `query`, `database`, `cursor`. `SELECT` results paginate via `cursor` / `nextCursor`; `SHOW`, `DESCRIBE`, `USE`, and `EXPLAIN` return a single page and ignore `cursor`. See [Cursor Pagination](https://dbmcp.haymon.ai/docs/features#cursor-pagination) for iteration details.
 
 ### writeQuery
 
@@ -239,7 +239,7 @@ cargo test --workspace --lib --bins
 ./tests/run.sh --filter sqlite
 
 # With MCP Inspector
-npx @modelcontextprotocol/inspector ./target/release/database-mcp stdio
+npx @modelcontextprotocol/inspector ./target/release/dbmcp stdio
 
 # HTTP mode testing
 curl -X POST http://localhost:9001/mcp \
@@ -254,13 +254,13 @@ This is a Cargo workspace with the following crates:
 
 | Crate | Path | Description |
 |-------|------|-------------|
-| `database-mcp` | `.` (root) | Main binary — CLI, transports, database backends |
-| `database-mcp-backend` | `crates/backend/` | Shared error types, validation, and identifier utilities |
-| `database-mcp-config` | `crates/config/` | Configuration structs and CLI argument mapping |
-| `database-mcp-server` | `crates/server/` | Shared MCP tool implementations and server info |
-| `database-mcp-mysql` | `crates/mysql/` | MySQL/MariaDB backend handler and operations |
-| `database-mcp-postgres` | `crates/postgres/` | PostgreSQL backend handler and operations |
-| `database-mcp-sqlite` | `crates/sqlite/` | SQLite backend handler and operations |
+| `dbmcp` | `.` (root) | Main binary — CLI, transports, database backends |
+| `dbmcp-backend` | `crates/backend/` | Shared error types, validation, and identifier utilities |
+| `dbmcp-config` | `crates/config/` | Configuration structs and CLI argument mapping |
+| `dbmcp-server` | `crates/server/` | Shared MCP tool implementations and server info |
+| `dbmcp-mysql` | `crates/mysql/` | MySQL/MariaDB backend handler and operations |
+| `dbmcp-postgres` | `crates/postgres/` | PostgreSQL backend handler and operations |
+| `dbmcp-sqlite` | `crates/sqlite/` | SQLite backend handler and operations |
 | `sqlx-to-json` | `crates/sqlx-to-json/` | Type-safe row-to-JSON conversion for sqlx (`RowExt` trait) |
 
 ## Development

--- a/cog.toml
+++ b/cog.toml
@@ -15,7 +15,7 @@ pre_bump_hooks = [
     "cargo check --release",
     "git add :/Cargo.lock",
     "sed -i 's/\"version\": \".*\"/\"version\": \"{{version}}\"/' server.json",
-    "sed -i 's|ghcr.io/haymon-ai/database:[0-9]*\\.[0-9]*\\.[0-9]*|ghcr.io/haymon-ai/database:{{version}}|g' server.json",
+    "sed -i 's|ghcr.io/haymon-ai/dbmcp:[0-9]*\\.[0-9]*\\.[0-9]*|ghcr.io/haymon-ai/dbmcp:{{version}}|g' server.json",
     "git add :/server.json",
 ]
 
@@ -35,7 +35,7 @@ path = "CHANGELOG.md"
 template = "remote"
 remote = "github.com"
 owner = "haymon-ai"
-repository = "database-mcp"
+repository = "dbmcp"
 
 authors = [{ username = "athopen", signature = "Andreas Penz" }]
 

--- a/crates/config/Cargo.toml
+++ b/crates/config/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
-name = "database-mcp-config"
-description = "Config for database-mcp"
+name = "dbmcp-config"
+description = "Config for dbmcp"
 version.workspace = true
 edition.workspace = true
 homepage.workspace = true

--- a/crates/config/src/lib.rs
+++ b/crates/config/src/lib.rs
@@ -1,4 +1,4 @@
-//! Configuration types for the database-mcp project.
+//! Configuration types for the dbmcp project.
 //!
 //! Provides [`Config`], [`DatabaseConfig`], [`HttpConfig`],
 //! [`DatabaseBackend`], and [`ConfigError`] shared across all workspace crates.

--- a/crates/mysql/Cargo.toml
+++ b/crates/mysql/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
-name = "database-mcp-mysql"
-description = "MySQL/MariaDB for database-mcp"
+name = "dbmcp-mysql"
+description = "MySQL/MariaDB for dbmcp"
 version.workspace = true
 edition.workspace = true
 homepage.workspace = true
@@ -8,9 +8,9 @@ license.workspace = true
 repository.workspace = true
 
 [dependencies]
-database-mcp-config = { workspace = true }
-database-mcp-server = { workspace = true }
-database-mcp-sql = { workspace = true }
+dbmcp-config = { workspace = true }
+dbmcp-server = { workspace = true }
+dbmcp-sql = { workspace = true }
 moka = { workspace = true }
 rmcp = { workspace = true }
 serde = { workspace = true }

--- a/crates/mysql/src/connection.rs
+++ b/crates/mysql/src/connection.rs
@@ -6,10 +6,10 @@
 
 use std::time::Duration;
 
-use database_mcp_config::DatabaseConfig;
-use database_mcp_sql::Connection;
-use database_mcp_sql::SqlError;
-use database_mcp_sql::sanitize::validate_ident;
+use dbmcp_config::DatabaseConfig;
+use dbmcp_sql::Connection;
+use dbmcp_sql::SqlError;
+use dbmcp_sql::sanitize::validate_ident;
 use moka::future::Cache;
 use sqlx::mysql::{MySqlConnectOptions, MySqlPool, MySqlSslMode};
 use tracing::info;
@@ -168,7 +168,7 @@ fn create_lazy_pool(config: &DatabaseConfig, database: &str) -> MySqlPool {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use database_mcp_config::DatabaseBackend;
+    use dbmcp_config::DatabaseBackend;
 
     fn base_config() -> DatabaseConfig {
         DatabaseConfig {

--- a/crates/mysql/src/handler.rs
+++ b/crates/mysql/src/handler.rs
@@ -5,8 +5,8 @@
 //! surface and a small set of thin delegators that per-tool
 //! implementations call.
 
-use database_mcp_config::DatabaseConfig;
-use database_mcp_server::{Server, server_info};
+use dbmcp_config::DatabaseConfig;
+use dbmcp_server::{Server, server_info};
 use rmcp::RoleServer;
 use rmcp::handler::server::router::tool::ToolRouter;
 use rmcp::handler::server::tool::ToolCallContext;
@@ -150,7 +150,7 @@ impl ServerHandler for MysqlHandler {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use database_mcp_config::DatabaseBackend;
+    use dbmcp_config::DatabaseBackend;
 
     fn base_config() -> DatabaseConfig {
         DatabaseConfig {

--- a/crates/mysql/src/tools/create_database.rs
+++ b/crates/mysql/src/tools/create_database.rs
@@ -2,10 +2,10 @@
 
 use std::borrow::Cow;
 
-use database_mcp_server::types::{CreateDatabaseRequest, MessageResponse};
-use database_mcp_sql::Connection as _;
-use database_mcp_sql::SqlError;
-use database_mcp_sql::sanitize::{quote_ident, quote_literal, validate_ident};
+use dbmcp_server::types::{CreateDatabaseRequest, MessageResponse};
+use dbmcp_sql::Connection as _;
+use dbmcp_sql::SqlError;
+use dbmcp_sql::sanitize::{quote_ident, quote_literal, validate_ident};
 use rmcp::handler::server::router::tool::{AsyncTool, ToolBase};
 use rmcp::model::{ErrorData, ToolAnnotations};
 use sqlparser::dialect::MySqlDialect;

--- a/crates/mysql/src/tools/drop_database.rs
+++ b/crates/mysql/src/tools/drop_database.rs
@@ -2,10 +2,10 @@
 
 use std::borrow::Cow;
 
-use database_mcp_server::types::{DropDatabaseRequest, MessageResponse};
-use database_mcp_sql::Connection as _;
-use database_mcp_sql::SqlError;
-use database_mcp_sql::sanitize::{quote_ident, validate_ident};
+use dbmcp_server::types::{DropDatabaseRequest, MessageResponse};
+use dbmcp_sql::Connection as _;
+use dbmcp_sql::SqlError;
+use dbmcp_sql::sanitize::{quote_ident, validate_ident};
 use rmcp::handler::server::router::tool::{AsyncTool, ToolBase};
 use rmcp::model::{ErrorData, ToolAnnotations};
 use sqlparser::dialect::MySqlDialect;

--- a/crates/mysql/src/tools/drop_table.rs
+++ b/crates/mysql/src/tools/drop_table.rs
@@ -2,10 +2,10 @@
 
 use std::borrow::Cow;
 
-use database_mcp_server::types::MessageResponse;
-use database_mcp_sql::Connection as _;
-use database_mcp_sql::SqlError;
-use database_mcp_sql::sanitize::{quote_ident, validate_ident};
+use dbmcp_server::types::MessageResponse;
+use dbmcp_sql::Connection as _;
+use dbmcp_sql::SqlError;
+use dbmcp_sql::sanitize::{quote_ident, validate_ident};
 use rmcp::handler::server::router::tool::{AsyncTool, ToolBase};
 use rmcp::model::{ErrorData, ToolAnnotations};
 use sqlparser::dialect::MySqlDialect;

--- a/crates/mysql/src/tools/explain_query.rs
+++ b/crates/mysql/src/tools/explain_query.rs
@@ -2,11 +2,11 @@
 
 use std::borrow::Cow;
 
-use database_mcp_server::types::{ExplainQueryRequest, QueryResponse};
-use database_mcp_sql::Connection as _;
-use database_mcp_sql::SqlError;
-use database_mcp_sql::sanitize::validate_ident;
-use database_mcp_sql::validation::validate_read_only;
+use dbmcp_server::types::{ExplainQueryRequest, QueryResponse};
+use dbmcp_sql::Connection as _;
+use dbmcp_sql::SqlError;
+use dbmcp_sql::sanitize::validate_ident;
+use dbmcp_sql::validation::validate_read_only;
 use rmcp::handler::server::router::tool::{AsyncTool, ToolBase};
 use rmcp::model::{ErrorData, ToolAnnotations};
 

--- a/crates/mysql/src/tools/get_table_schema.rs
+++ b/crates/mysql/src/tools/get_table_schema.rs
@@ -3,10 +3,10 @@
 use std::borrow::Cow;
 use std::collections::HashMap;
 
-use database_mcp_server::types::{GetTableSchemaRequest, TableSchemaResponse};
-use database_mcp_sql::Connection as _;
-use database_mcp_sql::SqlError;
-use database_mcp_sql::sanitize::{quote_ident, quote_literal, validate_ident};
+use dbmcp_server::types::{GetTableSchemaRequest, TableSchemaResponse};
+use dbmcp_sql::Connection as _;
+use dbmcp_sql::SqlError;
+use dbmcp_sql::sanitize::{quote_ident, quote_literal, validate_ident};
 use rmcp::handler::server::router::tool::{AsyncTool, ToolBase};
 use rmcp::model::{ErrorData, ToolAnnotations};
 use serde_json::{Value, json};

--- a/crates/mysql/src/tools/list_databases.rs
+++ b/crates/mysql/src/tools/list_databases.rs
@@ -2,9 +2,9 @@
 
 use std::borrow::Cow;
 
-use database_mcp_server::pagination::Pager;
-use database_mcp_server::types::{ListDatabasesRequest, ListDatabasesResponse};
-use database_mcp_sql::Connection as _;
+use dbmcp_server::pagination::Pager;
+use dbmcp_server::types::{ListDatabasesRequest, ListDatabasesResponse};
+use dbmcp_sql::Connection as _;
 use rmcp::handler::server::router::tool::{AsyncTool, ToolBase};
 use rmcp::model::{ErrorData, ToolAnnotations};
 

--- a/crates/mysql/src/tools/list_functions.rs
+++ b/crates/mysql/src/tools/list_functions.rs
@@ -2,10 +2,10 @@
 
 use std::borrow::Cow;
 
-use database_mcp_server::pagination::Pager;
-use database_mcp_server::types::{ListFunctionsRequest, ListFunctionsResponse};
-use database_mcp_sql::Connection as _;
-use database_mcp_sql::sanitize::{quote_literal, validate_ident};
+use dbmcp_server::pagination::Pager;
+use dbmcp_server::types::{ListFunctionsRequest, ListFunctionsResponse};
+use dbmcp_sql::Connection as _;
+use dbmcp_sql::sanitize::{quote_literal, validate_ident};
 use rmcp::handler::server::router::tool::{AsyncTool, ToolBase};
 use rmcp::model::{ErrorData, ToolAnnotations};
 

--- a/crates/mysql/src/tools/list_procedures.rs
+++ b/crates/mysql/src/tools/list_procedures.rs
@@ -2,10 +2,10 @@
 
 use std::borrow::Cow;
 
-use database_mcp_server::pagination::Pager;
-use database_mcp_server::types::{ListProceduresRequest, ListProceduresResponse};
-use database_mcp_sql::Connection as _;
-use database_mcp_sql::sanitize::{quote_literal, validate_ident};
+use dbmcp_server::pagination::Pager;
+use dbmcp_server::types::{ListProceduresRequest, ListProceduresResponse};
+use dbmcp_sql::Connection as _;
+use dbmcp_sql::sanitize::{quote_literal, validate_ident};
 use rmcp::handler::server::router::tool::{AsyncTool, ToolBase};
 use rmcp::model::{ErrorData, ToolAnnotations};
 

--- a/crates/mysql/src/tools/list_tables.rs
+++ b/crates/mysql/src/tools/list_tables.rs
@@ -2,10 +2,10 @@
 
 use std::borrow::Cow;
 
-use database_mcp_server::pagination::Pager;
-use database_mcp_server::types::{ListTablesRequest, ListTablesResponse};
-use database_mcp_sql::Connection as _;
-use database_mcp_sql::sanitize::{quote_literal, validate_ident};
+use dbmcp_server::pagination::Pager;
+use dbmcp_server::types::{ListTablesRequest, ListTablesResponse};
+use dbmcp_sql::Connection as _;
+use dbmcp_sql::sanitize::{quote_literal, validate_ident};
 use rmcp::handler::server::router::tool::{AsyncTool, ToolBase};
 use rmcp::model::{ErrorData, ToolAnnotations};
 

--- a/crates/mysql/src/tools/list_triggers.rs
+++ b/crates/mysql/src/tools/list_triggers.rs
@@ -2,10 +2,10 @@
 
 use std::borrow::Cow;
 
-use database_mcp_server::pagination::Pager;
-use database_mcp_server::types::{ListTriggersRequest, ListTriggersResponse};
-use database_mcp_sql::Connection as _;
-use database_mcp_sql::sanitize::{quote_literal, validate_ident};
+use dbmcp_server::pagination::Pager;
+use dbmcp_server::types::{ListTriggersRequest, ListTriggersResponse};
+use dbmcp_sql::Connection as _;
+use dbmcp_sql::sanitize::{quote_literal, validate_ident};
 use rmcp::handler::server::router::tool::{AsyncTool, ToolBase};
 use rmcp::model::{ErrorData, ToolAnnotations};
 

--- a/crates/mysql/src/tools/list_views.rs
+++ b/crates/mysql/src/tools/list_views.rs
@@ -2,10 +2,10 @@
 
 use std::borrow::Cow;
 
-use database_mcp_server::pagination::Pager;
-use database_mcp_server::types::{ListViewsRequest, ListViewsResponse};
-use database_mcp_sql::Connection as _;
-use database_mcp_sql::sanitize::{quote_literal, validate_ident};
+use dbmcp_server::pagination::Pager;
+use dbmcp_server::types::{ListViewsRequest, ListViewsResponse};
+use dbmcp_sql::Connection as _;
+use dbmcp_sql::sanitize::{quote_literal, validate_ident};
 use rmcp::handler::server::router::tool::{AsyncTool, ToolBase};
 use rmcp::model::{ErrorData, ToolAnnotations};
 

--- a/crates/mysql/src/tools/read_query.rs
+++ b/crates/mysql/src/tools/read_query.rs
@@ -2,14 +2,14 @@
 
 use std::borrow::Cow;
 
-use database_mcp_server::pagination::Pager;
-use database_mcp_server::types::{ReadQueryRequest, ReadQueryResponse};
-use database_mcp_sql::Connection as _;
-use database_mcp_sql::SqlError;
-use database_mcp_sql::StatementKind;
-use database_mcp_sql::pagination::with_limit_offset;
-use database_mcp_sql::sanitize::validate_ident;
-use database_mcp_sql::validation::validate_read_only;
+use dbmcp_server::pagination::Pager;
+use dbmcp_server::types::{ReadQueryRequest, ReadQueryResponse};
+use dbmcp_sql::Connection as _;
+use dbmcp_sql::SqlError;
+use dbmcp_sql::StatementKind;
+use dbmcp_sql::pagination::with_limit_offset;
+use dbmcp_sql::sanitize::validate_ident;
+use dbmcp_sql::validation::validate_read_only;
 use rmcp::handler::server::router::tool::{AsyncTool, ToolBase};
 use rmcp::model::{ErrorData, ToolAnnotations};
 

--- a/crates/mysql/src/tools/write_query.rs
+++ b/crates/mysql/src/tools/write_query.rs
@@ -2,10 +2,10 @@
 
 use std::borrow::Cow;
 
-use database_mcp_server::types::{QueryRequest, QueryResponse};
-use database_mcp_sql::Connection as _;
-use database_mcp_sql::SqlError;
-use database_mcp_sql::sanitize::validate_ident;
+use dbmcp_server::types::{QueryRequest, QueryResponse};
+use dbmcp_sql::Connection as _;
+use dbmcp_sql::SqlError;
+use dbmcp_sql::sanitize::validate_ident;
 use rmcp::handler::server::router::tool::{AsyncTool, ToolBase};
 use rmcp::model::{ErrorData, ToolAnnotations};
 

--- a/crates/postgres/Cargo.toml
+++ b/crates/postgres/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
-name = "database-mcp-postgres"
-description = "PostgreSQL for database-mcp"
+name = "dbmcp-postgres"
+description = "PostgreSQL for dbmcp"
 version.workspace = true
 edition.workspace = true
 homepage.workspace = true
@@ -8,9 +8,9 @@ license.workspace = true
 repository.workspace = true
 
 [dependencies]
-database-mcp-config = { workspace = true }
-database-mcp-server = { workspace = true }
-database-mcp-sql = { workspace = true }
+dbmcp-config = { workspace = true }
+dbmcp-server = { workspace = true }
+dbmcp-sql = { workspace = true }
 moka = { workspace = true }
 rmcp = { workspace = true }
 serde = { workspace = true }

--- a/crates/postgres/src/connection.rs
+++ b/crates/postgres/src/connection.rs
@@ -6,10 +6,10 @@
 
 use std::time::Duration;
 
-use database_mcp_config::DatabaseConfig;
-use database_mcp_sql::Connection;
-use database_mcp_sql::SqlError;
-use database_mcp_sql::sanitize::validate_ident;
+use dbmcp_config::DatabaseConfig;
+use dbmcp_sql::Connection;
+use dbmcp_sql::SqlError;
+use dbmcp_sql::sanitize::validate_ident;
 use moka::future::Cache;
 use sqlx::postgres::{PgConnectOptions, PgPool, PgSslMode};
 use tracing::info;
@@ -168,7 +168,7 @@ fn create_lazy_pool(config: &DatabaseConfig, database: &str) -> PgPool {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use database_mcp_config::DatabaseBackend;
+    use dbmcp_config::DatabaseBackend;
 
     fn base_config() -> DatabaseConfig {
         DatabaseConfig {

--- a/crates/postgres/src/handler.rs
+++ b/crates/postgres/src/handler.rs
@@ -5,8 +5,8 @@
 //! the MCP `ServerHandler` surface and exposes a small set of thin
 //! delegator methods that the per-tool implementations call.
 
-use database_mcp_config::DatabaseConfig;
-use database_mcp_server::{Server, server_info};
+use dbmcp_config::DatabaseConfig;
+use dbmcp_server::{Server, server_info};
 use rmcp::RoleServer;
 use rmcp::handler::server::router::tool::ToolRouter;
 use rmcp::handler::server::tool::ToolCallContext;
@@ -155,7 +155,7 @@ impl ServerHandler for PostgresHandler {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use database_mcp_config::DatabaseBackend;
+    use dbmcp_config::DatabaseBackend;
 
     fn base_config() -> DatabaseConfig {
         DatabaseConfig {

--- a/crates/postgres/src/tools/create_database.rs
+++ b/crates/postgres/src/tools/create_database.rs
@@ -2,10 +2,10 @@
 
 use std::borrow::Cow;
 
-use database_mcp_server::types::{CreateDatabaseRequest, MessageResponse};
-use database_mcp_sql::Connection as _;
-use database_mcp_sql::SqlError;
-use database_mcp_sql::sanitize::{quote_ident, validate_ident};
+use dbmcp_server::types::{CreateDatabaseRequest, MessageResponse};
+use dbmcp_sql::Connection as _;
+use dbmcp_sql::SqlError;
+use dbmcp_sql::sanitize::{quote_ident, validate_ident};
 use rmcp::handler::server::router::tool::{AsyncTool, ToolBase};
 use rmcp::model::{ErrorData, ToolAnnotations};
 use sqlparser::dialect::PostgreSqlDialect;

--- a/crates/postgres/src/tools/drop_database.rs
+++ b/crates/postgres/src/tools/drop_database.rs
@@ -2,10 +2,10 @@
 
 use std::borrow::Cow;
 
-use database_mcp_server::types::{DropDatabaseRequest, MessageResponse};
-use database_mcp_sql::Connection as _;
-use database_mcp_sql::SqlError;
-use database_mcp_sql::sanitize::{quote_ident, validate_ident};
+use dbmcp_server::types::{DropDatabaseRequest, MessageResponse};
+use dbmcp_sql::Connection as _;
+use dbmcp_sql::SqlError;
+use dbmcp_sql::sanitize::{quote_ident, validate_ident};
 use rmcp::handler::server::router::tool::{AsyncTool, ToolBase};
 use rmcp::model::{ErrorData, ToolAnnotations};
 use sqlparser::dialect::PostgreSqlDialect;

--- a/crates/postgres/src/tools/drop_table.rs
+++ b/crates/postgres/src/tools/drop_table.rs
@@ -2,10 +2,10 @@
 
 use std::borrow::Cow;
 
-use database_mcp_server::types::MessageResponse;
-use database_mcp_sql::Connection as _;
-use database_mcp_sql::SqlError;
-use database_mcp_sql::sanitize::{quote_ident, validate_ident};
+use dbmcp_server::types::MessageResponse;
+use dbmcp_sql::Connection as _;
+use dbmcp_sql::SqlError;
+use dbmcp_sql::sanitize::{quote_ident, validate_ident};
 use rmcp::handler::server::router::tool::{AsyncTool, ToolBase};
 use rmcp::model::{ErrorData, ToolAnnotations};
 use sqlparser::dialect::PostgreSqlDialect;

--- a/crates/postgres/src/tools/explain_query.rs
+++ b/crates/postgres/src/tools/explain_query.rs
@@ -2,11 +2,11 @@
 
 use std::borrow::Cow;
 
-use database_mcp_server::types::{ExplainQueryRequest, QueryResponse};
-use database_mcp_sql::Connection as _;
-use database_mcp_sql::SqlError;
-use database_mcp_sql::sanitize::validate_ident;
-use database_mcp_sql::validation::validate_read_only;
+use dbmcp_server::types::{ExplainQueryRequest, QueryResponse};
+use dbmcp_sql::Connection as _;
+use dbmcp_sql::SqlError;
+use dbmcp_sql::sanitize::validate_ident;
+use dbmcp_sql::validation::validate_read_only;
 use rmcp::handler::server::router::tool::{AsyncTool, ToolBase};
 use rmcp::model::{ErrorData, ToolAnnotations};
 

--- a/crates/postgres/src/tools/get_table_schema.rs
+++ b/crates/postgres/src/tools/get_table_schema.rs
@@ -3,10 +3,10 @@
 use std::borrow::Cow;
 use std::collections::HashMap;
 
-use database_mcp_server::types::{GetTableSchemaRequest, TableSchemaResponse};
-use database_mcp_sql::Connection as _;
-use database_mcp_sql::SqlError;
-use database_mcp_sql::sanitize::{quote_literal, validate_ident};
+use dbmcp_server::types::{GetTableSchemaRequest, TableSchemaResponse};
+use dbmcp_sql::Connection as _;
+use dbmcp_sql::SqlError;
+use dbmcp_sql::sanitize::{quote_literal, validate_ident};
 use rmcp::handler::server::router::tool::{AsyncTool, ToolBase};
 use rmcp::model::{ErrorData, ToolAnnotations};
 use serde_json::{Value, json};

--- a/crates/postgres/src/tools/list_databases.rs
+++ b/crates/postgres/src/tools/list_databases.rs
@@ -2,9 +2,9 @@
 
 use std::borrow::Cow;
 
-use database_mcp_server::pagination::Pager;
-use database_mcp_server::types::{ListDatabasesRequest, ListDatabasesResponse};
-use database_mcp_sql::Connection as _;
+use dbmcp_server::pagination::Pager;
+use dbmcp_server::types::{ListDatabasesRequest, ListDatabasesResponse};
+use dbmcp_sql::Connection as _;
 use rmcp::handler::server::router::tool::{AsyncTool, ToolBase};
 use rmcp::model::{ErrorData, ToolAnnotations};
 

--- a/crates/postgres/src/tools/list_functions.rs
+++ b/crates/postgres/src/tools/list_functions.rs
@@ -2,10 +2,10 @@
 
 use std::borrow::Cow;
 
-use database_mcp_server::pagination::Pager;
-use database_mcp_server::types::{ListFunctionsRequest, ListFunctionsResponse};
-use database_mcp_sql::Connection as _;
-use database_mcp_sql::sanitize::validate_ident;
+use dbmcp_server::pagination::Pager;
+use dbmcp_server::types::{ListFunctionsRequest, ListFunctionsResponse};
+use dbmcp_sql::Connection as _;
+use dbmcp_sql::sanitize::validate_ident;
 use rmcp::handler::server::router::tool::{AsyncTool, ToolBase};
 use rmcp::model::{ErrorData, ToolAnnotations};
 

--- a/crates/postgres/src/tools/list_materialized_views.rs
+++ b/crates/postgres/src/tools/list_materialized_views.rs
@@ -2,10 +2,10 @@
 
 use std::borrow::Cow;
 
-use database_mcp_server::pagination::Pager;
-use database_mcp_server::types::{ListMaterializedViewsRequest, ListMaterializedViewsResponse};
-use database_mcp_sql::Connection as _;
-use database_mcp_sql::sanitize::validate_ident;
+use dbmcp_server::pagination::Pager;
+use dbmcp_server::types::{ListMaterializedViewsRequest, ListMaterializedViewsResponse};
+use dbmcp_sql::Connection as _;
+use dbmcp_sql::sanitize::validate_ident;
 use rmcp::handler::server::router::tool::{AsyncTool, ToolBase};
 use rmcp::model::{ErrorData, ToolAnnotations};
 

--- a/crates/postgres/src/tools/list_procedures.rs
+++ b/crates/postgres/src/tools/list_procedures.rs
@@ -2,10 +2,10 @@
 
 use std::borrow::Cow;
 
-use database_mcp_server::pagination::Pager;
-use database_mcp_server::types::{ListProceduresRequest, ListProceduresResponse};
-use database_mcp_sql::Connection as _;
-use database_mcp_sql::sanitize::validate_ident;
+use dbmcp_server::pagination::Pager;
+use dbmcp_server::types::{ListProceduresRequest, ListProceduresResponse};
+use dbmcp_sql::Connection as _;
+use dbmcp_sql::sanitize::validate_ident;
 use rmcp::handler::server::router::tool::{AsyncTool, ToolBase};
 use rmcp::model::{ErrorData, ToolAnnotations};
 

--- a/crates/postgres/src/tools/list_tables.rs
+++ b/crates/postgres/src/tools/list_tables.rs
@@ -2,10 +2,10 @@
 
 use std::borrow::Cow;
 
-use database_mcp_server::pagination::Pager;
-use database_mcp_server::types::{ListTablesRequest, ListTablesResponse};
-use database_mcp_sql::Connection as _;
-use database_mcp_sql::sanitize::validate_ident;
+use dbmcp_server::pagination::Pager;
+use dbmcp_server::types::{ListTablesRequest, ListTablesResponse};
+use dbmcp_sql::Connection as _;
+use dbmcp_sql::sanitize::validate_ident;
 use rmcp::handler::server::router::tool::{AsyncTool, ToolBase};
 use rmcp::model::{ErrorData, ToolAnnotations};
 

--- a/crates/postgres/src/tools/list_triggers.rs
+++ b/crates/postgres/src/tools/list_triggers.rs
@@ -2,10 +2,10 @@
 
 use std::borrow::Cow;
 
-use database_mcp_server::pagination::Pager;
-use database_mcp_server::types::{ListTriggersRequest, ListTriggersResponse};
-use database_mcp_sql::Connection as _;
-use database_mcp_sql::sanitize::validate_ident;
+use dbmcp_server::pagination::Pager;
+use dbmcp_server::types::{ListTriggersRequest, ListTriggersResponse};
+use dbmcp_sql::Connection as _;
+use dbmcp_sql::sanitize::validate_ident;
 use rmcp::handler::server::router::tool::{AsyncTool, ToolBase};
 use rmcp::model::{ErrorData, ToolAnnotations};
 

--- a/crates/postgres/src/tools/list_views.rs
+++ b/crates/postgres/src/tools/list_views.rs
@@ -2,10 +2,10 @@
 
 use std::borrow::Cow;
 
-use database_mcp_server::pagination::Pager;
-use database_mcp_server::types::{ListViewsRequest, ListViewsResponse};
-use database_mcp_sql::Connection as _;
-use database_mcp_sql::sanitize::validate_ident;
+use dbmcp_server::pagination::Pager;
+use dbmcp_server::types::{ListViewsRequest, ListViewsResponse};
+use dbmcp_sql::Connection as _;
+use dbmcp_sql::sanitize::validate_ident;
 use rmcp::handler::server::router::tool::{AsyncTool, ToolBase};
 use rmcp::model::{ErrorData, ToolAnnotations};
 

--- a/crates/postgres/src/tools/read_query.rs
+++ b/crates/postgres/src/tools/read_query.rs
@@ -2,14 +2,14 @@
 
 use std::borrow::Cow;
 
-use database_mcp_server::pagination::Pager;
-use database_mcp_server::types::{ReadQueryRequest, ReadQueryResponse};
-use database_mcp_sql::Connection as _;
-use database_mcp_sql::SqlError;
-use database_mcp_sql::StatementKind;
-use database_mcp_sql::pagination::with_limit_offset;
-use database_mcp_sql::sanitize::validate_ident;
-use database_mcp_sql::validation::validate_read_only;
+use dbmcp_server::pagination::Pager;
+use dbmcp_server::types::{ReadQueryRequest, ReadQueryResponse};
+use dbmcp_sql::Connection as _;
+use dbmcp_sql::SqlError;
+use dbmcp_sql::StatementKind;
+use dbmcp_sql::pagination::with_limit_offset;
+use dbmcp_sql::sanitize::validate_ident;
+use dbmcp_sql::validation::validate_read_only;
 use rmcp::handler::server::router::tool::{AsyncTool, ToolBase};
 use rmcp::model::{ErrorData, ToolAnnotations};
 

--- a/crates/postgres/src/tools/write_query.rs
+++ b/crates/postgres/src/tools/write_query.rs
@@ -2,10 +2,10 @@
 
 use std::borrow::Cow;
 
-use database_mcp_server::types::{QueryRequest, QueryResponse};
-use database_mcp_sql::Connection as _;
-use database_mcp_sql::SqlError;
-use database_mcp_sql::sanitize::validate_ident;
+use dbmcp_server::types::{QueryRequest, QueryResponse};
+use dbmcp_sql::Connection as _;
+use dbmcp_sql::SqlError;
+use dbmcp_sql::sanitize::validate_ident;
 use rmcp::handler::server::router::tool::{AsyncTool, ToolBase};
 use rmcp::model::{ErrorData, ToolAnnotations};
 

--- a/crates/server/Cargo.toml
+++ b/crates/server/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
-name = "database-mcp-server"
-description = "Server for database-mcp"
+name = "dbmcp-server"
+description = "Server for dbmcp"
 version.workspace = true
 edition.workspace = true
 homepage.workspace = true

--- a/crates/server/src/server.rs
+++ b/crates/server/src/server.rs
@@ -13,7 +13,7 @@ use rmcp::model::{Implementation, ServerCapabilities, ServerInfo};
 use rmcp::service::{DynService, NotificationContext, RequestContext, ServiceExt};
 
 /// Hardcoded product name matching the root binary crate.
-const NAME: &str = "database-mcp";
+const NAME: &str = "dbmcp";
 
 /// The current version, derived from the workspace `Cargo.toml` at compile time.
 const VERSION: &str = env!("CARGO_PKG_VERSION");

--- a/crates/sql/Cargo.toml
+++ b/crates/sql/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
-name = "database-mcp-sql"
-description = "SQL validation and identifier utilities for database-mcp"
+name = "dbmcp-sql"
+description = "SQL validation and identifier utilities for dbmcp"
 version.workspace = true
 edition.workspace = true
 homepage.workspace = true

--- a/crates/sqlite/Cargo.toml
+++ b/crates/sqlite/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
-name = "database-mcp-sqlite"
-description = "SQLite for database-mcp"
+name = "dbmcp-sqlite"
+description = "SQLite for dbmcp"
 version.workspace = true
 edition.workspace = true
 homepage.workspace = true
@@ -8,9 +8,9 @@ license.workspace = true
 repository.workspace = true
 
 [dependencies]
-database-mcp-config = { workspace = true }
-database-mcp-server = { workspace = true }
-database-mcp-sql = { workspace = true }
+dbmcp-config = { workspace = true }
+dbmcp-server = { workspace = true }
+dbmcp-sql = { workspace = true }
 rmcp = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }

--- a/crates/sqlite/src/connection.rs
+++ b/crates/sqlite/src/connection.rs
@@ -6,9 +6,9 @@
 
 use std::time::Duration;
 
-use database_mcp_config::DatabaseConfig;
-use database_mcp_sql::Connection;
-use database_mcp_sql::SqlError;
+use dbmcp_config::DatabaseConfig;
+use dbmcp_sql::Connection;
+use dbmcp_sql::SqlError;
 use sqlx::sqlite::{SqliteConnectOptions, SqlitePool};
 use tracing::info;
 
@@ -79,7 +79,7 @@ fn create_lazy_pool(config: &DatabaseConfig) -> SqlitePool {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use database_mcp_config::DatabaseBackend;
+    use dbmcp_config::DatabaseBackend;
 
     fn base_config() -> DatabaseConfig {
         DatabaseConfig {

--- a/crates/sqlite/src/handler.rs
+++ b/crates/sqlite/src/handler.rs
@@ -5,8 +5,8 @@
 //! `ServerHandler` surface and one thin delegator method that the
 //! per-tool implementations call.
 
-use database_mcp_config::DatabaseConfig;
-use database_mcp_server::{Server, server_info};
+use dbmcp_config::DatabaseConfig;
+use dbmcp_server::{Server, server_info};
 use rmcp::RoleServer;
 use rmcp::handler::server::router::tool::ToolRouter;
 use rmcp::handler::server::tool::ToolCallContext;
@@ -137,7 +137,7 @@ impl ServerHandler for SqliteHandler {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use database_mcp_config::DatabaseBackend;
+    use dbmcp_config::DatabaseBackend;
 
     fn handler(read_only: bool) -> SqliteHandler {
         SqliteHandler::new(&DatabaseConfig {

--- a/crates/sqlite/src/tools/drop_table.rs
+++ b/crates/sqlite/src/tools/drop_table.rs
@@ -2,11 +2,11 @@
 
 use std::borrow::Cow;
 
-use database_mcp_server::types::MessageResponse;
-use database_mcp_sql::SqlError;
+use dbmcp_server::types::MessageResponse;
+use dbmcp_sql::SqlError;
 
-use database_mcp_sql::Connection as _;
-use database_mcp_sql::sanitize::{quote_ident, validate_ident};
+use dbmcp_sql::Connection as _;
+use dbmcp_sql::sanitize::{quote_ident, validate_ident};
 use rmcp::handler::server::router::tool::{AsyncTool, ToolBase};
 use rmcp::model::{ErrorData, ToolAnnotations};
 use sqlparser::dialect::SQLiteDialect;

--- a/crates/sqlite/src/tools/explain_query.rs
+++ b/crates/sqlite/src/tools/explain_query.rs
@@ -2,10 +2,10 @@
 
 use std::borrow::Cow;
 
-use database_mcp_server::types::QueryResponse;
+use dbmcp_server::types::QueryResponse;
 
-use database_mcp_sql::Connection as _;
-use database_mcp_sql::SqlError;
+use dbmcp_sql::Connection as _;
+use dbmcp_sql::SqlError;
 use rmcp::handler::server::router::tool::{AsyncTool, ToolBase};
 use rmcp::model::{ErrorData, ToolAnnotations};
 

--- a/crates/sqlite/src/tools/get_table_schema.rs
+++ b/crates/sqlite/src/tools/get_table_schema.rs
@@ -3,15 +3,15 @@
 use std::borrow::Cow;
 use std::collections::HashMap;
 
-use database_mcp_server::types::TableSchemaResponse;
-use database_mcp_sql::Connection as _;
-use database_mcp_sql::sanitize::{quote_ident, validate_ident};
+use dbmcp_server::types::TableSchemaResponse;
+use dbmcp_sql::Connection as _;
+use dbmcp_sql::sanitize::{quote_ident, validate_ident};
 use rmcp::handler::server::router::tool::{AsyncTool, ToolBase};
 use rmcp::model::{ErrorData, ToolAnnotations};
 use serde_json::{Value, json};
 use sqlparser::dialect::SQLiteDialect;
 
-use database_mcp_sql::SqlError;
+use dbmcp_sql::SqlError;
 
 use crate::SqliteHandler;
 use crate::types::GetTableSchemaRequest;

--- a/crates/sqlite/src/tools/list_tables.rs
+++ b/crates/sqlite/src/tools/list_tables.rs
@@ -3,10 +3,10 @@
 use std::borrow::Cow;
 use std::sync::Arc;
 
-use database_mcp_server::pagination::Pager;
-use database_mcp_server::types::ListTablesResponse;
+use dbmcp_server::pagination::Pager;
+use dbmcp_server::types::ListTablesResponse;
 
-use database_mcp_sql::Connection as _;
+use dbmcp_sql::Connection as _;
 use rmcp::handler::server::router::tool::{AsyncTool, ToolBase};
 use rmcp::model::{ErrorData, JsonObject, ToolAnnotations};
 

--- a/crates/sqlite/src/tools/list_triggers.rs
+++ b/crates/sqlite/src/tools/list_triggers.rs
@@ -3,10 +3,10 @@
 use std::borrow::Cow;
 use std::sync::Arc;
 
-use database_mcp_server::pagination::Pager;
-use database_mcp_server::types::ListTriggersResponse;
+use dbmcp_server::pagination::Pager;
+use dbmcp_server::types::ListTriggersResponse;
 
-use database_mcp_sql::Connection as _;
+use dbmcp_sql::Connection as _;
 use rmcp::handler::server::router::tool::{AsyncTool, ToolBase};
 use rmcp::model::{ErrorData, JsonObject, ToolAnnotations};
 

--- a/crates/sqlite/src/tools/list_views.rs
+++ b/crates/sqlite/src/tools/list_views.rs
@@ -3,10 +3,10 @@
 use std::borrow::Cow;
 use std::sync::Arc;
 
-use database_mcp_server::pagination::Pager;
-use database_mcp_server::types::ListViewsResponse;
+use dbmcp_server::pagination::Pager;
+use dbmcp_server::types::ListViewsResponse;
 
-use database_mcp_sql::Connection as _;
+use dbmcp_sql::Connection as _;
 use rmcp::handler::server::router::tool::{AsyncTool, ToolBase};
 use rmcp::model::{ErrorData, JsonObject, ToolAnnotations};
 

--- a/crates/sqlite/src/tools/read_query.rs
+++ b/crates/sqlite/src/tools/read_query.rs
@@ -2,14 +2,14 @@
 
 use std::borrow::Cow;
 
-use database_mcp_server::pagination::Pager;
-use database_mcp_server::types::ReadQueryResponse;
+use dbmcp_server::pagination::Pager;
+use dbmcp_server::types::ReadQueryResponse;
 
-use database_mcp_sql::Connection as _;
-use database_mcp_sql::SqlError;
-use database_mcp_sql::StatementKind;
-use database_mcp_sql::pagination::with_limit_offset;
-use database_mcp_sql::validation::validate_read_only;
+use dbmcp_sql::Connection as _;
+use dbmcp_sql::SqlError;
+use dbmcp_sql::StatementKind;
+use dbmcp_sql::pagination::with_limit_offset;
+use dbmcp_sql::validation::validate_read_only;
 use rmcp::handler::server::router::tool::{AsyncTool, ToolBase};
 use rmcp::model::{ErrorData, ToolAnnotations};
 

--- a/crates/sqlite/src/tools/write_query.rs
+++ b/crates/sqlite/src/tools/write_query.rs
@@ -2,10 +2,10 @@
 
 use std::borrow::Cow;
 
-use database_mcp_server::types::QueryResponse;
+use dbmcp_server::types::QueryResponse;
 
-use database_mcp_sql::Connection as _;
-use database_mcp_sql::SqlError;
+use dbmcp_sql::Connection as _;
+use dbmcp_sql::SqlError;
 use rmcp::handler::server::router::tool::{AsyncTool, ToolBase};
 use rmcp::model::{ErrorData, ToolAnnotations};
 

--- a/crates/sqlite/src/types.rs
+++ b/crates/sqlite/src/types.rs
@@ -4,7 +4,7 @@
 //! has no database selection. These types omit the `database`
 //! field present in the shared server types.
 
-use database_mcp_server::pagination::Cursor;
+use dbmcp_server::pagination::Cursor;
 use rmcp::schemars;
 use rmcp::schemars::JsonSchema;
 use serde::Deserialize;

--- a/docs/app/layout.tsx
+++ b/docs/app/layout.tsx
@@ -8,7 +8,7 @@ const inter = Inter({
 });
 
 export const metadata: Metadata = {
-  metadataBase: new URL("https://database.haymon.ai"),
+  metadataBase: new URL("https://dbmcp.haymon.ai"),
   title: {
     default: "Haymon Database MCP — AI access to your SQL databases",
     template: "%s | Haymon Database MCP",
@@ -19,7 +19,7 @@ export const metadata: Metadata = {
     title: "Haymon Database MCP — AI access to your SQL databases",
     description:
       "A single-binary MCP server for MySQL, MariaDB, PostgreSQL, and SQLite. Zero runtime dependencies, read-only by default.",
-    url: "https://database.haymon.ai",
+    url: "https://dbmcp.haymon.ai",
     siteName: "Haymon Database MCP",
     type: "website",
   },

--- a/docs/components/homepage/hero.tsx
+++ b/docs/components/homepage/hero.tsx
@@ -1,7 +1,7 @@
 import Link from "next/link";
 import { InstallCommand } from "./install";
 
-const gitHubUrl = "https://github.com/haymon-ai/database";
+const gitHubUrl = "https://github.com/haymon-ai/dbmcp";
 
 export function Hero() {
   return (

--- a/docs/components/homepage/install.tsx
+++ b/docs/components/homepage/install.tsx
@@ -10,16 +10,16 @@ interface InstallTab {
 const tabs: InstallTab[] = [
   {
     label: "macOS, Linux, WSL",
-    command: "curl -fsSL https://database.haymon.ai/install.sh | bash",
+    command: "curl -fsSL https://dbmcp.haymon.ai/install.sh | bash",
   },
   {
     label: "Windows PowerShell",
-    command: "irm https://database.haymon.ai/install.ps1 | iex",
+    command: "irm https://dbmcp.haymon.ai/install.ps1 | iex",
   },
   {
     label: "Windows CMD",
     command:
-      "curl -fsSL https://database.haymon.ai/install.cmd -o install.cmd && install.cmd && del install.cmd",
+      "curl -fsSL https://dbmcp.haymon.ai/install.cmd -o install.cmd && install.cmd && del install.cmd",
   },
 ];
 

--- a/docs/content/docs/configuration.mdx
+++ b/docs/content/docs/configuration.mdx
@@ -1,6 +1,6 @@
 ---
 title: Configuration
-description: Configure database-mcp with CLI flags, environment variables, and backend-specific defaults
+description: Configure dbmcp with CLI flags, environment variables, and backend-specific defaults
 ---
 
 Database MCP is configured through CLI flags and environment variables. This page documents every available option.
@@ -74,7 +74,7 @@ The page size applies uniformly to every paginated tool; see the [Cursor Paginat
 
 ## HTTP Transport
 
-These options are available only when running in HTTP mode (`database-mcp http`):
+These options are available only when running in HTTP mode (`dbmcp http`):
 
 | CLI Flag | Default | Description |
 |----------|---------|-------------|
@@ -83,7 +83,7 @@ These options are available only when running in HTTP mode (`database-mcp http`)
 | `--allowed-origins` | `http://localhost,http://127.0.0.1,https://localhost,https://127.0.0.1` | Allowed CORS origins (comma-separated) |
 | `--allowed-hosts` | `localhost,127.0.0.1` | Allowed host names (comma-separated) |
 
-A transport subcommand is required — running `database-mcp` with no subcommand prints usage help and exits with a non-zero status. The `stdio` transport requires no additional configuration beyond the database options above.
+A transport subcommand is required — running `dbmcp` with no subcommand prints usage help and exits with a non-zero status. The `stdio` transport requires no additional configuration beyond the database options above.
 
 ## Client Configuration Examples
 
@@ -96,8 +96,8 @@ Create a `.mcp.json` file in your project root:
 ```json
 {
   "mcpServers": {
-    "database-mcp": {
-      "command": "database-mcp",
+    "dbmcp": {
+      "command": "dbmcp",
       "args": ["stdio"],
       "env": {
         "DB_BACKEND": "mysql",
@@ -116,7 +116,7 @@ Claude Code also supports HTTP transport for remote servers:
 ```json
 {
   "mcpServers": {
-    "database-mcp": {
+    "dbmcp": {
       "type": "http",
       "url": "http://127.0.0.1:9001/mcp"
     }
@@ -131,13 +131,13 @@ Using Docker:
 ```json
 {
   "mcpServers": {
-    "database-mcp": {
+    "dbmcp": {
       "type": "stdio",
       "command": "docker",
       "args": ["run", "-i", "--rm",
         "-e", "DB_BACKEND", "-e", "DB_HOST", "-e", "DB_USER",
         "-e", "DB_PASSWORD", "-e", "DB_NAME",
-        "ghcr.io/haymon-ai/database"
+        "ghcr.io/haymon-ai/dbmcp"
       ],
       "env": {
         "DB_BACKEND": "postgres",
@@ -159,8 +159,8 @@ Edit the config file at:
 ```json
 {
   "mcpServers": {
-    "database-mcp": {
-      "command": "database-mcp",
+    "dbmcp": {
+      "command": "dbmcp",
       "args": ["stdio"],
       "env": {
         "DB_BACKEND": "postgres",
@@ -179,12 +179,12 @@ Using Docker:
 ```json
 {
   "mcpServers": {
-    "database-mcp": {
+    "dbmcp": {
       "command": "docker",
       "args": ["run", "-i", "--rm",
         "-e", "DB_BACKEND", "-e", "DB_HOST", "-e", "DB_USER",
         "-e", "DB_PASSWORD", "-e", "DB_NAME",
-        "ghcr.io/haymon-ai/database"
+        "ghcr.io/haymon-ai/dbmcp"
       ],
       "env": {
         "DB_BACKEND": "postgres",
@@ -207,9 +207,9 @@ Create `.cursor/mcp.json` in your project root, or use `~/.cursor/mcp.json` for 
 ```json
 {
   "mcpServers": {
-    "database-mcp": {
+    "dbmcp": {
       "type": "stdio",
-      "command": "database-mcp",
+      "command": "dbmcp",
       "args": ["stdio"],
       "env": {
         "DB_BACKEND": "mysql",
@@ -228,13 +228,13 @@ Using Docker:
 ```json
 {
   "mcpServers": {
-    "database-mcp": {
+    "dbmcp": {
       "type": "stdio",
       "command": "docker",
       "args": ["run", "-i", "--rm",
         "-e", "DB_BACKEND", "-e", "DB_HOST", "-e", "DB_USER",
         "-e", "DB_PASSWORD", "-e", "DB_NAME",
-        "ghcr.io/haymon-ai/database"
+        "ghcr.io/haymon-ai/dbmcp"
       ],
       "env": {
         "DB_BACKEND": "mysql",
@@ -258,8 +258,8 @@ Edit the config file at:
 ```json
 {
   "mcpServers": {
-    "database-mcp": {
-      "command": "database-mcp",
+    "dbmcp": {
+      "command": "dbmcp",
       "args": ["stdio"],
       "env": {
         "DB_BACKEND": "mysql",
@@ -278,12 +278,12 @@ Using Docker:
 ```json
 {
   "mcpServers": {
-    "database-mcp": {
+    "dbmcp": {
       "command": "docker",
       "args": ["run", "-i", "--rm",
         "-e", "DB_BACKEND", "-e", "DB_HOST", "-e", "DB_USER",
         "-e", "DB_PASSWORD", "-e", "DB_NAME",
-        "ghcr.io/haymon-ai/database"
+        "ghcr.io/haymon-ai/dbmcp"
       ],
       "env": {
         "DB_BACKEND": "mysql",

--- a/docs/content/docs/installation.mdx
+++ b/docs/content/docs/installation.mdx
@@ -1,6 +1,6 @@
 ---
 title: Installation
-description: Install database-mcp via Docker, prebuilt binary, or from source
+description: Install dbmcp via Docker, prebuilt binary, or from source
 ---
 
 Database MCP is distributed as a single binary with no runtime dependencies. Choose the installation method that works best for your setup.
@@ -10,25 +10,25 @@ Database MCP is distributed as a single binary with no runtime dependencies. Cho
 **macOS, Linux, WSL**:
 
 ```bash
-curl -fsSL https://database.haymon.ai/install.sh | bash
+curl -fsSL https://dbmcp.haymon.ai/install.sh | bash
 ```
 
 Or with `wget`:
 
 ```bash
-wget -qO- https://database.haymon.ai/install.sh | bash
+wget -qO- https://dbmcp.haymon.ai/install.sh | bash
 ```
 
 **Windows** (PowerShell):
 
 ```powershell
-irm https://database.haymon.ai/install.ps1 | iex
+irm https://dbmcp.haymon.ai/install.ps1 | iex
 ```
 
 **Windows** (CMD):
 
 ```batch
-curl -fsSL https://database.haymon.ai/install.cmd -o install.cmd && install.cmd && del install.cmd
+curl -fsSL https://dbmcp.haymon.ai/install.cmd -o install.cmd && install.cmd && del install.cmd
 ```
 
 This detects your platform, downloads the correct binary, and installs it. Re-run the same command to upgrade to the latest version.
@@ -36,15 +36,15 @@ This detects your platform, downloads the correct binary, and installs it. Re-ru
 To install to a custom directory:
 
 ```bash
-INSTALL_DIR=/opt/bin curl -fsSL https://database.haymon.ai/install.sh | bash
+INSTALL_DIR=/opt/bin curl -fsSL https://dbmcp.haymon.ai/install.sh | bash
 ```
 
 ```powershell
-$env:INSTALL_DIR = "C:\tools\database-mcp"; irm https://database.haymon.ai/install.ps1 | iex
+$env:INSTALL_DIR = "C:\tools\dbmcp"; irm https://dbmcp.haymon.ai/install.ps1 | iex
 ```
 
 ```batch
-set INSTALL_DIR=C:\tools\database-mcp && curl -fsSL https://database.haymon.ai/install.cmd -o install.cmd && install.cmd && del install.cmd
+set INSTALL_DIR=C:\tools\dbmcp && curl -fsSL https://dbmcp.haymon.ai/install.cmd -o install.cmd && install.cmd && del install.cmd
 ```
 
 ## Prebuilt Binaries
@@ -56,17 +56,17 @@ Download the latest release from GitHub.
 **x86_64 (Intel/AMD)**:
 
 ```bash
-curl -LO https://github.com/haymon-ai/database/releases/latest/download/database-mcp-x86_64-unknown-linux-gnu.tar.gz
-tar xzf database-mcp-x86_64-unknown-linux-gnu.tar.gz
-sudo mv database-mcp /usr/local/bin/
+curl -LO https://github.com/haymon-ai/dbmcp/releases/latest/download/dbmcp-x86_64-unknown-linux-gnu.tar.gz
+tar xzf dbmcp-x86_64-unknown-linux-gnu.tar.gz
+sudo mv dbmcp /usr/local/bin/
 ```
 
 **aarch64 (ARM)**:
 
 ```bash
-curl -LO https://github.com/haymon-ai/database/releases/latest/download/database-mcp-aarch64-unknown-linux-gnu.tar.gz
-tar xzf database-mcp-aarch64-unknown-linux-gnu.tar.gz
-sudo mv database-mcp /usr/local/bin/
+curl -LO https://github.com/haymon-ai/dbmcp/releases/latest/download/dbmcp-aarch64-unknown-linux-gnu.tar.gz
+tar xzf dbmcp-aarch64-unknown-linux-gnu.tar.gz
+sudo mv dbmcp /usr/local/bin/
 ```
 
 ### macOS
@@ -74,17 +74,17 @@ sudo mv database-mcp /usr/local/bin/
 **Apple Silicon (M1/M2/M3/M4)**:
 
 ```bash
-curl -LO https://github.com/haymon-ai/database/releases/latest/download/database-mcp-aarch64-apple-darwin.tar.gz
-tar xzf database-mcp-aarch64-apple-darwin.tar.gz
-sudo mv database-mcp /usr/local/bin/
+curl -LO https://github.com/haymon-ai/dbmcp/releases/latest/download/dbmcp-aarch64-apple-darwin.tar.gz
+tar xzf dbmcp-aarch64-apple-darwin.tar.gz
+sudo mv dbmcp /usr/local/bin/
 ```
 
 **Intel**:
 
 ```bash
-curl -LO https://github.com/haymon-ai/database/releases/latest/download/database-mcp-x86_64-apple-darwin.tar.gz
-tar xzf database-mcp-x86_64-apple-darwin.tar.gz
-sudo mv database-mcp /usr/local/bin/
+curl -LO https://github.com/haymon-ai/dbmcp/releases/latest/download/dbmcp-x86_64-apple-darwin.tar.gz
+tar xzf dbmcp-x86_64-apple-darwin.tar.gz
+sudo mv dbmcp /usr/local/bin/
 ```
 
 ### Windows
@@ -94,26 +94,26 @@ sudo mv database-mcp /usr/local/bin/
 Download the latest release:
 
 ```powershell
-Invoke-WebRequest -Uri https://github.com/haymon-ai/database/releases/latest/download/database-mcp-x86_64-pc-windows-msvc.zip -OutFile database-mcp.zip
-Expand-Archive database-mcp.zip -DestinationPath .
+Invoke-WebRequest -Uri https://github.com/haymon-ai/dbmcp/releases/latest/download/dbmcp-x86_64-pc-windows-msvc.zip -OutFile dbmcp.zip
+Expand-Archive dbmcp.zip -DestinationPath .
 ```
 
-Move `database-mcp.exe` to a directory on your PATH, or run it directly from the extracted location.
+Move `dbmcp.exe` to a directory on your PATH, or run it directly from the extracted location.
 
 Verify the installation:
 
 ```powershell
-database-mcp.exe --help
+dbmcp.exe --help
 ```
 
 ---
 
-For older versions or other assets, see the [GitHub Releases](https://github.com/haymon-ai/database/releases) page.
+For older versions or other assets, see the [GitHub Releases](https://github.com/haymon-ai/dbmcp/releases) page.
 
 Verify the installation (Linux/macOS):
 
 ```bash
-database-mcp --help
+dbmcp --help
 ```
 
 ## Docker
@@ -121,7 +121,7 @@ database-mcp --help
 No Rust toolchain or compilation needed.
 
 ```bash
-docker pull ghcr.io/haymon-ai/database:latest
+docker pull ghcr.io/haymon-ai/dbmcp:latest
 ```
 
 **stdio mode** (for Claude Desktop, Cursor, and other MCP clients):
@@ -131,7 +131,7 @@ docker run -i --rm \
   -e DB_BACKEND=postgres \
   -e DB_HOST=host.docker.internal \
   -e DB_USER=postgres \
-  ghcr.io/haymon-ai/database
+  ghcr.io/haymon-ai/dbmcp
 ```
 
 **HTTP mode** (for web clients and remote access):
@@ -142,7 +142,7 @@ docker run --rm \
   -e DB_HOST=host.docker.internal \
   -e DB_USER=postgres \
   -p 9001:9001 \
-  ghcr.io/haymon-ai/database http --host 0.0.0.0
+  ghcr.io/haymon-ai/dbmcp http --host 0.0.0.0
 ```
 
 **SQLite with a mounted volume**:
@@ -152,10 +152,10 @@ docker run -i --rm \
   -e DB_BACKEND=sqlite \
   -e DB_NAME=/data/my.db \
   -v /path/to/local/db:/data \
-  ghcr.io/haymon-ai/database
+  ghcr.io/haymon-ai/dbmcp
 ```
 
-Images are available for `linux/amd64` and `linux/arm64`. A specific version can be pinned with `ghcr.io/haymon-ai/database:<version>`.
+Images are available for `linux/amd64` and `linux/arm64`. A specific version can be pinned with `ghcr.io/haymon-ai/dbmcp:<version>`.
 
 ## Package Managers
 
@@ -164,7 +164,7 @@ Images are available for `linux/amd64` and `linux/arm64`. A specific version can
 If you have the [Rust toolchain](https://rustup.rs/) installed:
 
 ```bash
-cargo install database-mcp
+cargo install dbmcp
 ```
 
 This builds from source and installs the binary to `~/.cargo/bin/`.
@@ -172,7 +172,7 @@ This builds from source and installs the binary to `~/.cargo/bin/`.
 Verify the installation:
 
 ```bash
-database-mcp --help
+dbmcp --help
 ```
 
 ## Build from Source
@@ -185,21 +185,21 @@ database-mcp --help
 ### Build
 
 ```bash
-git clone https://github.com/haymon-ai/database.git
-cd database-mcp
+git clone https://github.com/haymon-ai/dbmcp.git
+cd dbmcp
 cargo build --release
 ```
 
 Copy the binary to a directory on your PATH:
 
 ```bash
-sudo cp target/release/database-mcp /usr/local/bin/
+sudo cp target/release/dbmcp /usr/local/bin/
 ```
 
 Verify the installation:
 
 ```bash
-database-mcp --help
+dbmcp --help
 ```
 
 ## Comparison

--- a/docs/lib/shared.ts
+++ b/docs/lib/shared.ts
@@ -5,6 +5,6 @@ export const docsRoute = '/docs';
 
 export const gitConfig = {
   user: 'haymon-ai',
-  repo: 'database-mcp',
+  repo: 'dbmcp',
   branch: 'master',
 };

--- a/docs/public/install.cmd
+++ b/docs/public/install.cmd
@@ -1,8 +1,8 @@
 @echo off
 setlocal enabledelayedexpansion
 
-REM Install script for database-mcp (Windows CMD)
-REM Usage: curl -fsSL https://database.haymon.ai/install.cmd -o install.cmd && install.cmd && del install.cmd
+REM Install script for dbmcp (Windows CMD)
+REM Usage: curl -fsSL https://dbmcp.haymon.ai/install.cmd -o install.cmd && install.cmd && del install.cmd
 REM
 REM Environment variables:
 REM   INSTALL_DIR   - Override the install directory
@@ -12,12 +12,12 @@ REM                   latest published release. Without this, re-running the
 REM                   script on an up-to-date install is a no-op (no download,
 REM                   no file writes).
 REM
-REM The script probes https://github.com/haymon-ai/database/releases/latest
+REM The script probes https://github.com/haymon-ai/dbmcp/releases/latest
 REM (a HEAD request that follows redirects) to learn the latest version. The
 REM no-op path performs zero downloads and zero writes to the install directory.
 
-set "BINARY_NAME=database-mcp"
-set "REPO=haymon-ai/database"
+set "BINARY_NAME=dbmcp"
+set "REPO=haymon-ai/dbmcp"
 set "TARGET=x86_64-pc-windows-msvc"
 set "ASSET=%BINARY_NAME%-%TARGET%.zip"
 set "BASE_URL=https://github.com/%REPO%/releases/latest/download"
@@ -25,7 +25,7 @@ set "URL=%BASE_URL%/%ASSET%"
 set "IS_REINSTALL=0"
 
 echo.
-echo Installing database-mcp...
+echo Installing dbmcp...
 echo.
 
 REM Resolve install directory
@@ -70,11 +70,11 @@ goto :resolved
 
 :default_dir
 REM Priority 3: Default location
-set "BIN_DIR=%LOCALAPPDATA%\Programs\database-mcp"
+set "BIN_DIR=%LOCALAPPDATA%\Programs\dbmcp"
 
 :resolved
 if %IS_UPGRADE% equ 1 (
-    echo Found existing database-mcp at %BIN_DIR% ^(%OLD_VERSION%^)
+    echo Found existing dbmcp at %BIN_DIR% ^(%OLD_VERSION%^)
 ) else (
     echo Install directory: %BIN_DIR%
     goto :prepare_install
@@ -102,7 +102,7 @@ set "DBMCP_REPO=%REPO%"
 REM Write a small helper script to a temp file and invoke it. This keeps the
 REM PowerShell logic readable without relying on the fragile combination of
 REM `for /f`, backquotes, and caret line-continuation.
-set "NOOP_HELPER=%TEMP%\database-mcp-noop-%RANDOM%%RANDOM%.ps1"
+set "NOOP_HELPER=%TEMP%\dbmcp-noop-%RANDOM%%RANDOM%.ps1"
 > "%NOOP_HELPER%" echo $ErrorActionPreference='SilentlyContinue'
 >>"%NOOP_HELPER%" echo try { [Net.ServicePointManager]::SecurityProtocol = [Net.ServicePointManager]::SecurityProtocol -bor [Net.SecurityProtocolType]::Tls12 } catch {}
 >>"%NOOP_HELPER%" echo $r = $null
@@ -116,7 +116,7 @@ set "NOOP_HELPER=%TEMP%\database-mcp-noop-%RANDOM%%RANDOM%.ps1"
 >>"%NOOP_HELPER%" echo $inst = $env:DBMCP_OLD_VERSION
 >>"%NOOP_HELPER%" echo if (-not $inst) { exit 0 }
 >>"%NOOP_HELPER%" echo $iN = $inst.Trim()
->>"%NOOP_HELPER%" echo if ($iN.StartsWith('database-mcp ')) { $iN = $iN.Substring('database-mcp '.Length) }
+>>"%NOOP_HELPER%" echo if ($iN.StartsWith('dbmcp ')) { $iN = $iN.Substring('dbmcp '.Length) }
 >>"%NOOP_HELPER%" echo if ($iN.StartsWith('v') -or $iN.StartsWith('V')) { $iN = $iN.Substring(1) }
 >>"%NOOP_HELPER%" echo $lN = $tag
 >>"%NOOP_HELPER%" echo if ($lN.StartsWith('v') -or $lN.StartsWith('V')) { $lN = $lN.Substring(1) }
@@ -154,7 +154,7 @@ if /i "%ACTION%"=="UPGRADE" (
     echo Upgrading to %LATEST_VERSION%
 )
 if "%ACTION%"=="" (
-    echo Upgrading database-mcp at %BIN_DIR% ^(current: %OLD_VERSION%^)
+    echo Upgrading dbmcp at %BIN_DIR% ^(current: %OLD_VERSION%^)
 )
 
 :prepare_install
@@ -162,7 +162,7 @@ REM Create install directory if needed
 if not exist "%BIN_DIR%" mkdir "%BIN_DIR%"
 
 REM Create temp directory (double %RANDOM% for better collision resistance)
-set "TMPDIR=%TEMP%\database-mcp-install-%RANDOM%%RANDOM%"
+set "TMPDIR=%TEMP%\dbmcp-install-%RANDOM%%RANDOM%"
 mkdir "%TMPDIR%"
 
 echo Downloading %ASSET%...
@@ -192,7 +192,7 @@ REM Install
 copy /y "%TMPDIR%\extracted\%BINARY_NAME%.exe" "%BIN_DIR%\%BINARY_NAME%.exe" >nul
 if %errorlevel% neq 0 (
     echo error: failed to install binary to %BIN_DIR%
-    echo   Is an existing database-mcp process running?
+    echo   Is an existing dbmcp process running?
     goto :cleanup_fail
 )
 
@@ -206,14 +206,14 @@ if not defined INSTALLED_VERSION (
 
 echo.
 if %IS_REINSTALL% equ 1 (
-    echo Successfully reinstalled database-mcp!
+    echo Successfully reinstalled dbmcp!
     echo   Version: %INSTALLED_VERSION%
 ) else (
     if %IS_UPGRADE% equ 1 (
-        echo Successfully upgraded database-mcp!
+        echo Successfully upgraded dbmcp!
         echo   %OLD_VERSION% -^> %INSTALLED_VERSION%
     ) else (
-        echo Successfully installed database-mcp!
+        echo Successfully installed dbmcp!
         echo   Version: %INSTALLED_VERSION%
     )
 )

--- a/docs/public/install.ps1
+++ b/docs/public/install.ps1
@@ -1,5 +1,5 @@
-# Install script for database-mcp (Windows)
-# Usage: irm https://database.haymon.ai/install.ps1 | iex
+# Install script for dbmcp (Windows)
+# Usage: irm https://dbmcp.haymon.ai/install.ps1 | iex
 #    or: powershell -ExecutionPolicy Bypass -File install.ps1
 #
 # Environment variables:
@@ -10,7 +10,7 @@
 #                   script on an up-to-date install is a no-op (no download,
 #                   no file writes).
 #
-# The script probes https://github.com/haymon-ai/database/releases/latest
+# The script probes https://github.com/haymon-ai/dbmcp/releases/latest
 # (a HEAD request that follows redirects) to learn the latest version. The
 # no-op path performs zero downloads and zero writes to the install directory.
 
@@ -37,7 +37,7 @@
         param([string]$Version)
         if (-not $Version) { return '' }
         $v = $Version.Trim()
-        if ($v.StartsWith('database-mcp ')) { $v = $v.Substring('database-mcp '.Length) }
+        if ($v.StartsWith('dbmcp ')) { $v = $v.Substring('dbmcp '.Length) }
         if ($v.StartsWith('v') -or $v.StartsWith('V')) { $v = $v.Substring(1) }
         return $v
     }
@@ -127,7 +127,7 @@
         }
 
         # Priority 3: Default location
-        $DefaultDir = Join-Path $env:LOCALAPPDATA "Programs\database-mcp"
+        $DefaultDir = Join-Path $env:LOCALAPPDATA "Programs\dbmcp"
         return @{ Path = $DefaultDir; IsUpgrade = $false; OldVersion = "" }
     }
 
@@ -170,8 +170,8 @@
 
     # --- Main flow ---
 
-    $BinaryName = "database-mcp"
-    $Repo = "haymon-ai/database"
+    $BinaryName = "dbmcp"
+    $Repo = "haymon-ai/dbmcp"
     $Target = "x86_64-pc-windows-msvc"
     $Asset = "$BinaryName-$Target.zip"
     $BaseUrl = "https://github.com/$Repo/releases/latest/download"
@@ -182,7 +182,7 @@
 
     try {
         Write-Host ""
-        Write-Host "Installing database-mcp..." -ForegroundColor Cyan
+        Write-Host "Installing dbmcp..." -ForegroundColor Cyan
         Write-Host ""
 
         # Resolve install directory
@@ -192,7 +192,7 @@
         $BinDir = $InstallInfo.Path
 
         if ($IsUpgrade) {
-            Write-Host "Found existing database-mcp at $BinDir ($OldVersion)" -ForegroundColor Cyan
+            Write-Host "Found existing dbmcp at $BinDir ($OldVersion)" -ForegroundColor Cyan
 
             # No-op / force / newer-than-latest check. Only runs when an
             # existing binary was detected. Skipped entirely if the version
@@ -220,7 +220,7 @@
                     Write-Host "Upgrading to $LatestVersion" -ForegroundColor Cyan
                 }
             } else {
-                Write-Host "Upgrading database-mcp at $BinDir (current: $OldVersion)" -ForegroundColor Cyan
+                Write-Host "Upgrading dbmcp at $BinDir (current: $OldVersion)" -ForegroundColor Cyan
             }
         } else {
             Write-Host "Install directory: $BinDir" -ForegroundColor Cyan
@@ -262,7 +262,7 @@
         try {
             Copy-Item -Path $BinaryPath -Destination $Dest -Force
         } catch {
-            throw "failed to install binary to $BinDir - is an existing database-mcp process running? ($($_.Exception.Message))"
+            throw "failed to install binary to $BinDir - is an existing dbmcp process running? ($($_.Exception.Message))"
         }
 
         # Verify
@@ -278,13 +278,13 @@
 
         Write-Host ""
         if ($ForceReinstall) {
-            Write-Host "Successfully reinstalled database-mcp!" -ForegroundColor Green
+            Write-Host "Successfully reinstalled dbmcp!" -ForegroundColor Green
             Write-Host "  Version: $InstalledVersion"
         } elseif ($IsUpgrade) {
-            Write-Host "Successfully upgraded database-mcp!" -ForegroundColor Green
+            Write-Host "Successfully upgraded dbmcp!" -ForegroundColor Green
             Write-Host "  $OldVersion -> $InstalledVersion"
         } else {
-            Write-Host "Successfully installed database-mcp!" -ForegroundColor Green
+            Write-Host "Successfully installed dbmcp!" -ForegroundColor Green
             Write-Host "  Version: $InstalledVersion"
         }
         Write-Host "  Location: $Dest"

--- a/docs/public/install.sh
+++ b/docs/public/install.sh
@@ -1,7 +1,7 @@
 #!/bin/sh
-# Install script for database-mcp
-# Usage: curl -fsSL https://database.haymon.ai/install.sh | bash
-#    or: wget -qO- https://database.haymon.ai/install.sh | bash
+# Install script for dbmcp
+# Usage: curl -fsSL https://dbmcp.haymon.ai/install.sh | bash
+#    or: wget -qO- https://dbmcp.haymon.ai/install.sh | bash
 #    or: sh install.sh
 #
 # Environment variables:
@@ -12,7 +12,7 @@
 #                   script on an up-to-date install is a no-op (no download,
 #                   no file writes).
 #
-# The script probes https://github.com/haymon-ai/database/releases/latest
+# The script probes https://github.com/haymon-ai/dbmcp/releases/latest
 # (a HEAD request that follows redirects) to learn the latest version. The
 # no-op path performs zero downloads and zero writes to the install directory.
 
@@ -79,7 +79,7 @@ main() {
     # universally portable).
     normalize_version() {
         _v=$(printf '%s' "$1" | sed -e 's/^[[:space:]]*//' -e 's/[[:space:]]*$//')
-        _v=${_v#database-mcp }
+        _v=${_v#dbmcp }
         _v=${_v#v}
         printf '%s' "$_v"
     }
@@ -211,7 +211,7 @@ main() {
         fi
 
         # Priority 2: Existing binary detection (upgrade in-place)
-        _existing=$(command -v database-mcp 2>/dev/null || true)
+        _existing=$(command -v dbmcp 2>/dev/null || true)
         if [ -n "$_existing" ]; then
             # Resolve symlinks to find the actual binary location
             _existing=$(readlink -f "$_existing" 2>/dev/null || echo "$_existing")
@@ -295,13 +295,13 @@ main() {
 
     # --- Main flow (T008, T009-T012) ---
 
-    BINARY_NAME="database-mcp"
-    REPO="haymon-ai/database"
+    BINARY_NAME="dbmcp"
+    REPO="haymon-ai/dbmcp"
     BASE_URL="https://github.com/${REPO}/releases/latest/download"
     USE_SUDO=false
     FORCE_REINSTALL=false
 
-    info "Installing database-mcp..."
+    info "Installing dbmcp..."
     echo ""
 
     # T005-T006: Detect platform and target
@@ -313,7 +313,7 @@ main() {
     resolve_install_dir
 
     if [ "$UPGRADE" = true ]; then
-        info "Found existing database-mcp at ${BIN_DIR} (${OLD_VERSION})"
+        info "Found existing dbmcp at ${BIN_DIR} (${OLD_VERSION})"
 
         # No-op / force / newer-than-latest check. Only runs when an existing
         # binary was detected. Skipped entirely if the version lookup fails,
@@ -343,14 +343,14 @@ main() {
                 info "Upgrading to ${_latest_version}"
             fi
         else
-            info "Upgrading database-mcp at ${BIN_DIR} (current: ${OLD_VERSION})"
+            info "Upgrading dbmcp at ${BIN_DIR} (current: ${OLD_VERSION})"
         fi
     else
         info "Install directory: ${BIN_DIR}"
     fi
 
     # T008: Temp directory with cleanup trap
-    _tmpdir=$(mktemp -d 2>/dev/null || mktemp -d -t database-mcp)
+    _tmpdir=$(mktemp -d 2>/dev/null || mktemp -d -t dbmcp)
     trap 'rm -rf "$_tmpdir"' EXIT
 
     # T009: Download
@@ -386,13 +386,13 @@ main() {
 
     echo ""
     if [ "$FORCE_REINSTALL" = true ]; then
-        success "Successfully reinstalled database-mcp!"
+        success "Successfully reinstalled dbmcp!"
         echo "  Version: ${_installed_version}"
     elif [ "$UPGRADE" = true ]; then
-        success "Successfully upgraded database-mcp!"
+        success "Successfully upgraded dbmcp!"
         echo "  ${OLD_VERSION} → ${_installed_version}"
     else
-        success "Successfully installed database-mcp!"
+        success "Successfully installed dbmcp!"
         echo "  Version: ${_installed_version}"
     fi
     echo "  Location: ${_dest}"

--- a/docs/tapes/demo.tape
+++ b/docs/tapes/demo.tape
@@ -15,7 +15,7 @@ Set TypingSpeed 80ms
 Set Framerate 24
 Set CursorBlink false
 
-Set Theme {"name":"database-mcp","black":"#1a1a1a","red":"#ff4800","green":"#16a34a","yellow":"#d97706","blue":"#2563eb","magenta":"#9333ea","cyan":"#0891b2","white":"#374151","brightBlack":"#6b7280","brightRed":"#ff6b35","brightGreen":"#22c55e","brightYellow":"#f59e0b","brightBlue":"#3b82f6","brightMagenta":"#a855f7","brightCyan":"#06b6d4","brightWhite":"#111827","background":"#ffffff","foreground":"#1a1a1a","selection":"#ff480020","cursor":"#ff4800"}
+Set Theme {"name":"dbmcp","black":"#1a1a1a","red":"#ff4800","green":"#16a34a","yellow":"#d97706","blue":"#2563eb","magenta":"#9333ea","cyan":"#0891b2","white":"#374151","brightBlack":"#6b7280","brightRed":"#ff6b35","brightGreen":"#22c55e","brightYellow":"#f59e0b","brightBlue":"#3b82f6","brightMagenta":"#a855f7","brightCyan":"#06b6d4","brightWhite":"#111827","background":"#ffffff","foreground":"#1a1a1a","selection":"#ff480020","cursor":"#ff4800"}
 
 # Hidden setup: launch interactive simulation
 Hide

--- a/server.json
+++ b/server.json
@@ -2,7 +2,7 @@
   "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
   "name": "ai.haymon/dbmcp",
   "description": "Database MCP server for MySQL, MariaDB, PostgreSQL & SQLite",
-  "version": "0.8.0",
+  "version": "0.7.0",
   "websiteUrl": "https://dbmcp.haymon.ai",
   "repository": {
     "url": "https://github.com/haymon-ai/dbmcp",
@@ -11,7 +11,7 @@
   "packages": [
     {
       "registryType": "oci",
-      "identifier": "ghcr.io/haymon-ai/dbmcp:0.8.0",
+      "identifier": "ghcr.io/haymon-ai/dbmcp:0.7.0",
       "runtimeHint": "docker",
       "transport": {
         "type": "stdio"
@@ -27,7 +27,7 @@
     },
     {
       "registryType": "oci",
-      "identifier": "ghcr.io/haymon-ai/dbmcp:0.8.0",
+      "identifier": "ghcr.io/haymon-ai/dbmcp:0.7.0",
       "runtimeHint": "docker",
       "transport": {
         "type": "streamable-http",

--- a/server.json
+++ b/server.json
@@ -1,17 +1,17 @@
 {
   "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
-  "name": "ai.haymon/database",
+  "name": "ai.haymon/dbmcp",
   "description": "Database MCP server for MySQL, MariaDB, PostgreSQL & SQLite",
-  "version": "0.7.0",
-  "websiteUrl": "https://database.haymon.ai",
+  "version": "0.8.0",
+  "websiteUrl": "https://dbmcp.haymon.ai",
   "repository": {
-    "url": "https://github.com/haymon-ai/database",
+    "url": "https://github.com/haymon-ai/dbmcp",
     "source": "github"
   },
   "packages": [
     {
       "registryType": "oci",
-      "identifier": "ghcr.io/haymon-ai/database:0.7.0",
+      "identifier": "ghcr.io/haymon-ai/dbmcp:0.8.0",
       "runtimeHint": "docker",
       "transport": {
         "type": "stdio"
@@ -27,7 +27,7 @@
     },
     {
       "registryType": "oci",
-      "identifier": "ghcr.io/haymon-ai/database:0.7.0",
+      "identifier": "ghcr.io/haymon-ai/dbmcp:0.8.0",
       "runtimeHint": "docker",
       "transport": {
         "type": "streamable-http",

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -55,7 +55,7 @@ impl From<LogLevel> for tracing::Level {
 
 /// Top-level CLI arguments parsed by clap.
 #[derive(Debug, Parser)]
-#[command(name = "database-mcp", about = "Database MCP Server", version)]
+#[command(name = "dbmcp", about = "Database MCP Server", version)]
 struct Arguments {
     /// Subcommand selector.
     #[command(subcommand)]

--- a/src/commands/common.rs
+++ b/src/commands/common.rs
@@ -7,13 +7,13 @@
 //! configured [`DatabaseBackend`] onto the matching concrete adapter.
 
 use clap::Args;
-use database_mcp_config::{ConfigError, DatabaseBackend, DatabaseConfig};
-use database_mcp_mysql::MysqlHandler;
-use database_mcp_postgres::PostgresHandler;
-use database_mcp_sqlite::SqliteHandler;
+use dbmcp_config::{ConfigError, DatabaseBackend, DatabaseConfig};
+use dbmcp_mysql::MysqlHandler;
+use dbmcp_postgres::PostgresHandler;
+use dbmcp_sqlite::SqliteHandler;
 use tracing::info;
 
-pub(crate) use database_mcp_server::Server;
+pub(crate) use dbmcp_server::Server;
 
 /// Shared database connection flags embedded in transport subcommands.
 #[derive(Debug, Args)]

--- a/src/commands/http.rs
+++ b/src/commands/http.rs
@@ -5,7 +5,7 @@
 //! the underlying connection pools.
 
 use clap::{Args, Parser};
-use database_mcp_config::{ConfigError, DatabaseConfig, HttpConfig};
+use dbmcp_config::{ConfigError, DatabaseConfig, HttpConfig};
 use rmcp::transport::streamable_http_server::{
     StreamableHttpServerConfig, StreamableHttpService, session::local::LocalSessionManager,
 };

--- a/src/commands/stdio.rs
+++ b/src/commands/stdio.rs
@@ -4,7 +4,7 @@
 //! Cursor, and other MCP clients that communicate via stdio.
 
 use clap::Parser;
-use database_mcp_config::DatabaseConfig;
+use dbmcp_config::DatabaseConfig;
 use rmcp::ServiceExt;
 use tracing::{error, info};
 
@@ -46,7 +46,7 @@ impl StdioCommand {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use database_mcp_config::{ConfigError, DatabaseBackend};
+    use dbmcp_config::{ConfigError, DatabaseBackend};
 
     #[track_caller]
     fn parse(args: &[&str]) -> StdioCommand {

--- a/src/consts.rs
+++ b/src/consts.rs
@@ -1,4 +1,4 @@
-//! Compile-time constants for the database-mcp binary.
+//! Compile-time constants for the dbmcp binary.
 
 /// The name of the binary, derived from `Cargo.toml` at compile time.
 pub(crate) const BIN: &str = env!("CARGO_PKG_NAME");

--- a/src/error.rs
+++ b/src/error.rs
@@ -3,7 +3,7 @@
 //! Defines the top-level [`Error`] enum used for server startup and
 //! transport failures in the binary crate.
 
-use database_mcp_config::ConfigError;
+use dbmcp_config::ConfigError;
 
 /// Application-level errors for server startup and transport.
 ///

--- a/tests/approval/common.rs
+++ b/tests/approval/common.rs
@@ -3,7 +3,7 @@
 //! Provides duplex transport setup and client lifecycle management
 //! used by tool schema snapshot tests.
 
-use database_mcp_server::Server;
+use dbmcp_server::Server;
 use rmcp::service::{Peer, RunningService, ServiceExt};
 
 /// Connects a [`Server`] over a duplex transport, runs a closure, then cleans up.

--- a/tests/approval/mysql.rs
+++ b/tests/approval/mysql.rs
@@ -4,9 +4,9 @@
 
 mod common;
 
-use database_mcp_config::{DatabaseBackend, DatabaseConfig};
-use database_mcp_mysql::MysqlHandler;
-use database_mcp_server::Server;
+use dbmcp_config::{DatabaseBackend, DatabaseConfig};
+use dbmcp_mysql::MysqlHandler;
+use dbmcp_server::Server;
 
 /// Creates a `MySQL`-backed [`Server`] from `DB_HOST` and `DB_PORT` environment variables.
 fn server(read_only: bool) -> Server {

--- a/tests/approval/postgres.rs
+++ b/tests/approval/postgres.rs
@@ -4,9 +4,9 @@
 
 mod common;
 
-use database_mcp_config::{DatabaseBackend, DatabaseConfig};
-use database_mcp_postgres::PostgresHandler;
-use database_mcp_server::Server;
+use dbmcp_config::{DatabaseBackend, DatabaseConfig};
+use dbmcp_postgres::PostgresHandler;
+use dbmcp_server::Server;
 
 /// Creates a `PostgreSQL`-backed [`Server`] from `DB_HOST` and `DB_PORT` environment variables.
 fn server(read_only: bool) -> Server {

--- a/tests/approval/snapshots/approval_mysql__server_info.snap
+++ b/tests/approval/snapshots/approval_mysql__server_info.snap
@@ -9,11 +9,11 @@ expression: info
     "tools": {}
   },
   "serverInfo": {
-    "name": "database-mcp",
+    "name": "dbmcp",
     "title": "Database MCP Server",
     "version": "[version]",
     "description": "Database MCP Server for MySQL and MariaDB",
-    "websiteUrl": "https://database.haymon.ai"
+    "websiteUrl": "https://dbmcp.haymon.ai"
   },
   "instructions": "## Workflow\n\n1. Call `listDatabases` to discover available databases.\n2. Call `listTables` to see tables.\n3. Call `listViews` to see views.\n4. Call `listTriggers` to see triggers.\n5. Call `listFunctions` to see stored functions.\n6. Call `listProcedures` to see stored procedures.\n7. Call `getTableSchema` to inspect columns, types, and foreign keys before writing queries.\n8. Use `readQuery` for read-only SQL (SELECT, SHOW, DESCRIBE, USE, EXPLAIN).\n9. Use `writeQuery` for data changes (INSERT, UPDATE, DELETE, CREATE, ALTER, DROP).\n10. Use `explainQuery` to analyze query execution plans and diagnose slow queries.\n11. Use `createDatabase` to create a new database.\n12. Use `dropDatabase` to drop an existing database.\n13. Use `dropTable` to remove a table from a database.\n\nPer-database tools default to the active database; pass `database` to target another.\n\n## Constraints\n\n- The `writeQuery`, `createDatabase`, `dropDatabase`, and `dropTable` tools are hidden when read-only mode is active.\n- Multi-statement queries are not supported. Send one statement per request."
 }

--- a/tests/approval/snapshots/approval_postgres__server_info.snap
+++ b/tests/approval/snapshots/approval_postgres__server_info.snap
@@ -9,11 +9,11 @@ expression: info
     "tools": {}
   },
   "serverInfo": {
-    "name": "database-mcp",
+    "name": "dbmcp",
     "title": "Database MCP Server",
     "version": "[version]",
     "description": "Database MCP Server for PostgreSQL",
-    "websiteUrl": "https://database.haymon.ai"
+    "websiteUrl": "https://dbmcp.haymon.ai"
   },
   "instructions": "## Workflow\n\n1. Call `listDatabases` to discover available databases.\n2. Call `listTables` to see tables.\n3. Call `listViews` to see views in the `public` schema.\n4. Call `listTriggers` to see user-defined triggers in the `public` schema.\n5. Call `listFunctions` to see user-defined functions in the `public` schema.\n6. Call `listProcedures` to see user-defined procedures in the `public` schema.\n7. Call `listMaterializedViews` to see materialized views in the `public` schema.\n8. Call `getTableSchema` to inspect columns, types, and foreign keys before writing queries.\n9. Use `readQuery` for read-only SQL (SELECT, SHOW, EXPLAIN).\n10. Use `writeQuery` for data changes (INSERT, UPDATE, DELETE, CREATE, ALTER, DROP).\n11. Use `explainQuery` to analyze query execution plans and diagnose slow queries.\n12. Use `createDatabase` to create a new database.\n13. Use `dropDatabase` to drop an existing database.\n14. Use `dropTable` to remove a table from a database (supports `cascade` for foreign key dependencies).\n\nPer-database tools default to the active database; pass `database` to target another.\n\n## Constraints\n\n- The `writeQuery`, `createDatabase`, `dropDatabase`, and `dropTable` tools are hidden when read-only mode is active.\n- Multi-statement queries are not supported. Send one statement per request."
 }

--- a/tests/approval/snapshots/approval_sqlite__server_info.snap
+++ b/tests/approval/snapshots/approval_sqlite__server_info.snap
@@ -9,11 +9,11 @@ expression: info
     "tools": {}
   },
   "serverInfo": {
-    "name": "database-mcp",
+    "name": "dbmcp",
     "title": "Database MCP Server",
     "version": "[version]",
     "description": "Database MCP Server for SQLite",
-    "websiteUrl": "https://database.haymon.ai"
+    "websiteUrl": "https://dbmcp.haymon.ai"
   },
   "instructions": "## Workflow\n\n1. Call `listTables` to discover tables in the connected database.\n2. Call `listViews` to discover views in the connected database.\n3. Call `listTriggers` to discover triggers in the connected database.\n4. Call `getTableSchema` with a `table` to inspect columns, types, and foreign keys before writing queries.\n5. Use `readQuery` for read-only SQL (SELECT).\n6. Use `writeQuery` for data changes (INSERT, UPDATE, DELETE, CREATE, ALTER, DROP).\n7. Use `explainQuery` to analyze query execution plans and diagnose slow queries.\n8. Use `dropTable` to remove a table from the database.\n\n## Constraints\n\n- The `writeQuery` and `dropTable` tools are hidden when read-only mode is active.\n- Multi-statement queries are not supported. Send one statement per request."
 }

--- a/tests/approval/sqlite.rs
+++ b/tests/approval/sqlite.rs
@@ -4,9 +4,9 @@
 
 mod common;
 
-use database_mcp_config::{DatabaseBackend, DatabaseConfig};
-use database_mcp_server::Server;
-use database_mcp_sqlite::SqliteHandler;
+use dbmcp_config::{DatabaseBackend, DatabaseConfig};
+use dbmcp_server::Server;
+use dbmcp_sqlite::SqliteHandler;
 
 /// Creates a `SQLite`-backed [`Server`] from the `DB_PATH` environment variable.
 fn server(read_only: bool) -> Server {

--- a/tests/functional/mysql.rs
+++ b/tests/functional/mysql.rs
@@ -8,10 +8,10 @@
 //! ./tests/run.sh --filter mysql      # MySQL
 //! ```
 
-use database_mcp_config::{DatabaseBackend, DatabaseConfig};
-use database_mcp_mysql::MysqlHandler;
-use database_mcp_mysql::types::DropTableRequest;
-use database_mcp_server::types::{
+use dbmcp_config::{DatabaseBackend, DatabaseConfig};
+use dbmcp_mysql::MysqlHandler;
+use dbmcp_mysql::types::DropTableRequest;
+use dbmcp_server::types::{
     CreateDatabaseRequest, DropDatabaseRequest, ExplainQueryRequest, GetTableSchemaRequest, ListDatabasesRequest,
     ListFunctionsRequest, ListProceduresRequest, ListTablesRequest, ListTriggersRequest, ListViewsRequest,
     QueryRequest, ReadQueryRequest,
@@ -1334,7 +1334,7 @@ const MY_DB: &str = "app";
 
 async fn collect_all_paged(handler: &MysqlHandler) -> Vec<String> {
     let mut all = Vec::new();
-    let mut cursor: Option<database_mcp_server::pagination::Cursor> = None;
+    let mut cursor: Option<dbmcp_server::pagination::Cursor> = None;
     loop {
         let request = ListTablesRequest {
             database: Some(MY_DB.into()),
@@ -1424,7 +1424,7 @@ async fn test_list_tables_pagination_boundary_page_size_equals_total() {
 
 #[tokio::test]
 async fn test_list_tables_pagination_off_the_end_cursor_returns_empty_page() {
-    use database_mcp_server::pagination::Cursor;
+    use dbmcp_server::pagination::Cursor;
 
     let handler = handler(true);
     let request = ListTablesRequest {
@@ -1474,7 +1474,7 @@ async fn test_list_tables_respects_configured_page_size_minimum() {
 
 async fn collect_all_paged_databases(handler: &MysqlHandler) -> Vec<String> {
     let mut all = Vec::new();
-    let mut cursor: Option<database_mcp_server::pagination::Cursor> = None;
+    let mut cursor: Option<dbmcp_server::pagination::Cursor> = None;
     loop {
         let request = ListDatabasesRequest { cursor };
         let response = handler.list_databases(request).await.expect("list page");
@@ -1546,7 +1546,7 @@ async fn test_list_databases_pagination_boundary_page_size_equals_total() {
 
 #[tokio::test]
 async fn test_list_databases_pagination_off_the_end_cursor_returns_empty_page() {
-    use database_mcp_server::pagination::Cursor;
+    use dbmcp_server::pagination::Cursor;
 
     let handler = handler(true);
     let request = ListDatabasesRequest {
@@ -1582,7 +1582,7 @@ async fn test_list_databases_respects_configured_page_size() {
 
 async fn collect_all_paged_read_query(handler: &MysqlHandler, query: &str) -> Vec<Value> {
     let mut all = Vec::new();
-    let mut cursor: Option<database_mcp_server::pagination::Cursor> = None;
+    let mut cursor: Option<dbmcp_server::pagination::Cursor> = None;
     loop {
         let request = ReadQueryRequest {
             query: query.into(),
@@ -1682,7 +1682,7 @@ async fn test_read_query_pagination_preserves_inner_limit() {
 
 #[tokio::test]
 async fn test_read_query_pagination_off_the_end_cursor_returns_empty() {
-    use database_mcp_server::pagination::Cursor;
+    use dbmcp_server::pagination::Cursor;
     let handler = handler_with_page_size(2);
     let response = handler
         .read_query(ReadQueryRequest {
@@ -1721,7 +1721,7 @@ async fn test_read_query_pagination_invalid_cursor_rejected_at_deserialize() {
 async fn test_read_query_non_select_show_tables_single_page() {
     // SHOW TABLES is NonSelect; cursor must be ignored (no error, no nextCursor,
     // response identical to the no-cursor call) and all rows returned.
-    use database_mcp_server::pagination::Cursor;
+    use dbmcp_server::pagination::Cursor;
     let handler = handler_with_page_size(2);
 
     let without_cursor = handler
@@ -1912,7 +1912,7 @@ async fn test_list_views_pagination_traverses_pages() {
     let handler_full = handler(true);
 
     let mut all = Vec::new();
-    let mut cursor: Option<database_mcp_server::pagination::Cursor> = None;
+    let mut cursor: Option<dbmcp_server::pagination::Cursor> = None;
     loop {
         let request = ListViewsRequest {
             database: Some("app".into()),

--- a/tests/functional/postgres.rs
+++ b/tests/functional/postgres.rs
@@ -7,10 +7,10 @@
 //! ./tests/run.sh --filter postgres
 //! ```
 
-use database_mcp_config::{DatabaseBackend, DatabaseConfig};
-use database_mcp_postgres::PostgresHandler;
-use database_mcp_postgres::types::DropTableRequest;
-use database_mcp_server::types::{
+use dbmcp_config::{DatabaseBackend, DatabaseConfig};
+use dbmcp_postgres::PostgresHandler;
+use dbmcp_postgres::types::DropTableRequest;
+use dbmcp_server::types::{
     CreateDatabaseRequest, DropDatabaseRequest, ExplainQueryRequest, GetTableSchemaRequest, ListDatabasesRequest,
     ListFunctionsRequest, ListMaterializedViewsRequest, ListProceduresRequest, ListTablesRequest, ListTriggersRequest,
     ListViewsRequest, QueryRequest, ReadQueryRequest,
@@ -1198,7 +1198,7 @@ const PG_DB: &str = "app";
 
 async fn collect_all_paged(handler: &PostgresHandler) -> Vec<String> {
     let mut all = Vec::new();
-    let mut cursor: Option<database_mcp_server::pagination::Cursor> = None;
+    let mut cursor: Option<dbmcp_server::pagination::Cursor> = None;
     loop {
         let request = ListTablesRequest {
             database: Some(PG_DB.into()),
@@ -1288,7 +1288,7 @@ async fn test_list_tables_pagination_boundary_page_size_equals_total() {
 
 #[tokio::test]
 async fn test_list_tables_pagination_off_the_end_cursor_returns_empty_page() {
-    use database_mcp_server::pagination::Cursor;
+    use dbmcp_server::pagination::Cursor;
 
     let handler = handler(true);
     let request = ListTablesRequest {
@@ -1338,7 +1338,7 @@ async fn test_list_tables_respects_configured_page_size_minimum() {
 
 async fn collect_all_paged_databases(handler: &PostgresHandler) -> Vec<String> {
     let mut all = Vec::new();
-    let mut cursor: Option<database_mcp_server::pagination::Cursor> = None;
+    let mut cursor: Option<dbmcp_server::pagination::Cursor> = None;
     loop {
         let request = ListDatabasesRequest { cursor };
         let response = handler.list_databases(request).await.expect("list page");
@@ -1410,7 +1410,7 @@ async fn test_list_databases_pagination_boundary_page_size_equals_total() {
 
 #[tokio::test]
 async fn test_list_databases_pagination_off_the_end_cursor_returns_empty_page() {
-    use database_mcp_server::pagination::Cursor;
+    use dbmcp_server::pagination::Cursor;
 
     let handler = handler(true);
     let request = ListDatabasesRequest {
@@ -1446,7 +1446,7 @@ async fn test_list_databases_respects_configured_page_size() {
 
 async fn collect_all_paged_read_query(handler: &PostgresHandler, query: &str) -> Vec<Value> {
     let mut all = Vec::new();
-    let mut cursor: Option<database_mcp_server::pagination::Cursor> = None;
+    let mut cursor: Option<dbmcp_server::pagination::Cursor> = None;
     loop {
         let request = ReadQueryRequest {
             query: query.into(),
@@ -1546,7 +1546,7 @@ async fn test_read_query_pagination_preserves_inner_limit() {
 
 #[tokio::test]
 async fn test_read_query_pagination_off_the_end_cursor_returns_empty() {
-    use database_mcp_server::pagination::Cursor;
+    use dbmcp_server::pagination::Cursor;
     let handler = handler_with_page_size(2);
     let response = handler
         .read_query(ReadQueryRequest {
@@ -1584,7 +1584,7 @@ async fn test_read_query_pagination_invalid_cursor_rejected_at_deserialize() {
 #[tokio::test]
 async fn test_read_query_non_select_show_server_version_single_page() {
     // SHOW is classified as NonSelect; cursor must be ignored.
-    use database_mcp_server::pagination::Cursor;
+    use dbmcp_server::pagination::Cursor;
     let handler = handler_with_page_size(2);
 
     let without_cursor = handler
@@ -1727,7 +1727,7 @@ async fn test_list_views_pagination_traverses_pages() {
     let handler_full = handler(true);
 
     let mut all = Vec::new();
-    let mut cursor: Option<database_mcp_server::pagination::Cursor> = None;
+    let mut cursor: Option<dbmcp_server::pagination::Cursor> = None;
     loop {
         let request = ListViewsRequest {
             database: Some("app".into()),

--- a/tests/functional/sqlite.rs
+++ b/tests/functional/sqlite.rs
@@ -9,9 +9,9 @@
 //! ./tests/run.sh --filter sqlite
 //! ```
 
-use database_mcp_config::{DatabaseBackend, DatabaseConfig};
-use database_mcp_sqlite::SqliteHandler;
-use database_mcp_sqlite::types::{
+use dbmcp_config::{DatabaseBackend, DatabaseConfig};
+use dbmcp_sqlite::SqliteHandler;
+use dbmcp_sqlite::types::{
     DropTableRequest, ExplainQueryRequest, GetTableSchemaRequest, ListTablesRequest, ListTriggersRequest,
     ListViewsRequest, QueryRequest, ReadQueryRequest,
 };
@@ -642,7 +642,7 @@ async fn test_create_drop_table_with_spaces() {
 
 async fn collect_all_paged(handler: &SqliteHandler) -> Vec<String> {
     let mut all = Vec::new();
-    let mut cursor: Option<database_mcp_server::pagination::Cursor> = None;
+    let mut cursor: Option<dbmcp_server::pagination::Cursor> = None;
     loop {
         let request = ListTablesRequest { cursor };
         let response = handler.list_tables(request).await.expect("list page");
@@ -714,7 +714,7 @@ async fn test_list_tables_pagination_boundary_page_size_equals_total() {
 
 #[tokio::test]
 async fn test_list_tables_pagination_off_the_end_cursor_returns_empty_page() {
-    use database_mcp_server::pagination::Cursor;
+    use dbmcp_server::pagination::Cursor;
 
     let handler = handler(true);
     let request = ListTablesRequest {
@@ -785,7 +785,7 @@ async fn test_list_tables_pagination_invalid_cursor_rejected_at_deserialize() {
 
 async fn collect_all_paged_read_query(handler: &SqliteHandler, query: &str) -> Vec<Value> {
     let mut all = Vec::new();
-    let mut cursor: Option<database_mcp_server::pagination::Cursor> = None;
+    let mut cursor: Option<dbmcp_server::pagination::Cursor> = None;
     loop {
         let request = ReadQueryRequest {
             query: query.into(),
@@ -881,7 +881,7 @@ async fn test_read_query_pagination_preserves_inner_limit() {
 
 #[tokio::test]
 async fn test_read_query_pagination_off_the_end_cursor_returns_empty() {
-    use database_mcp_server::pagination::Cursor;
+    use dbmcp_server::pagination::Cursor;
     let handler = handler_with_page_size(2);
     let response = handler
         .read_query(ReadQueryRequest {
@@ -898,7 +898,7 @@ async fn test_read_query_pagination_off_the_end_cursor_returns_empty() {
 async fn test_read_query_pagination_survives_trailing_line_comment() {
     // A trailing `-- comment` in the caller's SQL must not swallow the
     // subquery-wrap's closing paren + LIMIT/OFFSET. Regression guard for
-    // the newline-before-`)` fix in database_mcp_sql::pagination::with_limit_offset.
+    // the newline-before-`)` fix in dbmcp_sql::pagination::with_limit_offset.
     let handler = handler_with_page_size(2);
     let response = handler
         .read_query(ReadQueryRequest {
@@ -953,7 +953,7 @@ async fn test_read_query_pagination_invalid_cursor_rejected_at_deserialize() {
 
 #[tokio::test]
 async fn test_read_query_cursor_does_not_bypass_read_only() {
-    use database_mcp_server::pagination::Cursor;
+    use dbmcp_server::pagination::Cursor;
     let handler = handler_with_page_size(2);
     let result = handler
         .read_query(ReadQueryRequest {
@@ -971,7 +971,7 @@ async fn test_read_query_cursor_does_not_bypass_read_only() {
 async fn test_read_query_non_select_single_page_with_cursor_ignored() {
     // EXPLAIN is classified as NonSelect; cursor must be ignored (no error,
     // no nextCursor, response identical to the no-cursor call).
-    use database_mcp_server::pagination::Cursor;
+    use dbmcp_server::pagination::Cursor;
     let handler = handler_with_page_size(2);
 
     let without_cursor = handler
@@ -1066,7 +1066,7 @@ async fn test_list_views_pagination_traverses_pages() {
     let handler_full = handler(true);
 
     let mut all = Vec::new();
-    let mut cursor: Option<database_mcp_server::pagination::Cursor> = None;
+    let mut cursor: Option<dbmcp_server::pagination::Cursor> = None;
     loop {
         let response = handler_paged
             .list_views(ListViewsRequest { cursor })


### PR DESCRIPTION
## Summary

Renames the project end-to-end from `database-mcp` / `database` to `dbmcp` across the binary, workspace crates, MCP surface, release artifacts, Docker image, documentation, and registry metadata. First release under the new name is **`0.8.0`** — a breaking-change bump under Cargo's pre-1.0 compatibility rules (`^0.7` and `^0.8` are incompatible).

Clean break: no wrapper binary, no alias, no deprecated Docker tag. Migration info lives in the `0.8.0` CHANGELOG entry + release notes + updated README.

Full scope, decisions, and rationale are in the feature spec: `specs/042-rename-to-dbmcp/` (spec, plan, research, data-model, contracts, tasks, quickstart).

### Preserved (contract)

All CLI flags (`--db-*`, `--host`, `--port`), environment variables (`DB_*`, `HTTP_*`, `LOG_LEVEL`), MCP tool names and schemas, supported backends and transports, and security constraints are **unchanged**. `sqlx_to_json` crate is **unchanged**. The `"Database MCP Server"` human-readable title (clap `about`, module docs, snapshot `title`/`description` fields) is **preserved** — it describes what the tool is, not its name.

### Migration (matches CHANGELOG `[v0.8.0]`)

| Surface | Before | After |
| ------- | ------ | ----- |
| Binary on `PATH` | `database-mcp` | `dbmcp` |
| MCP client config server key | `"database-mcp"` | `"dbmcp"` |
| MCP client config `command` | `database-mcp` | `dbmcp` |
| MCP `serverInfo.name` | `"database-mcp"` | `"dbmcp"` |
| MCP registry entry | `ai.haymon/database` (will be deprecated) | `ai.haymon/dbmcp` (new) |
| GitHub repository | `github.com/haymon-ai/database` | `github.com/haymon-ai/dbmcp` |
| Docs domain | `database.haymon.ai` (≥12-month 301 redirect) | `dbmcp.haymon.ai` |
| Docker image | `ghcr.io/haymon-ai/database:0.7.0` | `ghcr.io/haymon-ai/dbmcp:0.8.0` |
| Release tarball/zip | `database-mcp-{target}.{tar.gz,zip}` | `dbmcp-{target}.{tar.gz,zip}` |
| Cargo workspace crates | `database-mcp-{config,server,sql,mysql,postgres,sqlite}` | `dbmcp-{config,server,sql,mysql,postgres,sqlite}` |
| Cargo root crate | `database-mcp` | `dbmcp` |

Pinned `database-mcp-*` crates on crates.io at 0.7.0 stay untouched (no yank, no deprecation release). Existing `database-mcp` installs keep working indefinitely at 0.7.0 but do not auto-upgrade.

### Commits

- `d4d4a77` — `feat!: rename to dbmcp` — atomic foundational commit (68 files): Cargo workspace, Rust module imports, CLI binary name, MCP `serverInfo.name` const, `.mcp.json` dev config, approval snapshots.
- `b5d5c29` — `feat(release): rename user-facing install and release surfaces to dbmcp` (13 files): install scripts, `Dockerfile`, `.github/workflows/release.yml`, `server.json`, docs site pages.
- `0367f8b` — `docs(changelog): add 0.8.0 rename entry; retarget cog.toml` (2 files): CHANGELOG `[v0.8.0]` section with migration table; `cog.toml` pre-bump `sed` regex and `[changelog].repository`.
- `4d31a6c` — `docs: rename to dbmcp in README, CLAUDE.md, and issue templates` (6 files): README, CLAUDE.md, four issue templates.

**Review aid**: no files were renamed (`git mv`). Only contents changed. `git diff --stat master..HEAD` → 89 files, +531/−488.

## Test plan

- [x] `cargo build --workspace` passes.
- [x] `cargo test --workspace --lib --bins` — **166 tests pass, 0 fail**, exact baseline parity.
- [x] `cargo clippy --workspace --tests -- -D warnings` clean.
- [x] `cargo fmt --check` clean.
- [x] `taplo fmt --check` clean.
- [x] Binary sanity: `target/debug/dbmcp --version` → `dbmcp 0.8.0`; `--help` shows `Usage: dbmcp …`.
- [x] Approval snapshots: only `*__server_info.snap` files change (3 files, flipping `"name"` and `"websiteUrl"`); `*__list_tools*.snap` are byte-identical.
- [x] `./tests/run.sh` integration matrix — **402 tests pass** across mariadb_12 (115) / mysql_9 (115) / postgres_18 (106) / sqlite (66) in ~51s.
- [x] Grep sweep for `database[-_]mcp|haymon-ai/database|database.haymon.ai|ai.haymon/database` in live files (excluding `CHANGELOG.md` historical entries and `specs/**`) → **zero hits**.
- [x] Intentional residual: `keywords = [..., "database", ...]` in root `Cargo.toml` kept — topical, not nominal (see `specs/042-rename-to-dbmcp/research.md` R6).

## Operational follow-ups (not in this PR)

After merge, in this order:
1. `cog bump --auto` → tags `v0.8.0`, runs release workflow (builds artifacts, pushes `ghcr.io/haymon-ai/dbmcp:0.8.0`).
2. GitHub Settings → rename `haymon-ai/database` → `haymon-ai/dbmcp` (preserves issues/PRs/stars/releases; 301-redirects).
3. DNS: `dbmcp.haymon.ai` live, `database.haymon.ai` 301 for ≥12 months.
4. `cargo publish -p dbmcp-{config,sql,server,mysql,postgres,sqlite}` (leaves first), then `-p dbmcp`.
5. `mcp-publisher publish` (new `ai.haymon/dbmcp`), then `mcp-publisher status --status deprecated --all-versions --message "Renamed to ai.haymon/dbmcp" ai.haymon/database`.

Details in `specs/042-rename-to-dbmcp/quickstart.md` §C.