### PR TITLE
fix(deps): bump rustls-webpki to 0.103.13 for RUSTSEC-2026-0104

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1859,9 +1859,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-webpki"
-version = "0.103.12"
+version = "0.103.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8279bb85272c9f10811ae6a6c547ff594d6a7f3c6c6b02ee9726d1d0dcfcdd06"
+checksum = "61c429a8649f110dddef65e2a5ad240f747e85f7758a6bccc7e5777bd33f756e"
 dependencies = [
  "ring",
  "rustls-pki-types",


### PR DESCRIPTION
## Summary
- Bumps `rustls-webpki` 0.103.12 → 0.103.13 via `cargo update -p rustls-webpki` to patch [RUSTSEC-2026-0104 / GHSA-82j2-j2ch-gfr8](https://github.com/advisories/GHSA-82j2-j2ch-gfr8).
- The advisory reports a reachable panic in `BorrowedCertRevocationList::from_der` / `OwnedCertRevocationList::from_der` when an `IssuingDistributionPoint` extension contains an empty `BIT STRING` in `onlySomeReasons`. The panic is reachable *before* CRL signature verification.
- Lockfile-only change; no source edits.

Closes #123

## Test plan
- [x] `cargo build`
- [x] `cargo fmt --check`
- [x] `cargo clippy --workspace --tests -- -D warnings`
- [x] `cargo test --workspace --lib --bins`
- [ ] `./tests/run.sh` (Docker integration tests) — please verify in CI