### PR TITLE
feat(list-procedures): search + detailed mode (Postgres, MySQL, MariaDB)

### DIFF
--- a/README.md
+++ b/README.md
@@ -226,14 +226,14 @@ See [Cursor Pagination](https://dbmcp.haymon.ai/docs/features#cursor-pagination)
 
 ### listProcedures
 
-Lists user-defined stored procedures, paginated via `cursor` / `nextCursor`. Available on MySQL/MariaDB and PostgreSQL (`public` schema, PostgreSQL 11+). Not available for SQLite. Parameters: `database`, `cursor`; PostgreSQL additionally accepts `search` and `detailed`.
+Lists user-defined stored procedures, paginated via `cursor` / `nextCursor`. Available on MySQL/MariaDB and PostgreSQL (`public` schema, PostgreSQL 11+). Not available for SQLite. Parameters: `database` (defaults to the active database), `cursor`, `search`, `detailed`.
 
-`search` (PostgreSQL only) is an optional case-insensitive `ILIKE` pattern with `%` and `_` as wildcards. The `search` value must remain identical across paginated calls for cursor continuity.
+`search` is an optional case-insensitive `LIKE`/`ILIKE` pattern with `%` (any sequence) and `_` (single character) as wildcards. The `search` value must remain identical across paginated calls for cursor continuity.
 
-`detailed` (PostgreSQL only, default `false`) switches the response shape:
+`detailed` (default `false`) switches the response shape:
 
-- **Brief** (default) — `procedures` is a sorted JSON array of bare procedure-name strings. Overloaded procedures appear once per overload (duplicate name strings are expected).
-- **Detailed** (`detailed: true`) — `procedures` is a JSON object keyed by procedure signature `name(arguments)` (overloads disambiguate; zero-arg procedures key as `name()`). Each value carries `schema`, `name`, `language`, `arguments`, `security`, `owner`, `description`, and `definition`. Detailed mode deliberately omits the `listFunctions`-only fields `returnType`, `volatility`, `strict`, and `parallelSafety` — they are not meaningful for procedures. See the [`listProcedures` reference](https://dbmcp.haymon.ai/docs/features#listprocedures) for the full field list.
+- **Brief** (default) — `procedures` is a sorted JSON array of bare procedure-name strings. PostgreSQL overloads appear once per overload (duplicate name strings are expected).
+- **Detailed** (`detailed: true`) — `procedures` is a JSON object keyed by procedure signature; each value carries the per-backend metadata payload (language, arguments, security, definition, and backend-specific extras such as PostgreSQL `owner` or MySQL/MariaDB `deterministic`/`sqlDataAccess`/session-context fields). PostgreSQL keys are `name(arguments)` (overloads disambiguate; zero-arg procedures key as `name()`); MySQL/MariaDB keys are bare names (no overloading). See the [`listProcedures` reference](https://dbmcp.haymon.ai/docs/features#listprocedures) for the full per-backend field list.
 
 See [Cursor Pagination](https://dbmcp.haymon.ai/docs/features#cursor-pagination) for iteration details.
 

--- a/README.md
+++ b/README.md
@@ -226,7 +226,16 @@ See [Cursor Pagination](https://dbmcp.haymon.ai/docs/features#cursor-pagination)
 
 ### listProcedures
 
-Lists user-defined stored procedures, paginated via `cursor` / `nextCursor`. Available on MySQL/MariaDB and PostgreSQL (`public` schema, PostgreSQL 11+). Not available for SQLite. Parameters: `database`, `cursor`. See [Cursor Pagination](https://dbmcp.haymon.ai/docs/features#cursor-pagination) for iteration details.
+Lists user-defined stored procedures, paginated via `cursor` / `nextCursor`. Available on MySQL/MariaDB and PostgreSQL (`public` schema, PostgreSQL 11+). Not available for SQLite. Parameters: `database`, `cursor`; PostgreSQL additionally accepts `search` and `detailed`.
+
+`search` (PostgreSQL only) is an optional case-insensitive `ILIKE` pattern with `%` and `_` as wildcards. The `search` value must remain identical across paginated calls for cursor continuity.
+
+`detailed` (PostgreSQL only, default `false`) switches the response shape:
+
+- **Brief** (default) — `procedures` is a sorted JSON array of bare procedure-name strings. Overloaded procedures appear once per overload (duplicate name strings are expected).
+- **Detailed** (`detailed: true`) — `procedures` is a JSON object keyed by procedure signature `name(arguments)` (overloads disambiguate; zero-arg procedures key as `name()`). Each value carries `schema`, `name`, `language`, `arguments`, `security`, `owner`, `description`, and `definition`. Detailed mode deliberately omits the `listFunctions`-only fields `returnType`, `volatility`, `strict`, and `parallelSafety` — they are not meaningful for procedures. See the [`listProcedures` reference](https://dbmcp.haymon.ai/docs/features#listprocedures) for the full field list.
+
+See [Cursor Pagination](https://dbmcp.haymon.ai/docs/features#cursor-pagination) for iteration details.
 
 ### listMaterializedViews
 

--- a/crates/mysql/src/tools/list_procedures.rs
+++ b/crates/mysql/src/tools/list_procedures.rs
@@ -3,13 +3,13 @@
 use std::borrow::Cow;
 
 use dbmcp_server::pagination::Pager;
-use dbmcp_server::types::{ListProceduresRequest, ListProceduresResponse};
 use dbmcp_sql::Connection as _;
-use dbmcp_sql::sanitize::{quote_literal, validate_ident};
+use dbmcp_sql::sanitize::validate_ident;
 use rmcp::handler::server::router::tool::{AsyncTool, ToolBase};
 use rmcp::model::{ErrorData, ToolAnnotations};
 
 use crate::MysqlHandler;
+use crate::types::{ListProceduresRequest, ListProceduresResponse};
 
 /// Marker type for the `listProcedures` MCP tool.
 pub(crate) struct ListProceduresTool;
@@ -17,27 +17,37 @@ pub(crate) struct ListProceduresTool;
 impl ListProceduresTool {
     const NAME: &'static str = "listProcedures";
     const TITLE: &'static str = "List Procedures";
-    const DESCRIPTION: &'static str = r#"List all stored procedures in a specific database.
+    const DESCRIPTION: &'static str = r#"List user-defined stored procedures in a database, optionally filtered and/or with full metadata. Stored functions and loadable UDFs (`mysql.func`) are excluded.
 
 <usecase>
 Use when:
-- Exploring a database's stored logic
-- Verifying a procedure exists before calling it
-- The user asks what procedures are defined
+- Auditing stored procedures across a database (brief mode, default).
+- Searching for a procedure by partial name (pass `search`).
+- Inspecting a procedure's language, parameter list (with `IN`/`OUT`/`INOUT` modes), determinism, SQL-data-access classification, security mode, definer, comment, session context, and full reconstructed `CREATE PROCEDURE` text before reasoning about correctness or invocation safety (pass `detailed: true`). Detailed mode supersedes ad-hoc `readQuery` against `information_schema.ROUTINES` / `information_schema.PARAMETERS`.
 </usecase>
+
+<parameters>
+- `database` — Database to target. Defaults to the active database.
+- `cursor` — Opaque pagination cursor; echo the prior response's `nextCursor`.
+- `search` — Case-insensitive filter on procedure names via `LIKE`. `%` matches any sequence; `_` matches a single character.
+- `detailed` — When `true`, returns full metadata objects keyed by procedure name instead of bare name strings. Default `false`.
+</parameters>
 
 <examples>
 ✓ "What procedures are in the mydb database?" → listProcedures(database="mydb")
-✓ "Does an archive_user procedure exist?" → listProcedures to check
+✓ "Find the order archival routine" → listProcedures(search="archive")
+✓ "What does archive_order do?" → listProcedures(search="archive_order", detailed=true)
 ✗ "List functions" → use listFunctions instead
+✗ "List loadable UDFs from mysql.func" → not supported; only routines in information_schema.ROUTINES are returned
 </examples>
 
 <what_it_returns>
-A sorted JSON array of procedure name strings.
+Brief mode (default): a sorted JSON array of procedure-name strings, e.g. `["archive_order", "archive_order_history", "purge_order_archive", "touch_post"]`.
+Detailed mode: a JSON object keyed by bare procedure name (MySQL/MariaDB do not allow procedure overloading, so no signature suffix is needed); each value carries `schema`, `language` (typically `"SQL"`; MariaDB external-language procedures report the external language name), `arguments` (comma-separated `MODE name type` triples from `information_schema.PARAMETERS` — `MODE` is one of `IN`, `OUT`, `INOUT`; empty string for zero-parameter procedures), `deterministic` (boolean), `sqlDataAccess` (one of `CONTAINS_SQL`, `NO_SQL`, `READS_SQL_DATA`, `MODIFIES_SQL_DATA`), `security` (`INVOKER` or `DEFINER`), `definer` (`user@host`), `description` (the `COMMENT` text or `null` when no comment was set — the empty string MySQL stores is coerced to JSON `null`), `definition` (the canonical reconstructed `CREATE PROCEDURE` text including `DEFINER=` in `` `user`@`host` `` form; no `RETURNS` clause — procedures have no return type), `sqlMode`, `characterSetClient`, `collationConnection`, and `databaseCollation`. Versus the Postgres `listProcedures` detailed payload: `volatility`, `parallelSafety`, `strict`, and `returnType` are intentionally absent (no MySQL/MariaDB analogues for the first three; procedures have no return type for the fourth — the Postgres-side payload also omits all four), `owner` is renamed to `definer` (more accurate for the MySQL `DEFINER` concept), keys are bare names rather than `name(arguments)` (no overloads possible), the four session-context fields (`sqlMode`, `characterSetClient`, `collationConnection`, `databaseCollation`) are MySQL/MariaDB-only additions, and `deterministic` plus `sqlDataAccess` are MySQL/MariaDB-only additions versus the Postgres `listProcedures` detailed payload (which omits both because Postgres procedures have no equivalent attributes).
 </what_it_returns>
 
 <pagination>
-Paginated. Pass the prior response's `nextCursor` as `cursor` to fetch the next page.
+Paginated. Pass the prior response's `nextCursor` as `cursor` to fetch the next page. The `search` filter must stay the same across pages for cursor continuity.
 </pagination>"#;
 }
 
@@ -75,8 +85,125 @@ impl AsyncTool<MysqlHandler> for ListProceduresTool {
     }
 }
 
+/// Brief-mode SQL: name-only column with optional case-insensitive `LIKE` filter.
+///
+/// `CAST(ROUTINE_NAME AS CHAR)` forces a `VARCHAR` decode — `MySQL` 9 reports
+/// `information_schema` text columns as `VARBINARY`. `LOWER(...)` on both sides
+/// of the `LIKE` makes the match case-insensitive regardless of column collation.
+const BRIEF_SQL: &str = r"
+    SELECT CAST(ROUTINE_NAME AS CHAR)
+    FROM information_schema.ROUTINES
+    WHERE ROUTINE_SCHEMA = ?
+      AND ROUTINE_TYPE   = 'PROCEDURE'
+      AND (? IS NULL OR LOWER(ROUTINE_NAME) LIKE LOWER(CONCAT('%', ?, '%')))
+    ORDER BY ROUTINE_NAME
+    LIMIT ? OFFSET ?";
+
+/// Detailed-mode SQL — single SELECT against `information_schema.ROUTINES`.
+///
+/// `JSON_OBJECT(...)` projects thirteen fields per row. The parameter list is
+/// assembled by a correlated subquery against `information_schema.PARAMETERS`
+/// filtered to the row's `(SPECIFIC_SCHEMA, SPECIFIC_NAME)` and to
+/// `ROUTINE_TYPE='PROCEDURE'`. Procedures (unlike functions) have no synthetic
+/// RETURN row at ordinal 0, so no `ORDINAL_POSITION > 0` filter is needed —
+/// every parameter row is real. Each parameter token is rendered as
+/// `MODE name type`, where `MODE` is one of `IN`, `OUT`, `INOUT` and is taken
+/// verbatim from `PARAMETER_MODE`.
+///
+/// The reconstructed `definition` produces the canonical `CREATE PROCEDURE`
+/// text. The five comma-separated `CONCAT` chunks at the top of the
+/// `definition` rebuild the canonical `DEFINER=` `` `<user>`@`<host>` `` opener
+/// inline; the user portion may itself contain `@` (e.g.
+/// `'foo@bar'@'localhost'`), so the host segment is taken after the **last**
+/// `@` (`SUBSTRING_INDEX(..., '@', -1)`) and the user is everything before it
+/// (`LEFT(..., LENGTH - host_len - 1)`), with embedded backticks doubled in
+/// both components. Parameter names in the argument list are backtick-quoted
+/// with embedded backticks doubled. There is NO `RETURNS <type>` clause —
+/// procedures have no return type. `SQL_DATA_ACCESS` is stored with spaces
+/// (`'READS SQL DATA'` etc.); the embedded DDL emits the column directly while
+/// the structured `sqlDataAccess` field substitutes underscores for
+/// programmatic comparison. `QUOTE(...)` on `ROUTINE_COMMENT` produces a
+/// properly escaped single-quoted SQL string literal (handles embedded `'` and
+/// `\`). The `''` → `null` coercion on `description` mirrors the
+/// Postgres detailed-payload contract.
+///
+/// `LIMIT` pushes down before the JSON projection and the correlated
+/// subqueries, so per-page work scales with `page_size + 1` rows regardless
+/// of how many procedures the schema holds in total.
+const DETAILED_SQL: &str = r"
+    SELECT
+        CAST(r.ROUTINE_NAME AS CHAR) AS name,
+        JSON_OBJECT(
+            'schema',              CAST(r.ROUTINE_SCHEMA AS CHAR),
+            'language',            CAST(COALESCE(NULLIF(r.EXTERNAL_LANGUAGE, ''), r.ROUTINE_BODY) AS CHAR),
+            'arguments',           COALESCE((
+                SELECT GROUP_CONCAT(
+                    CONCAT(
+                        CAST(p.PARAMETER_MODE AS CHAR), ' ',
+                        CAST(p.PARAMETER_NAME AS CHAR), ' ',
+                        CAST(p.DTD_IDENTIFIER  AS CHAR)
+                    )
+                    ORDER BY p.ORDINAL_POSITION ASC
+                    SEPARATOR ', '
+                )
+                FROM information_schema.PARAMETERS p
+                WHERE p.SPECIFIC_SCHEMA = r.ROUTINE_SCHEMA
+                  AND p.SPECIFIC_NAME   = r.ROUTINE_NAME
+                  AND p.ROUTINE_TYPE    = 'PROCEDURE'
+            ), ''),
+            'deterministic',       (r.IS_DETERMINISTIC = 'YES'),
+            'sqlDataAccess',       CAST(REPLACE(r.SQL_DATA_ACCESS, ' ', '_') AS CHAR),
+            'security',            CAST(r.SECURITY_TYPE AS CHAR),
+            'definer',             CAST(r.DEFINER AS CHAR),
+            'description',         CASE WHEN r.ROUTINE_COMMENT IS NULL OR r.ROUTINE_COMMENT = ''
+                                        THEN NULL ELSE CAST(r.ROUTINE_COMMENT AS CHAR) END,
+            'definition',          CONCAT(
+                'CREATE DEFINER=`',
+                REPLACE(LEFT(r.DEFINER, LENGTH(r.DEFINER) - LENGTH(SUBSTRING_INDEX(r.DEFINER, '@', -1)) - 1), '`', '``'),
+                '`@`',
+                REPLACE(SUBSTRING_INDEX(r.DEFINER, '@', -1), '`', '``'),
+                '`',
+                ' PROCEDURE ',
+                '`', REPLACE(r.ROUTINE_NAME, '`', '``'), '`',
+                '(',
+                COALESCE((
+                    SELECT GROUP_CONCAT(
+                        CONCAT(
+                            CAST(p.PARAMETER_MODE AS CHAR), ' ',
+                            '`', REPLACE(p.PARAMETER_NAME, '`', '``'), '` ',
+                            CAST(p.DTD_IDENTIFIER AS CHAR)
+                        )
+                        ORDER BY p.ORDINAL_POSITION ASC
+                        SEPARATOR ', '
+                    )
+                    FROM information_schema.PARAMETERS p
+                    WHERE p.SPECIFIC_SCHEMA = r.ROUTINE_SCHEMA
+                      AND p.SPECIFIC_NAME   = r.ROUTINE_NAME
+                      AND p.ROUTINE_TYPE    = 'PROCEDURE'
+                ), ''),
+                ')',
+                CASE WHEN r.IS_DETERMINISTIC = 'YES' THEN ' DETERMINISTIC' ELSE ' NOT DETERMINISTIC' END,
+                ' ', CAST(r.SQL_DATA_ACCESS AS CHAR),
+                ' SQL SECURITY ', CAST(r.SECURITY_TYPE AS CHAR),
+                CASE WHEN r.ROUTINE_COMMENT IS NULL OR r.ROUTINE_COMMENT = '' THEN ''
+                     ELSE CONCAT(' COMMENT ', QUOTE(r.ROUTINE_COMMENT)) END,
+                ' ',
+                CAST(r.ROUTINE_DEFINITION AS CHAR)
+            ),
+            'sqlMode',             CAST(r.SQL_MODE                AS CHAR),
+            'characterSetClient',  CAST(r.CHARACTER_SET_CLIENT    AS CHAR),
+            'collationConnection', CAST(r.COLLATION_CONNECTION    AS CHAR),
+            'databaseCollation',   CAST(r.DATABASE_COLLATION      AS CHAR)
+        ) AS entry
+    FROM information_schema.ROUTINES r
+    WHERE r.ROUTINE_SCHEMA = ?
+      AND r.ROUTINE_TYPE   = 'PROCEDURE'
+      AND (? IS NULL OR LOWER(r.ROUTINE_NAME) LIKE LOWER(CONCAT('%', ?, '%')))
+    ORDER BY r.ROUTINE_NAME
+    LIMIT ? OFFSET ?";
+
 impl MysqlHandler {
-    /// Lists one page of stored procedures in a database.
+    /// Lists one page of stored procedures, optionally filtered and/or detailed.
     ///
     /// # Errors
     ///
@@ -85,32 +212,57 @@ impl MysqlHandler {
     /// or the underlying query fails.
     pub async fn list_procedures(
         &self,
-        ListProceduresRequest { database, cursor }: ListProceduresRequest,
+        ListProceduresRequest {
+            database,
+            cursor,
+            search,
+            detailed,
+        }: ListProceduresRequest,
     ) -> Result<ListProceduresResponse, ErrorData> {
-        let database = database
-            .as_deref()
-            .map(str::trim)
-            .filter(|s| !s.is_empty())
-            .map_or_else(|| self.connection.default_database_name().to_owned(), str::to_owned);
+        let database = validate_ident(
+            database
+                .as_deref()
+                .map(str::trim)
+                .filter(|s| !s.is_empty())
+                .unwrap_or_else(|| self.connection.default_database_name()),
+        )?;
 
-        validate_ident(&database)?;
-
+        let pattern = search.as_deref().map(str::trim).filter(|s| !s.is_empty());
         let pager = Pager::new(cursor, self.config.page_size);
-        let query = format!(
-            r"
-            SELECT CAST(ROUTINE_NAME AS CHAR)
-            FROM information_schema.ROUTINES
-            WHERE ROUTINE_SCHEMA = {} AND ROUTINE_TYPE = 'PROCEDURE'
-            ORDER BY ROUTINE_NAME
-            LIMIT {} OFFSET {}",
-            quote_literal(&database),
-            pager.limit(),
-            pager.offset(),
-        );
 
-        let rows: Vec<String> = self.connection.fetch_scalar(query.as_str(), None).await?;
+        if detailed {
+            let rows: Vec<(String, sqlx::types::Json<serde_json::Value>)> = self
+                .connection
+                .fetch(
+                    sqlx::query(DETAILED_SQL)
+                        .bind(database)
+                        .bind(pattern)
+                        .bind(pattern)
+                        .bind(pager.limit())
+                        .bind(pager.offset()),
+                    None,
+                )
+                .await?;
+            let (rows, next_cursor) = pager.paginate(rows);
+            return Ok(ListProceduresResponse::detailed(
+                rows.into_iter().map(|(name, json)| (name, json.0)).collect(),
+                next_cursor,
+            ));
+        }
+
+        let rows: Vec<String> = self
+            .connection
+            .fetch_scalar(
+                sqlx::query(BRIEF_SQL)
+                    .bind(database)
+                    .bind(pattern)
+                    .bind(pattern)
+                    .bind(pager.limit())
+                    .bind(pager.offset()),
+                None,
+            )
+            .await?;
         let (procedures, next_cursor) = pager.paginate(rows);
-
         Ok(ListProceduresResponse::brief(procedures, next_cursor))
     }
 }

--- a/crates/mysql/src/tools/list_procedures.rs
+++ b/crates/mysql/src/tools/list_procedures.rs
@@ -111,9 +111,6 @@ impl MysqlHandler {
         let rows: Vec<String> = self.connection.fetch_scalar(query.as_str(), None).await?;
         let (procedures, next_cursor) = pager.paginate(rows);
 
-        Ok(ListProceduresResponse {
-            procedures,
-            next_cursor,
-        })
+        Ok(ListProceduresResponse::brief(procedures, next_cursor))
     }
 }

--- a/crates/mysql/src/types.rs
+++ b/crates/mysql/src/types.rs
@@ -8,7 +8,7 @@ use dbmcp_server::pagination::Cursor;
 use schemars::JsonSchema;
 use serde::Deserialize;
 
-pub use dbmcp_server::types::{ListEntries, ListFunctionsResponse, ListTablesResponse};
+pub use dbmcp_server::types::{ListEntries, ListFunctionsResponse, ListProceduresResponse, ListTablesResponse};
 
 /// Request for the `dropTable` tool.
 #[derive(Debug, Default, Deserialize, JsonSchema)]
@@ -65,9 +65,32 @@ pub struct ListFunctionsRequest {
     pub detailed: bool,
 }
 
+/// Request for the MySQL/MariaDB `listProcedures` tool — supports search + detailed mode.
+#[derive(Debug, Default, Deserialize, JsonSchema)]
+#[serde(rename_all = "camelCase")]
+pub struct ListProceduresRequest {
+    /// Database to list procedures from. Defaults to the active database.
+    #[serde(default)]
+    pub database: Option<String>,
+    /// Opaque cursor from a prior response's `nextCursor`; omit for the first page.
+    #[serde(default)]
+    pub cursor: Option<Cursor>,
+    /// Optional case-insensitive filter on procedure names. The input is used within a `LIKE`
+    /// clause: `%` matches any sequence of characters and `_` matches any single character.
+    #[serde(default)]
+    pub search: Option<String>,
+    /// When `true`, each returned entry is a full metadata object (schema, language,
+    /// arguments with IN/OUT/INOUT mode tokens, deterministic, sqlDataAccess, security,
+    /// definer, description, definition, sqlMode, characterSetClient,
+    /// collationConnection, databaseCollation); when `false` or omitted, each entry
+    /// is the bare procedure-name string.
+    #[serde(default)]
+    pub detailed: bool,
+}
+
 #[cfg(test)]
 mod tests {
-    use super::{ListFunctionsRequest, ListTablesRequest};
+    use super::{ListFunctionsRequest, ListProceduresRequest, ListTablesRequest};
 
     #[test]
     fn list_tables_request_defaults_to_brief_mode_without_search() {
@@ -95,6 +118,21 @@ mod tests {
         let req: ListFunctionsRequest =
             serde_json::from_str(r#"{"search": "order", "detailed": true}"#).expect("parse");
         assert_eq!(req.search.as_deref(), Some("order"));
+        assert!(req.detailed);
+    }
+
+    #[test]
+    fn list_procedures_request_defaults_to_brief_mode_without_search() {
+        let req: ListProceduresRequest = serde_json::from_str("{}").expect("empty object should parse");
+        assert!(req.search.is_none());
+        assert!(!req.detailed, "detailed must default to false");
+    }
+
+    #[test]
+    fn list_procedures_request_accepts_search_and_detailed() {
+        let req: ListProceduresRequest =
+            serde_json::from_str(r#"{"search": "archive", "detailed": true}"#).expect("parse");
+        assert_eq!(req.search.as_deref(), Some("archive"));
         assert!(req.detailed);
     }
 }

--- a/crates/postgres/src/tools/list_procedures.rs
+++ b/crates/postgres/src/tools/list_procedures.rs
@@ -3,13 +3,12 @@
 use std::borrow::Cow;
 
 use dbmcp_server::pagination::Pager;
-use dbmcp_server::types::{ListProceduresRequest, ListProceduresResponse};
 use dbmcp_sql::Connection as _;
-use dbmcp_sql::sanitize::validate_ident;
 use rmcp::handler::server::router::tool::{AsyncTool, ToolBase};
 use rmcp::model::{ErrorData, ToolAnnotations};
 
 use crate::PostgresHandler;
+use crate::types::{ListProceduresRequest, ListProceduresResponse};
 
 /// Marker type for the `listProcedures` MCP tool.
 pub(crate) struct ListProceduresTool;
@@ -17,27 +16,39 @@ pub(crate) struct ListProceduresTool;
 impl ListProceduresTool {
     const NAME: &'static str = "listProcedures";
     const TITLE: &'static str = "List Procedures";
-    const DESCRIPTION: &'static str = r#"List all user-defined procedures in the `public` schema of a database (PostgreSQL 11+).
+    const DESCRIPTION: &'static str = r#"List user-defined procedures in the `public` schema, optionally filtered and/or with full metadata. Functions, aggregates, and window functions are excluded.
 
 <usecase>
 Use when:
-- Exploring a database's stored logic
-- Verifying a procedure exists before calling it
-- The user asks what procedures are defined
+- Auditing procedures across a database (brief mode, default).
+- Searching for a procedure by partial name (pass `search`).
+- Inspecting a procedure's language, signature, security mode, owner, comment, and full `CREATE PROCEDURE` text before reasoning about correctness or invocation safety (pass `detailed: true`). Detailed mode supersedes ad-hoc `readQuery` against `pg_proc` / `information_schema.routines`.
 </usecase>
 
+<parameters>
+- `database` — Database to target. Defaults to the active database.
+- `cursor` — Opaque pagination cursor; echo the prior response's `nextCursor`.
+- `search` — Case-insensitive filter on procedure names via `ILIKE`. `%` matches any sequence; `_` matches a single character.
+- `detailed` — When `true`, returns full metadata objects keyed by `name(arguments)` instead of bare name strings. Default `false`.
+</parameters>
+
 <examples>
-✓ "What procedures are in the mydb database?" → listProcedures(database="mydb")
-✓ "Does an archive_user procedure exist?" → listProcedures to check
+✓ "What procedures are in mydb?" → listProcedures(database="mydb")
+✓ "Find the order archival routine" → listProcedures(search="archive")
+✓ "What does archive_order do?" → listProcedures(search="archive_order", detailed=true)
 ✗ "List functions" → use listFunctions instead
+✗ "List aggregates" → not supported; aggregates are excluded
 </examples>
 
 <what_it_returns>
-A sorted JSON array of procedure name strings.
+Brief mode (default): a sorted JSON array of procedure-name strings, e.g. `["archive_order", "archive_order_history", "archive_order_history"]`. Overloaded procedures appear as one entry per overload (duplicate name strings allowed).
+Detailed mode: a JSON object keyed by procedure signature `name(arguments)`; each value carries `schema`, `name`, `language`, `arguments`, `security` (INVOKER/DEFINER), `owner`, `description` (or null when no `COMMENT ON PROCEDURE`), and `definition` (the full `CREATE OR REPLACE PROCEDURE` text). Overloads occupy distinct keys (e.g. `archive_order_history(integer)` vs `archive_order_history(integer, boolean)`). Zero-arg procedures key as `name()` — the parens are always present so the key shape stays uniform.
+
+Detailed mode deliberately omits the `listFunctions`-only fields `returnType`, `volatility`, `strict`, and `parallelSafety`: procedures don't return a value, `pg_proc.provolatile` / `proisstrict` are not user-settable for procedures, and `proparallel` carries no procedure-level guarantee in PostgreSQL.
 </what_it_returns>
 
 <pagination>
-Paginated. Pass the prior response's `nextCursor` as `cursor` to fetch the next page.
+Paginated. Pass the prior response's `nextCursor` as `cursor` to fetch the next page. The `search` filter must stay the same across pages for cursor continuity. Brief and detailed modes share the same `(proname, oid)` row order, so a client can switch `detailed` between pages without losing position.
 </pagination>"#;
 }
 
@@ -75,8 +86,64 @@ impl AsyncTool<PostgresHandler> for ListProceduresTool {
     }
 }
 
+/// Brief-mode SQL: `pg_proc` scan with `ILIKE` filter on procedure name.
+///
+/// `n.nspname = 'public'` plus `p.prokind = 'p'` keep functions / aggregates /
+/// window functions out of the result. The `($1::text IS NULL OR ...)` trinary
+/// lets one statement cover both filtered and unfiltered cases. `(p.proname,
+/// p.oid)` is the sort key — `oid` is the unique tiebreaker across overloaded
+/// names so `OFFSET` pagination is deterministic.
+const BRIEF_SQL: &str = r"
+    SELECT p.proname
+    FROM pg_proc p
+    JOIN pg_namespace n ON n.oid = p.pronamespace
+    WHERE n.nspname = 'public'
+      AND p.prokind = 'p'
+      AND ($1::text IS NULL OR p.proname ILIKE '%' || $1 || '%')
+    ORDER BY p.proname, p.oid
+    LIMIT $2 OFFSET $3";
+
+/// Detailed-mode SQL: per-procedure `json_build_object` projection.
+///
+/// `n.nspname = 'public'` and `p.prokind = 'p'` filter to user-defined
+/// procedures in the `public` schema. Three small lookup joins (`pg_namespace`,
+/// `pg_language`, `pg_roles`) supply the language and owner names. Postgres
+/// defers SELECT-list evaluation past `LIMIT`, so the expensive `pg_get_*`
+/// projections (`pg_get_functiondef`, `pg_get_function_arguments`) and
+/// `obj_description` only run for the page's rows — never the full schema.
+///
+/// A `CROSS JOIN LATERAL` materialises `pg_get_function_arguments(p.oid)` into
+/// `args.text` so it is computed once per row and reused both in the keyed
+/// signature `name(args)` and in the JSON `arguments` field — no double-call.
+///
+/// `prosecdef` is a boolean. Procedure-only fields (`returnType`, `volatility`,
+/// `strict`, `parallelSafety`) are deliberately absent — see DESCRIPTION above.
+const DETAILED_SQL: &str = r"
+    SELECT
+        p.proname || '(' || args.text || ')' AS name,
+        json_build_object(
+            'schema',      'public',
+            'name',        p.proname,
+            'language',    l.lanname,
+            'arguments',   args.text,
+            'security',    CASE WHEN p.prosecdef THEN 'DEFINER' ELSE 'INVOKER' END,
+            'owner',       r.rolname,
+            'description', pg_catalog.obj_description(p.oid, 'pg_proc'),
+            'definition',  pg_get_functiondef(p.oid)
+        ) AS entry
+    FROM pg_proc p
+    JOIN pg_namespace n ON n.oid = p.pronamespace
+    JOIN pg_language  l ON l.oid = p.prolang
+    JOIN pg_roles     r ON r.oid = p.proowner
+    CROSS JOIN LATERAL (SELECT pg_get_function_arguments(p.oid) AS text) args
+    WHERE n.nspname = 'public'
+      AND p.prokind = 'p'
+      AND ($1::text IS NULL OR p.proname ILIKE '%' || $1 || '%')
+    ORDER BY p.proname, p.oid
+    LIMIT $2 OFFSET $3";
+
 impl PostgresHandler {
-    /// Lists one page of user-defined procedures in the `public` schema.
+    /// Lists one page of user-defined procedures, optionally filtered and/or detailed.
     ///
     /// # Errors
     ///
@@ -85,34 +152,46 @@ impl PostgresHandler {
     /// or the underlying query fails.
     pub async fn list_procedures(
         &self,
-        ListProceduresRequest { database, cursor }: ListProceduresRequest,
+        ListProceduresRequest {
+            database,
+            cursor,
+            search,
+            detailed,
+        }: ListProceduresRequest,
     ) -> Result<ListProceduresResponse, ErrorData> {
-        let database = database
-            .as_deref()
-            .map(str::trim)
-            .filter(|s| !s.is_empty())
-            .map(validate_ident)
-            .transpose()?;
-
+        let database = database.as_deref().map(str::trim).filter(|s| !s.is_empty());
+        let pattern = search.as_deref().map(str::trim).filter(|s| !s.is_empty());
         let pager = Pager::new(cursor, self.config.page_size);
-        let query = format!(
-            r"
-            SELECT p.proname
-            FROM pg_proc p
-            JOIN pg_namespace n ON p.pronamespace = n.oid
-            WHERE n.nspname = 'public' AND p.prokind = 'p'
-            ORDER BY p.proname
-            LIMIT {} OFFSET {}",
-            pager.limit(),
-            pager.offset(),
-        );
 
-        let rows: Vec<String> = self.connection.fetch_scalar(query.as_str(), database).await?;
+        if detailed {
+            let rows: Vec<(String, sqlx::types::Json<serde_json::Value>)> = self
+                .connection
+                .fetch(
+                    sqlx::query(DETAILED_SQL)
+                        .bind(pattern)
+                        .bind(pager.limit())
+                        .bind(pager.offset()),
+                    database,
+                )
+                .await?;
+            let (rows, next_cursor) = pager.paginate(rows);
+            return Ok(ListProceduresResponse::detailed(
+                rows.into_iter().map(|(key, json)| (key, json.0)).collect(),
+                next_cursor,
+            ));
+        }
+
+        let rows: Vec<String> = self
+            .connection
+            .fetch_scalar(
+                sqlx::query(BRIEF_SQL)
+                    .bind(pattern)
+                    .bind(pager.limit())
+                    .bind(pager.offset()),
+                database,
+            )
+            .await?;
         let (procedures, next_cursor) = pager.paginate(rows);
-
-        Ok(ListProceduresResponse {
-            procedures,
-            next_cursor,
-        })
+        Ok(ListProceduresResponse::brief(procedures, next_cursor))
     }
 }

--- a/crates/postgres/src/types.rs
+++ b/crates/postgres/src/types.rs
@@ -10,7 +10,8 @@ use schemars::JsonSchema;
 use serde::Deserialize;
 
 pub use dbmcp_server::types::{
-    ListEntries, ListFunctionsResponse, ListTablesResponse, ListTriggersRequest, ListTriggersResponse,
+    ListEntries, ListFunctionsResponse, ListProceduresResponse, ListTablesResponse, ListTriggersRequest,
+    ListTriggersResponse,
 };
 
 /// Request for the `dropTable` tool.
@@ -70,9 +71,30 @@ pub struct ListFunctionsRequest {
     pub detailed: bool,
 }
 
+/// Request for the Postgres `listProcedures` tool — extends the shared shape with `search` and `detailed`.
+#[derive(Debug, Default, Deserialize, JsonSchema)]
+#[serde(rename_all = "camelCase")]
+pub struct ListProceduresRequest {
+    /// Database to list procedures from. Defaults to the active database.
+    #[serde(default)]
+    pub database: Option<String>,
+    /// Opaque cursor from a prior response's `nextCursor`; omit for the first page.
+    #[serde(default)]
+    pub cursor: Option<Cursor>,
+    /// Optional case-insensitive filter on procedure names. The input is used within an `ILIKE`
+    /// clause: `%` matches any sequence of characters and `_` matches any single character.
+    #[serde(default)]
+    pub search: Option<String>,
+    /// When `true`, each returned entry is a full metadata object (schema, name,
+    /// language, arguments, security, owner, description, definition); when `false`
+    /// or omitted, each entry is the bare procedure-name string.
+    #[serde(default)]
+    pub detailed: bool,
+}
+
 #[cfg(test)]
 mod tests {
-    use super::{ListFunctionsRequest, ListTablesRequest};
+    use super::{ListFunctionsRequest, ListProceduresRequest, ListTablesRequest};
 
     #[test]
     fn list_tables_request_defaults_to_brief_mode_without_search() {
@@ -100,6 +122,21 @@ mod tests {
         let req: ListFunctionsRequest =
             serde_json::from_str(r#"{"search": "order", "detailed": true}"#).expect("parse");
         assert_eq!(req.search.as_deref(), Some("order"));
+        assert!(req.detailed);
+    }
+
+    #[test]
+    fn list_procedures_request_defaults_to_brief_mode_without_search() {
+        let req: ListProceduresRequest = serde_json::from_str("{}").expect("empty object should parse");
+        assert!(req.search.is_none());
+        assert!(!req.detailed, "detailed must default to false");
+    }
+
+    #[test]
+    fn list_procedures_request_accepts_search_and_detailed() {
+        let req: ListProceduresRequest =
+            serde_json::from_str(r#"{"search": "archive", "detailed": true}"#).expect("parse");
+        assert_eq!(req.search.as_deref(), Some("archive"));
         assert!(req.detailed);
     }
 }

--- a/crates/server/src/types.rs
+++ b/crates/server/src/types.rs
@@ -251,18 +251,6 @@ impl ListFunctionsResponse {
     }
 }
 
-/// Request for the `listProcedures` tool.
-#[derive(Debug, Default, Deserialize, JsonSchema)]
-#[serde(rename_all = "camelCase")]
-pub struct ListProceduresRequest {
-    /// Database to list procedures from. Defaults to the active database.
-    #[serde(default)]
-    pub database: Option<String>,
-    /// Opaque cursor from a prior response's `nextCursor`; omit for the first page.
-    #[serde(default)]
-    pub cursor: Option<Cursor>,
-}
-
 /// Response for the `listProcedures` tool.
 #[derive(Debug, Serialize, JsonSchema)]
 #[serde(rename_all = "camelCase")]

--- a/crates/server/src/types.rs
+++ b/crates/server/src/types.rs
@@ -267,11 +267,31 @@ pub struct ListProceduresRequest {
 #[derive(Debug, Serialize, JsonSchema)]
 #[serde(rename_all = "camelCase")]
 pub struct ListProceduresResponse {
-    /// Sorted list of procedure names for this page.
-    pub procedures: Vec<String>,
+    /// Page of matching procedures. Shape depends on the request's `detailed` flag.
+    pub procedures: ListEntries,
     /// Opaque cursor pointing to the next page. Absent when this is the final page.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub next_cursor: Option<Cursor>,
+}
+
+impl ListProceduresResponse {
+    /// Builds a brief-mode response from a page of bare procedure names.
+    #[must_use]
+    pub fn brief(procedures: Vec<String>, next_cursor: Option<Cursor>) -> Self {
+        Self {
+            procedures: ListEntries::Brief(procedures),
+            next_cursor,
+        }
+    }
+
+    /// Builds a detailed-mode response from a page of signature → metadata entries.
+    #[must_use]
+    pub fn detailed(procedures: IndexMap<String, Value>, next_cursor: Option<Cursor>) -> Self {
+        Self {
+            procedures: ListEntries::Detailed(procedures),
+            next_cursor,
+        }
+    }
 }
 
 /// Request for the `listMaterializedViews` tool.
@@ -507,6 +527,29 @@ mod tests {
         assert_eq!(
             serde_json::to_value(&response).unwrap(),
             json!({"functions": ["audit_user_login"]})
+        );
+    }
+
+    #[test]
+    fn list_procedures_response_brief_constructor_wraps_vec() {
+        let response = super::ListProceduresResponse::brief(vec!["archive_order".into()], None);
+        assert!(matches!(response.procedures, ListEntries::Brief(ref v) if v == &["archive_order"]));
+        assert!(response.next_cursor.is_none());
+    }
+
+    #[test]
+    fn list_procedures_response_detailed_constructor_wraps_indexmap() {
+        let map = IndexMap::from([("archive_order(integer)".into(), json!({"language": "plpgsql"}))]);
+        let response = super::ListProceduresResponse::detailed(map, None);
+        assert!(matches!(response.procedures, ListEntries::Detailed(_)));
+    }
+
+    #[test]
+    fn list_procedures_response_brief_matches_legacy_wire_shape() {
+        let response = super::ListProceduresResponse::brief(vec!["archive_order".into()], None);
+        assert_eq!(
+            serde_json::to_value(&response).unwrap(),
+            json!({"procedures": ["archive_order"]})
         );
     }
 }

--- a/docs/content/docs/features.mdx
+++ b/docs/content/docs/features.mdx
@@ -208,25 +208,41 @@ The detailed-mode field set diverges per backend:
 
 ### `listProcedures`
 
-List user-defined stored procedures in a database. Results are paginated — see [Cursor Pagination](#cursor-pagination) for the protocol.
+List user-defined stored procedures in a database, optionally filtered by `search` substring and/or expanded with `detailed: true`. Available on MySQL/MariaDB and PostgreSQL (`public` schema, PostgreSQL 11+). Not available for SQLite. Results are paginated — see [Cursor Pagination](#cursor-pagination) for the protocol. The `search` value (case-insensitive `LIKE`/`ILIKE` substring; `%` matches any sequence, `_` a single character) must remain identical across paginated calls for cursor continuity.
 
-Brief mode (default) returns a sorted JSON array of procedure-name strings:
+In **brief mode** (default) the response is a sorted JSON array of procedure-name strings. PostgreSQL overloads appear as one entry per overload — duplicate name strings are expected:
 
 ```json
 {
-  "procedures": ["archive_user", "rebuild_indexes"],
+  "procedures": ["archive_order", "archive_order_history", "archive_order_history"],
   "nextCursor": null
 }
 ```
 
-PostgreSQL also supports two optional parameters (mirroring `listFunctions`):
+In **detailed mode** the response is keyed by procedure signature. The PostgreSQL payload disambiguates overloads via `name(arguments)`; zero-arg procedures key as `name()` for shape uniformity:
 
-- `search` — case-insensitive `ILIKE` substring on procedure name. `%` matches any sequence; `_` matches a single character. Wildcard semantics match `listTables` / `listTriggers` / `listFunctions`. The `search` value must remain identical across paginated calls for cursor continuity.
-- `detailed` (default `false`) — when `true`, `procedures` becomes a JSON object keyed by procedure signature `name(arguments)` (overloads disambiguate; zero-arg procedures key as `name()` for shape uniformity). Each value carries `schema`, `name`, `language`, `arguments`, `security` (`INVOKER` / `DEFINER`), `owner`, `description` (or `null` when no `COMMENT ON PROCEDURE`), and `definition` (the full `pg_get_functiondef` output for `prokind='p'`). Brief and detailed pages share the same `(proname, oid)` row order, so a client can switch `detailed` mid-pagination without losing position.
+```json
+{
+  "procedures": {
+    "archive_order(order_id integer)": {
+      "schema": "public",
+      "name": "archive_order",
+      "language": "plpgsql",
+      "arguments": "order_id integer",
+      "security": "INVOKER",
+      "owner": "app_user",
+      "description": "Moves an order into the archive table",
+      "definition": "CREATE OR REPLACE PROCEDURE public.archive_order(order_id integer) ..."
+    }
+  },
+  "nextCursor": null
+}
+```
 
-Detailed mode deliberately omits the `listFunctions`-only fields `returnType`, `volatility`, `strict`, and `parallelSafety` — procedures don't return a value, `pg_proc.provolatile`/`proisstrict` are not user-settable for procedures, and `proparallel` carries no procedure-level guarantee in PostgreSQL.
+The detailed-mode field set diverges per backend:
 
-MySQL/MariaDB `listProcedures` accepts only `database` and `cursor` (brief mode only). Not available for SQLite. Available on MySQL/MariaDB and PostgreSQL (`public` schema, PostgreSQL 11+).
+- **PostgreSQL** — keyed by `name(arguments)` (overloads disambiguate; zero-arg procedures key as `name()`). Each value carries `schema`, `name`, `language`, `arguments`, `security` (`INVOKER` / `DEFINER`), `owner`, `description` (or `null` when no `COMMENT ON PROCEDURE`), and `definition` (the full `pg_get_functiondef` output for `prokind='p'`). Brief and detailed pages share the same `(proname, oid)` row order, so a client can switch `detailed` mid-pagination without losing position. The `listFunctions`-only fields `returnType`, `volatility`, `strict`, and `parallelSafety` are absent — procedures don't return a value, `pg_proc.provolatile`/`proisstrict` are not user-settable for procedures, and `proparallel` carries no procedure-level guarantee.
+- **MySQL / MariaDB** — keyed by bare procedure name (the engines do not allow procedure overloading). Each value carries `schema`, `language` (typically `"SQL"`; MariaDB external-language procedures report the external language name), `arguments` (comma-separated `MODE name type` triples from `information_schema.PARAMETERS` where `MODE` is `IN`/`OUT`/`INOUT`; empty string for zero-parameter procedures), `deterministic` (boolean), `sqlDataAccess` (`CONTAINS_SQL` / `NO_SQL` / `READS_SQL_DATA` / `MODIFIES_SQL_DATA`), `security` (`INVOKER` / `DEFINER`), `definer` (`user@host`), `description` (or `null` when no `COMMENT`), `definition` (canonical reconstructed `CREATE PROCEDURE` text including `DEFINER=` in `` `user`@`host` `` form; no `RETURNS` clause), plus the session context active at procedure-creation time: `sqlMode`, `characterSetClient`, `collationConnection`, `databaseCollation`. `returnType` is absent (procedures have no return type); `volatility`, `parallelSafety`, and `strict` are absent (no MySQL/MariaDB analogues). `owner` is renamed to `definer` to match the engine's terminology.
 
 ### `listMaterializedViews`
 

--- a/docs/content/docs/features.mdx
+++ b/docs/content/docs/features.mdx
@@ -208,7 +208,9 @@ The detailed-mode field set diverges per backend:
 
 ### `listProcedures`
 
-List user-defined stored procedures in a database. Results are paginated — see [Cursor Pagination](#cursor-pagination) for the protocol. The response is a sorted JSON array of procedure-name strings:
+List user-defined stored procedures in a database. Results are paginated — see [Cursor Pagination](#cursor-pagination) for the protocol.
+
+Brief mode (default) returns a sorted JSON array of procedure-name strings:
 
 ```json
 {
@@ -217,7 +219,14 @@ List user-defined stored procedures in a database. Results are paginated — see
 }
 ```
 
-Available on MySQL/MariaDB and PostgreSQL (`public` schema, PostgreSQL 11+). Not available for SQLite.
+PostgreSQL also supports two optional parameters (mirroring `listFunctions`):
+
+- `search` — case-insensitive `ILIKE` substring on procedure name. `%` matches any sequence; `_` matches a single character. Wildcard semantics match `listTables` / `listTriggers` / `listFunctions`. The `search` value must remain identical across paginated calls for cursor continuity.
+- `detailed` (default `false`) — when `true`, `procedures` becomes a JSON object keyed by procedure signature `name(arguments)` (overloads disambiguate; zero-arg procedures key as `name()` for shape uniformity). Each value carries `schema`, `name`, `language`, `arguments`, `security` (`INVOKER` / `DEFINER`), `owner`, `description` (or `null` when no `COMMENT ON PROCEDURE`), and `definition` (the full `pg_get_functiondef` output for `prokind='p'`). Brief and detailed pages share the same `(proname, oid)` row order, so a client can switch `detailed` mid-pagination without losing position.
+
+Detailed mode deliberately omits the `listFunctions`-only fields `returnType`, `volatility`, `strict`, and `parallelSafety` — procedures don't return a value, `pg_proc.provolatile`/`proisstrict` are not user-settable for procedures, and `proparallel` carries no procedure-level guarantee in PostgreSQL.
+
+MySQL/MariaDB `listProcedures` accepts only `database` and `cursor` (brief mode only). Not available for SQLite. Available on MySQL/MariaDB and PostgreSQL (`public` schema, PostgreSQL 11+).
 
 ### `listMaterializedViews`
 

--- a/tests/approval/snapshots/approval_mysql__list_tools.snap
+++ b/tests/approval/snapshots/approval_mysql__list_tools.snap
@@ -359,6 +359,25 @@ expression: tools
       "type": "object"
     },
     "outputSchema": {
+      "$defs": {
+        "ListEntries": {
+          "anyOf": [
+            {
+              "description": "Brief mode: sorted array of bare entity-name strings.",
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            },
+            {
+              "additionalProperties": true,
+              "description": "Detailed mode: name-keyed map; insertion order matches the SQL `ORDER BY` sort.",
+              "type": "object"
+            }
+          ],
+          "description": "Two-shape listing payload: bare names in brief mode, name-keyed metadata in detailed mode.\n\nShared by [`ListTablesResponse`] and [`ListTriggersResponse`]. Serialises untagged:\nbrief mode → JSON array of strings, detailed mode → JSON object whose keys are\nentity names and whose values are the per-entity metadata."
+        }
+      },
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "description": "Response for the `listProcedures` tool.",
       "properties": {
@@ -370,11 +389,8 @@ expression: tools
           ]
         },
         "procedures": {
-          "description": "Sorted list of procedure names for this page.",
-          "items": {
-            "type": "string"
-          },
-          "type": "array"
+          "$ref": "#/$defs/ListEntries",
+          "description": "Page of matching procedures. Shape depends on the request's `detailed` flag."
         }
       },
       "required": [

--- a/tests/approval/snapshots/approval_mysql__list_tools.snap
+++ b/tests/approval/snapshots/approval_mysql__list_tools.snap
@@ -1,5 +1,6 @@
 ---
 source: tests/approval/mysql.rs
+assertion_line: 42
 expression: tools
 ---
 [
@@ -333,10 +334,10 @@ expression: tools
   {
     "name": "listProcedures",
     "title": "List Procedures",
-    "description": "List all stored procedures in a specific database.\n\n<usecase>\nUse when:\n- Exploring a database's stored logic\n- Verifying a procedure exists before calling it\n- The user asks what procedures are defined\n</usecase>\n\n<examples>\n✓ \"What procedures are in the mydb database?\" → listProcedures(database=\"mydb\")\n✓ \"Does an archive_user procedure exist?\" → listProcedures to check\n✗ \"List functions\" → use listFunctions instead\n</examples>\n\n<what_it_returns>\nA sorted JSON array of procedure name strings.\n</what_it_returns>\n\n<pagination>\nPaginated. Pass the prior response's `nextCursor` as `cursor` to fetch the next page.\n</pagination>",
+    "description": "List user-defined stored procedures in a database, optionally filtered and/or with full metadata. Stored functions and loadable UDFs (`mysql.func`) are excluded.\n\n<usecase>\nUse when:\n- Auditing stored procedures across a database (brief mode, default).\n- Searching for a procedure by partial name (pass `search`).\n- Inspecting a procedure's language, parameter list (with `IN`/`OUT`/`INOUT` modes), determinism, SQL-data-access classification, security mode, definer, comment, session context, and full reconstructed `CREATE PROCEDURE` text before reasoning about correctness or invocation safety (pass `detailed: true`). Detailed mode supersedes ad-hoc `readQuery` against `information_schema.ROUTINES` / `information_schema.PARAMETERS`.\n</usecase>\n\n<parameters>\n- `database` — Database to target. Defaults to the active database.\n- `cursor` — Opaque pagination cursor; echo the prior response's `nextCursor`.\n- `search` — Case-insensitive filter on procedure names via `LIKE`. `%` matches any sequence; `_` matches a single character.\n- `detailed` — When `true`, returns full metadata objects keyed by procedure name instead of bare name strings. Default `false`.\n</parameters>\n\n<examples>\n✓ \"What procedures are in the mydb database?\" → listProcedures(database=\"mydb\")\n✓ \"Find the order archival routine\" → listProcedures(search=\"archive\")\n✓ \"What does archive_order do?\" → listProcedures(search=\"archive_order\", detailed=true)\n✗ \"List functions\" → use listFunctions instead\n✗ \"List loadable UDFs from mysql.func\" → not supported; only routines in information_schema.ROUTINES are returned\n</examples>\n\n<what_it_returns>\nBrief mode (default): a sorted JSON array of procedure-name strings, e.g. `[\"archive_order\", \"archive_order_history\", \"purge_order_archive\", \"touch_post\"]`.\nDetailed mode: a JSON object keyed by bare procedure name (MySQL/MariaDB do not allow procedure overloading, so no signature suffix is needed); each value carries `schema`, `language` (typically `\"SQL\"`; MariaDB external-language procedures report the external language name), `arguments` (comma-separated `MODE name type` triples from `information_schema.PARAMETERS` — `MODE` is one of `IN`, `OUT`, `INOUT`; empty string for zero-parameter procedures), `deterministic` (boolean), `sqlDataAccess` (one of `CONTAINS_SQL`, `NO_SQL`, `READS_SQL_DATA`, `MODIFIES_SQL_DATA`), `security` (`INVOKER` or `DEFINER`), `definer` (`user@host`), `description` (the `COMMENT` text or `null` when no comment was set — the empty string MySQL stores is coerced to JSON `null`), `definition` (the canonical reconstructed `CREATE PROCEDURE` text including `DEFINER=` in `` `user`@`host` `` form; no `RETURNS` clause — procedures have no return type), `sqlMode`, `characterSetClient`, `collationConnection`, and `databaseCollation`. Versus the Postgres `listProcedures` detailed payload: `volatility`, `parallelSafety`, `strict`, and `returnType` are intentionally absent (no MySQL/MariaDB analogues for the first three; procedures have no return type for the fourth — the Postgres-side payload also omits all four), `owner` is renamed to `definer` (more accurate for the MySQL `DEFINER` concept), keys are bare names rather than `name(arguments)` (no overloads possible), the four session-context fields (`sqlMode`, `characterSetClient`, `collationConnection`, `databaseCollation`) are MySQL/MariaDB-only additions, and `deterministic` plus `sqlDataAccess` are MySQL/MariaDB-only additions versus the Postgres `listProcedures` detailed payload (which omits both because Postgres procedures have no equivalent attributes).\n</what_it_returns>\n\n<pagination>\nPaginated. Pass the prior response's `nextCursor` as `cursor` to fetch the next page. The `search` filter must stay the same across pages for cursor continuity.\n</pagination>",
     "inputSchema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
-      "description": "Request for the `listProcedures` tool.",
+      "description": "Request for the MySQL/MariaDB `listProcedures` tool — supports search + detailed mode.",
       "properties": {
         "cursor": {
           "default": null,
@@ -349,6 +350,19 @@ expression: tools
         "database": {
           "default": null,
           "description": "Database to list procedures from. Defaults to the active database.",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "detailed": {
+          "default": false,
+          "description": "When `true`, each returned entry is a full metadata object (schema, language,\narguments with IN/OUT/INOUT mode tokens, deterministic, sqlDataAccess, security,\ndefiner, description, definition, sqlMode, characterSetClient,\ncollationConnection, databaseCollation); when `false` or omitted, each entry\nis the bare procedure-name string.",
+          "type": "boolean"
+        },
+        "search": {
+          "default": null,
+          "description": "Optional case-insensitive filter on procedure names. The input is used within a `LIKE`\nclause: `%` matches any sequence of characters and `_` matches any single character.",
           "type": [
             "string",
             "null"

--- a/tests/approval/snapshots/approval_mysql__list_tools_read_only.snap
+++ b/tests/approval/snapshots/approval_mysql__list_tools_read_only.snap
@@ -228,6 +228,25 @@ expression: tools
       "type": "object"
     },
     "outputSchema": {
+      "$defs": {
+        "ListEntries": {
+          "anyOf": [
+            {
+              "description": "Brief mode: sorted array of bare entity-name strings.",
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            },
+            {
+              "additionalProperties": true,
+              "description": "Detailed mode: name-keyed map; insertion order matches the SQL `ORDER BY` sort.",
+              "type": "object"
+            }
+          ],
+          "description": "Two-shape listing payload: bare names in brief mode, name-keyed metadata in detailed mode.\n\nShared by [`ListTablesResponse`] and [`ListTriggersResponse`]. Serialises untagged:\nbrief mode → JSON array of strings, detailed mode → JSON object whose keys are\nentity names and whose values are the per-entity metadata."
+        }
+      },
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "description": "Response for the `listProcedures` tool.",
       "properties": {
@@ -239,11 +258,8 @@ expression: tools
           ]
         },
         "procedures": {
-          "description": "Sorted list of procedure names for this page.",
-          "items": {
-            "type": "string"
-          },
-          "type": "array"
+          "$ref": "#/$defs/ListEntries",
+          "description": "Page of matching procedures. Shape depends on the request's `detailed` flag."
         }
       },
       "required": [

--- a/tests/approval/snapshots/approval_mysql__list_tools_read_only.snap
+++ b/tests/approval/snapshots/approval_mysql__list_tools_read_only.snap
@@ -1,5 +1,6 @@
 ---
 source: tests/approval/mysql.rs
+assertion_line: 51
 expression: tools
 ---
 [
@@ -202,10 +203,10 @@ expression: tools
   {
     "name": "listProcedures",
     "title": "List Procedures",
-    "description": "List all stored procedures in a specific database.\n\n<usecase>\nUse when:\n- Exploring a database's stored logic\n- Verifying a procedure exists before calling it\n- The user asks what procedures are defined\n</usecase>\n\n<examples>\n✓ \"What procedures are in the mydb database?\" → listProcedures(database=\"mydb\")\n✓ \"Does an archive_user procedure exist?\" → listProcedures to check\n✗ \"List functions\" → use listFunctions instead\n</examples>\n\n<what_it_returns>\nA sorted JSON array of procedure name strings.\n</what_it_returns>\n\n<pagination>\nPaginated. Pass the prior response's `nextCursor` as `cursor` to fetch the next page.\n</pagination>",
+    "description": "List user-defined stored procedures in a database, optionally filtered and/or with full metadata. Stored functions and loadable UDFs (`mysql.func`) are excluded.\n\n<usecase>\nUse when:\n- Auditing stored procedures across a database (brief mode, default).\n- Searching for a procedure by partial name (pass `search`).\n- Inspecting a procedure's language, parameter list (with `IN`/`OUT`/`INOUT` modes), determinism, SQL-data-access classification, security mode, definer, comment, session context, and full reconstructed `CREATE PROCEDURE` text before reasoning about correctness or invocation safety (pass `detailed: true`). Detailed mode supersedes ad-hoc `readQuery` against `information_schema.ROUTINES` / `information_schema.PARAMETERS`.\n</usecase>\n\n<parameters>\n- `database` — Database to target. Defaults to the active database.\n- `cursor` — Opaque pagination cursor; echo the prior response's `nextCursor`.\n- `search` — Case-insensitive filter on procedure names via `LIKE`. `%` matches any sequence; `_` matches a single character.\n- `detailed` — When `true`, returns full metadata objects keyed by procedure name instead of bare name strings. Default `false`.\n</parameters>\n\n<examples>\n✓ \"What procedures are in the mydb database?\" → listProcedures(database=\"mydb\")\n✓ \"Find the order archival routine\" → listProcedures(search=\"archive\")\n✓ \"What does archive_order do?\" → listProcedures(search=\"archive_order\", detailed=true)\n✗ \"List functions\" → use listFunctions instead\n✗ \"List loadable UDFs from mysql.func\" → not supported; only routines in information_schema.ROUTINES are returned\n</examples>\n\n<what_it_returns>\nBrief mode (default): a sorted JSON array of procedure-name strings, e.g. `[\"archive_order\", \"archive_order_history\", \"purge_order_archive\", \"touch_post\"]`.\nDetailed mode: a JSON object keyed by bare procedure name (MySQL/MariaDB do not allow procedure overloading, so no signature suffix is needed); each value carries `schema`, `language` (typically `\"SQL\"`; MariaDB external-language procedures report the external language name), `arguments` (comma-separated `MODE name type` triples from `information_schema.PARAMETERS` — `MODE` is one of `IN`, `OUT`, `INOUT`; empty string for zero-parameter procedures), `deterministic` (boolean), `sqlDataAccess` (one of `CONTAINS_SQL`, `NO_SQL`, `READS_SQL_DATA`, `MODIFIES_SQL_DATA`), `security` (`INVOKER` or `DEFINER`), `definer` (`user@host`), `description` (the `COMMENT` text or `null` when no comment was set — the empty string MySQL stores is coerced to JSON `null`), `definition` (the canonical reconstructed `CREATE PROCEDURE` text including `DEFINER=` in `` `user`@`host` `` form; no `RETURNS` clause — procedures have no return type), `sqlMode`, `characterSetClient`, `collationConnection`, and `databaseCollation`. Versus the Postgres `listProcedures` detailed payload: `volatility`, `parallelSafety`, `strict`, and `returnType` are intentionally absent (no MySQL/MariaDB analogues for the first three; procedures have no return type for the fourth — the Postgres-side payload also omits all four), `owner` is renamed to `definer` (more accurate for the MySQL `DEFINER` concept), keys are bare names rather than `name(arguments)` (no overloads possible), the four session-context fields (`sqlMode`, `characterSetClient`, `collationConnection`, `databaseCollation`) are MySQL/MariaDB-only additions, and `deterministic` plus `sqlDataAccess` are MySQL/MariaDB-only additions versus the Postgres `listProcedures` detailed payload (which omits both because Postgres procedures have no equivalent attributes).\n</what_it_returns>\n\n<pagination>\nPaginated. Pass the prior response's `nextCursor` as `cursor` to fetch the next page. The `search` filter must stay the same across pages for cursor continuity.\n</pagination>",
     "inputSchema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
-      "description": "Request for the `listProcedures` tool.",
+      "description": "Request for the MySQL/MariaDB `listProcedures` tool — supports search + detailed mode.",
       "properties": {
         "cursor": {
           "default": null,
@@ -218,6 +219,19 @@ expression: tools
         "database": {
           "default": null,
           "description": "Database to list procedures from. Defaults to the active database.",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "detailed": {
+          "default": false,
+          "description": "When `true`, each returned entry is a full metadata object (schema, language,\narguments with IN/OUT/INOUT mode tokens, deterministic, sqlDataAccess, security,\ndefiner, description, definition, sqlMode, characterSetClient,\ncollationConnection, databaseCollation); when `false` or omitted, each entry\nis the bare procedure-name string.",
+          "type": "boolean"
+        },
+        "search": {
+          "default": null,
+          "description": "Optional case-insensitive filter on procedure names. The input is used within a `LIKE`\nclause: `%` matches any sequence of characters and `_` matches any single character.",
           "type": [
             "string",
             "null"

--- a/tests/approval/snapshots/approval_postgres__list_tools.snap
+++ b/tests/approval/snapshots/approval_postgres__list_tools.snap
@@ -398,10 +398,10 @@ expression: tools
   {
     "name": "listProcedures",
     "title": "List Procedures",
-    "description": "List all user-defined procedures in the `public` schema of a database (PostgreSQL 11+).\n\n<usecase>\nUse when:\n- Exploring a database's stored logic\n- Verifying a procedure exists before calling it\n- The user asks what procedures are defined\n</usecase>\n\n<examples>\n✓ \"What procedures are in the mydb database?\" → listProcedures(database=\"mydb\")\n✓ \"Does an archive_user procedure exist?\" → listProcedures to check\n✗ \"List functions\" → use listFunctions instead\n</examples>\n\n<what_it_returns>\nA sorted JSON array of procedure name strings.\n</what_it_returns>\n\n<pagination>\nPaginated. Pass the prior response's `nextCursor` as `cursor` to fetch the next page.\n</pagination>",
+    "description": "List user-defined procedures in the `public` schema, optionally filtered and/or with full metadata. Functions, aggregates, and window functions are excluded.\n\n<usecase>\nUse when:\n- Auditing procedures across a database (brief mode, default).\n- Searching for a procedure by partial name (pass `search`).\n- Inspecting a procedure's language, signature, security mode, owner, comment, and full `CREATE PROCEDURE` text before reasoning about correctness or invocation safety (pass `detailed: true`). Detailed mode supersedes ad-hoc `readQuery` against `pg_proc` / `information_schema.routines`.\n</usecase>\n\n<parameters>\n- `database` — Database to target. Defaults to the active database.\n- `cursor` — Opaque pagination cursor; echo the prior response's `nextCursor`.\n- `search` — Case-insensitive filter on procedure names via `ILIKE`. `%` matches any sequence; `_` matches a single character.\n- `detailed` — When `true`, returns full metadata objects keyed by `name(arguments)` instead of bare name strings. Default `false`.\n</parameters>\n\n<examples>\n✓ \"What procedures are in mydb?\" → listProcedures(database=\"mydb\")\n✓ \"Find the order archival routine\" → listProcedures(search=\"archive\")\n✓ \"What does archive_order do?\" → listProcedures(search=\"archive_order\", detailed=true)\n✗ \"List functions\" → use listFunctions instead\n✗ \"List aggregates\" → not supported; aggregates are excluded\n</examples>\n\n<what_it_returns>\nBrief mode (default): a sorted JSON array of procedure-name strings, e.g. `[\"archive_order\", \"archive_order_history\", \"archive_order_history\"]`. Overloaded procedures appear as one entry per overload (duplicate name strings allowed).\nDetailed mode: a JSON object keyed by procedure signature `name(arguments)`; each value carries `schema`, `name`, `language`, `arguments`, `security` (INVOKER/DEFINER), `owner`, `description` (or null when no `COMMENT ON PROCEDURE`), and `definition` (the full `CREATE OR REPLACE PROCEDURE` text). Overloads occupy distinct keys (e.g. `archive_order_history(integer)` vs `archive_order_history(integer, boolean)`). Zero-arg procedures key as `name()` — the parens are always present so the key shape stays uniform.\n\nDetailed mode deliberately omits the `listFunctions`-only fields `returnType`, `volatility`, `strict`, and `parallelSafety`: procedures don't return a value, `pg_proc.provolatile` / `proisstrict` are not user-settable for procedures, and `proparallel` carries no procedure-level guarantee in PostgreSQL.\n</what_it_returns>\n\n<pagination>\nPaginated. Pass the prior response's `nextCursor` as `cursor` to fetch the next page. The `search` filter must stay the same across pages for cursor continuity. Brief and detailed modes share the same `(proname, oid)` row order, so a client can switch `detailed` between pages without losing position.\n</pagination>",
     "inputSchema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
-      "description": "Request for the `listProcedures` tool.",
+      "description": "Request for the Postgres `listProcedures` tool — extends the shared shape with `search` and `detailed`.",
       "properties": {
         "cursor": {
           "default": null,
@@ -418,12 +418,44 @@ expression: tools
             "string",
             "null"
           ]
+        },
+        "detailed": {
+          "default": false,
+          "description": "When `true`, each returned entry is a full metadata object (schema, name,\nlanguage, arguments, security, owner, description, definition); when `false`\nor omitted, each entry is the bare procedure-name string.",
+          "type": "boolean"
+        },
+        "search": {
+          "default": null,
+          "description": "Optional case-insensitive filter on procedure names. The input is used within an `ILIKE`\nclause: `%` matches any sequence of characters and `_` matches any single character.",
+          "type": [
+            "string",
+            "null"
+          ]
         }
       },
       "title": "ListProceduresRequest",
       "type": "object"
     },
     "outputSchema": {
+      "$defs": {
+        "ListEntries": {
+          "anyOf": [
+            {
+              "description": "Brief mode: sorted array of bare entity-name strings.",
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            },
+            {
+              "additionalProperties": true,
+              "description": "Detailed mode: name-keyed map; insertion order matches the SQL `ORDER BY` sort.",
+              "type": "object"
+            }
+          ],
+          "description": "Two-shape listing payload: bare names in brief mode, name-keyed metadata in detailed mode.\n\nShared by [`ListTablesResponse`] and [`ListTriggersResponse`]. Serialises untagged:\nbrief mode → JSON array of strings, detailed mode → JSON object whose keys are\nentity names and whose values are the per-entity metadata."
+        }
+      },
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "description": "Response for the `listProcedures` tool.",
       "properties": {
@@ -435,11 +467,8 @@ expression: tools
           ]
         },
         "procedures": {
-          "description": "Sorted list of procedure names for this page.",
-          "items": {
-            "type": "string"
-          },
-          "type": "array"
+          "$ref": "#/$defs/ListEntries",
+          "description": "Page of matching procedures. Shape depends on the request's `detailed` flag."
         }
       },
       "required": [

--- a/tests/approval/snapshots/approval_postgres__list_tools_read_only.snap
+++ b/tests/approval/snapshots/approval_postgres__list_tools_read_only.snap
@@ -262,10 +262,10 @@ expression: tools
   {
     "name": "listProcedures",
     "title": "List Procedures",
-    "description": "List all user-defined procedures in the `public` schema of a database (PostgreSQL 11+).\n\n<usecase>\nUse when:\n- Exploring a database's stored logic\n- Verifying a procedure exists before calling it\n- The user asks what procedures are defined\n</usecase>\n\n<examples>\n✓ \"What procedures are in the mydb database?\" → listProcedures(database=\"mydb\")\n✓ \"Does an archive_user procedure exist?\" → listProcedures to check\n✗ \"List functions\" → use listFunctions instead\n</examples>\n\n<what_it_returns>\nA sorted JSON array of procedure name strings.\n</what_it_returns>\n\n<pagination>\nPaginated. Pass the prior response's `nextCursor` as `cursor` to fetch the next page.\n</pagination>",
+    "description": "List user-defined procedures in the `public` schema, optionally filtered and/or with full metadata. Functions, aggregates, and window functions are excluded.\n\n<usecase>\nUse when:\n- Auditing procedures across a database (brief mode, default).\n- Searching for a procedure by partial name (pass `search`).\n- Inspecting a procedure's language, signature, security mode, owner, comment, and full `CREATE PROCEDURE` text before reasoning about correctness or invocation safety (pass `detailed: true`). Detailed mode supersedes ad-hoc `readQuery` against `pg_proc` / `information_schema.routines`.\n</usecase>\n\n<parameters>\n- `database` — Database to target. Defaults to the active database.\n- `cursor` — Opaque pagination cursor; echo the prior response's `nextCursor`.\n- `search` — Case-insensitive filter on procedure names via `ILIKE`. `%` matches any sequence; `_` matches a single character.\n- `detailed` — When `true`, returns full metadata objects keyed by `name(arguments)` instead of bare name strings. Default `false`.\n</parameters>\n\n<examples>\n✓ \"What procedures are in mydb?\" → listProcedures(database=\"mydb\")\n✓ \"Find the order archival routine\" → listProcedures(search=\"archive\")\n✓ \"What does archive_order do?\" → listProcedures(search=\"archive_order\", detailed=true)\n✗ \"List functions\" → use listFunctions instead\n✗ \"List aggregates\" → not supported; aggregates are excluded\n</examples>\n\n<what_it_returns>\nBrief mode (default): a sorted JSON array of procedure-name strings, e.g. `[\"archive_order\", \"archive_order_history\", \"archive_order_history\"]`. Overloaded procedures appear as one entry per overload (duplicate name strings allowed).\nDetailed mode: a JSON object keyed by procedure signature `name(arguments)`; each value carries `schema`, `name`, `language`, `arguments`, `security` (INVOKER/DEFINER), `owner`, `description` (or null when no `COMMENT ON PROCEDURE`), and `definition` (the full `CREATE OR REPLACE PROCEDURE` text). Overloads occupy distinct keys (e.g. `archive_order_history(integer)` vs `archive_order_history(integer, boolean)`). Zero-arg procedures key as `name()` — the parens are always present so the key shape stays uniform.\n\nDetailed mode deliberately omits the `listFunctions`-only fields `returnType`, `volatility`, `strict`, and `parallelSafety`: procedures don't return a value, `pg_proc.provolatile` / `proisstrict` are not user-settable for procedures, and `proparallel` carries no procedure-level guarantee in PostgreSQL.\n</what_it_returns>\n\n<pagination>\nPaginated. Pass the prior response's `nextCursor` as `cursor` to fetch the next page. The `search` filter must stay the same across pages for cursor continuity. Brief and detailed modes share the same `(proname, oid)` row order, so a client can switch `detailed` between pages without losing position.\n</pagination>",
     "inputSchema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
-      "description": "Request for the `listProcedures` tool.",
+      "description": "Request for the Postgres `listProcedures` tool — extends the shared shape with `search` and `detailed`.",
       "properties": {
         "cursor": {
           "default": null,
@@ -282,12 +282,44 @@ expression: tools
             "string",
             "null"
           ]
+        },
+        "detailed": {
+          "default": false,
+          "description": "When `true`, each returned entry is a full metadata object (schema, name,\nlanguage, arguments, security, owner, description, definition); when `false`\nor omitted, each entry is the bare procedure-name string.",
+          "type": "boolean"
+        },
+        "search": {
+          "default": null,
+          "description": "Optional case-insensitive filter on procedure names. The input is used within an `ILIKE`\nclause: `%` matches any sequence of characters and `_` matches any single character.",
+          "type": [
+            "string",
+            "null"
+          ]
         }
       },
       "title": "ListProceduresRequest",
       "type": "object"
     },
     "outputSchema": {
+      "$defs": {
+        "ListEntries": {
+          "anyOf": [
+            {
+              "description": "Brief mode: sorted array of bare entity-name strings.",
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            },
+            {
+              "additionalProperties": true,
+              "description": "Detailed mode: name-keyed map; insertion order matches the SQL `ORDER BY` sort.",
+              "type": "object"
+            }
+          ],
+          "description": "Two-shape listing payload: bare names in brief mode, name-keyed metadata in detailed mode.\n\nShared by [`ListTablesResponse`] and [`ListTriggersResponse`]. Serialises untagged:\nbrief mode → JSON array of strings, detailed mode → JSON object whose keys are\nentity names and whose values are the per-entity metadata."
+        }
+      },
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "description": "Response for the `listProcedures` tool.",
       "properties": {
@@ -299,11 +331,8 @@ expression: tools
           ]
         },
         "procedures": {
-          "description": "Sorted list of procedure names for this page.",
-          "items": {
-            "type": "string"
-          },
-          "type": "array"
+          "$ref": "#/$defs/ListEntries",
+          "description": "Page of matching procedures. Shape depends on the request's `detailed` flag."
         }
       },
       "required": [

--- a/tests/functional/mysql.rs
+++ b/tests/functional/mysql.rs
@@ -2557,15 +2557,14 @@ async fn test_list_procedures_returns_seeded_procedures() {
         .await
         .expect("list_procedures");
 
+    let names = response.procedures.as_brief().expect("brief mode").to_vec();
     assert!(
-        response.procedures.contains(&"archive_user".to_string()),
-        "expected seeded archive_user procedure, got {:?}",
-        response.procedures
+        names.contains(&"archive_user".to_string()),
+        "expected seeded archive_user procedure, got {names:?}"
     );
     assert!(
-        response.procedures.contains(&"touch_post".to_string()),
-        "expected seeded touch_post procedure, got {:?}",
-        response.procedures
+        names.contains(&"touch_post".to_string()),
+        "expected seeded touch_post procedure, got {names:?}"
     );
 }
 
@@ -2580,11 +2579,11 @@ async fn test_list_procedures_excludes_functions() {
         .await
         .expect("list_procedures");
 
+    let names = response.procedures.as_brief().expect("brief mode").to_vec();
     for func_name in ["calc_total", "double_it"] {
         assert!(
-            !response.procedures.contains(&func_name.to_string()),
-            "function `{func_name}` leaked into listProcedures output: {:?}",
-            response.procedures
+            !names.contains(&func_name.to_string()),
+            "function `{func_name}` leaked into listProcedures output: {names:?}"
         );
     }
 }

--- a/tests/functional/mysql.rs
+++ b/tests/functional/mysql.rs
@@ -10,10 +10,12 @@
 
 use dbmcp_config::{DatabaseBackend, DatabaseConfig};
 use dbmcp_mysql::MysqlHandler;
-use dbmcp_mysql::types::{DropTableRequest, ListEntries, ListFunctionsRequest, ListTablesRequest};
+use dbmcp_mysql::types::{
+    DropTableRequest, ListEntries, ListFunctionsRequest, ListProceduresRequest, ListTablesRequest,
+};
 use dbmcp_server::types::{
-    CreateDatabaseRequest, DropDatabaseRequest, ExplainQueryRequest, ListDatabasesRequest, ListProceduresRequest,
-    ListTriggersRequest, ListViewsRequest, QueryRequest, ReadQueryRequest,
+    CreateDatabaseRequest, DropDatabaseRequest, ExplainQueryRequest, ListDatabasesRequest, ListTriggersRequest,
+    ListViewsRequest, QueryRequest, ReadQueryRequest,
 };
 use serde_json::Value;
 
@@ -2552,7 +2554,7 @@ async fn test_list_procedures_returns_seeded_procedures() {
     let response = handler
         .list_procedures(ListProceduresRequest {
             database: Some("app".into()),
-            cursor: None,
+            ..Default::default()
         })
         .await
         .expect("list_procedures");
@@ -2574,7 +2576,7 @@ async fn test_list_procedures_excludes_functions() {
     let response = handler
         .list_procedures(ListProceduresRequest {
             database: Some("app".into()),
-            cursor: None,
+            ..Default::default()
         })
         .await
         .expect("list_procedures");
@@ -2608,7 +2610,7 @@ async fn test_list_routines_empty_for_empty_database() {
     let procedures = handler
         .list_procedures(ListProceduresRequest {
             database: Some("analytics".into()),
-            cursor: None,
+            ..Default::default()
         })
         .await
         .expect("list_procedures");
@@ -3727,4 +3729,389 @@ async fn test_list_triggers_and_tables_definer_form_unchanged_after_extraction()
             "legacy single-quoted DEFINER leaked in list_tables: {def:?}"
         );
     }
+}
+
+// ----- listProcedures enrichment (spec 062) -----
+
+async fn brief_procedures(handler: &MysqlHandler, search: Option<&str>) -> Vec<String> {
+    let response = handler
+        .list_procedures(ListProceduresRequest {
+            database: Some("app".into()),
+            search: search.map(str::to_owned),
+            ..Default::default()
+        })
+        .await
+        .expect("brief list_procedures");
+    response.procedures.into_brief().expect("brief mode")
+}
+
+async fn detailed_procedure_entries(handler: &MysqlHandler, search: &str) -> indexmap::IndexMap<String, Value> {
+    let response = handler
+        .list_procedures(ListProceduresRequest {
+            database: Some("app".into()),
+            search: Some(search.into()),
+            detailed: true,
+            ..Default::default()
+        })
+        .await
+        .expect("detailed list_procedures");
+    response.procedures.as_detailed().expect("detailed mode").clone()
+}
+
+#[tokio::test]
+async fn test_list_procedures_search_filters_by_substring() {
+    let handler = handler(true);
+    let names = brief_procedures(&handler, Some("archive")).await;
+    let expected = [
+        "archive_order".to_string(),
+        "archive_order_history".to_string(),
+        "archive_user".to_string(),
+        "purge_order_archive".to_string(),
+    ];
+    assert_eq!(names, expected, "got {names:?}");
+}
+
+#[tokio::test]
+async fn test_list_procedures_search_is_case_insensitive() {
+    let handler = handler(true);
+    let lower = brief_procedures(&handler, Some("archive")).await;
+    let upper = brief_procedures(&handler, Some("ArChIvE")).await;
+    assert_eq!(lower, upper);
+}
+
+#[tokio::test]
+async fn test_list_procedures_search_no_match_returns_empty() {
+    let handler = handler(true);
+    let names = brief_procedures(&handler, Some("nonexistent_proc_xyz")).await;
+    assert!(names.is_empty(), "expected empty list, got {names:?}");
+}
+
+#[tokio::test]
+async fn test_list_procedures_search_keeps_like_wildcards() {
+    let handler = handler(true);
+    // `_` is a `LIKE` single-char wildcard — `archive_user` matches but so do
+    // any other procedure with a single char between `archive` and `user`.
+    // The seed only contains `archive_user`, so the match set is `[archive_user]`.
+    let underscore = brief_procedures(&handler, Some("archive_user")).await;
+    assert!(
+        underscore.contains(&"archive_user".to_string()),
+        "underscore wildcard should match archive_user: {underscore:?}"
+    );
+    // `%` matches everything — must be a superset of the unfiltered list size.
+    let pct = brief_procedures(&handler, Some("%")).await;
+    let unfiltered = brief_procedures(&handler, None).await;
+    assert_eq!(pct, unfiltered, "% must match every procedure");
+}
+
+#[tokio::test]
+async fn test_list_procedures_search_resists_sql_meta_chars() {
+    let handler = handler(true);
+    for payload in ["'", ";", "--", "`", "\\", "archive'; DROP PROCEDURE bad; --"] {
+        let result = handler
+            .list_procedures(ListProceduresRequest {
+                database: Some("app".into()),
+                search: Some(payload.into()),
+                ..Default::default()
+            })
+            .await;
+        assert!(
+            result.is_ok(),
+            "adversarial payload {payload:?} must not error: {:?}",
+            result.err()
+        );
+    }
+}
+
+#[tokio::test]
+async fn test_list_procedures_brief_wire_shape_unchanged() {
+    let handler = handler(true);
+    let response = handler
+        .list_procedures(ListProceduresRequest {
+            database: Some("app".into()),
+            ..Default::default()
+        })
+        .await
+        .expect("list_procedures");
+
+    let names = response.procedures.as_brief().expect("brief mode (Vec<String>)");
+    assert!(
+        names.iter().all(|s| !s.is_empty()),
+        "brief mode names must be non-empty strings, got {names:?}"
+    );
+    let json = serde_json::to_value(&response).expect("serialize");
+    let procedures = json.get("procedures").expect("procedures key");
+    assert!(
+        procedures.is_array(),
+        "brief mode `procedures` must be a JSON array, got {procedures:?}"
+    );
+}
+
+#[tokio::test]
+async fn test_list_procedures_detailed_returns_keyed_object_with_all_fields() {
+    let handler = handler(true);
+    let entries = detailed_procedure_entries(&handler, "archive_order").await;
+    // search "archive_order" matches both `archive_order` and
+    // `archive_order_history`. Field-shape assertions only need archive_order.
+    let entry = entries.get("archive_order").expect("archive_order key present");
+
+    let obj = entry.as_object().expect("entry is object");
+    let expected_keys = [
+        "schema",
+        "language",
+        "arguments",
+        "deterministic",
+        "sqlDataAccess",
+        "security",
+        "definer",
+        "description",
+        "definition",
+        "sqlMode",
+        "characterSetClient",
+        "collationConnection",
+        "databaseCollation",
+    ];
+    for key in expected_keys {
+        assert!(obj.contains_key(key), "missing key {key:?} in {obj:?}");
+    }
+    assert_eq!(obj.len(), expected_keys.len(), "unexpected extra keys: {obj:?}");
+    for forbidden in ["returnType", "volatility", "parallelSafety", "strict", "owner", "name"] {
+        assert!(
+            !obj.contains_key(forbidden),
+            "forbidden key {forbidden:?} present in {obj:?}"
+        );
+    }
+
+    assert_eq!(obj.get("schema").and_then(Value::as_str), Some("app"));
+    assert_eq!(obj.get("deterministic").and_then(Value::as_bool), Some(true));
+    assert_eq!(
+        obj.get("sqlDataAccess").and_then(Value::as_str),
+        Some("MODIFIES_SQL_DATA")
+    );
+    assert_eq!(obj.get("security").and_then(Value::as_str), Some("INVOKER"));
+    assert_eq!(
+        obj.get("description").and_then(Value::as_str),
+        Some("Archives an order and returns the count")
+    );
+    let language = obj.get("language").and_then(Value::as_str).expect("language");
+    assert!(
+        language.eq_ignore_ascii_case("SQL"),
+        "expected language `SQL` (any casing), got {language:?}"
+    );
+}
+
+#[tokio::test]
+async fn test_list_procedures_detailed_renders_in_out_inout_modes_in_arguments() {
+    let handler = handler(true);
+    let entries = detailed_procedure_entries(&handler, "compute_user_metrics").await;
+    let arguments = entries
+        .get("compute_user_metrics")
+        .and_then(|e| e.get("arguments"))
+        .and_then(Value::as_str)
+        .expect("arguments");
+
+    let upper = arguments.to_uppercase();
+    assert!(upper.contains("IN UID"), "expected `IN uid` in {arguments:?}");
+    assert!(
+        upper.contains("OUT METRIC_TOTAL"),
+        "expected `OUT metric_total` in {arguments:?}"
+    );
+    assert!(
+        upper.contains("INOUT METRIC_AVG"),
+        "expected `INOUT metric_avg` in {arguments:?}"
+    );
+    let in_pos = upper.find("IN UID").unwrap();
+    let out_pos = upper.find("OUT METRIC_TOTAL").unwrap();
+    let inout_pos = upper.find("INOUT METRIC_AVG").unwrap();
+    assert!(
+        in_pos < out_pos && out_pos < inout_pos,
+        "parameter order must follow ORDINAL_POSITION: {arguments:?}"
+    );
+}
+
+#[tokio::test]
+async fn test_list_procedures_detailed_omits_returntype_field() {
+    let handler = handler(true);
+    let entries = detailed_procedure_entries(&handler, "archive_order").await;
+    let entry = entries.get("archive_order").expect("archive_order");
+    let obj = entry.as_object().expect("object");
+    assert!(
+        !obj.contains_key("returnType"),
+        "procedures must NOT carry returnType: {obj:?}"
+    );
+}
+
+#[tokio::test]
+async fn test_list_procedures_detailed_definition_omits_returns_clause() {
+    let handler = handler(true);
+    let entries = detailed_procedure_entries(&handler, "archive_order").await;
+    let definition = entries
+        .get("archive_order")
+        .and_then(|e| e.get("definition"))
+        .and_then(Value::as_str)
+        .expect("definition");
+
+    assert!(
+        !definition.contains(" RETURNS "),
+        "procedure `definition` must not contain ` RETURNS `: {definition:?}"
+    );
+    assert!(
+        definition.starts_with("CREATE DEFINER=`"),
+        "expected canonical CREATE DEFINER opener: {definition:?}"
+    );
+    assert!(
+        definition.contains(" PROCEDURE `archive_order`"),
+        "expected ` PROCEDURE `archive_order`` in: {definition:?}"
+    );
+}
+
+#[tokio::test]
+async fn test_list_procedures_detailed_zero_parameter_arguments_is_empty_string() {
+    let handler = handler(true);
+    let entries = detailed_procedure_entries(&handler, "no_arg_proc").await;
+    let entry = entries.get("no_arg_proc").expect("no_arg_proc");
+    assert_eq!(
+        entry.get("arguments").and_then(Value::as_str),
+        Some(""),
+        "zero-parameter procedure `arguments` must be empty string"
+    );
+    let definition = entry.get("definition").and_then(Value::as_str).expect("definition");
+    assert!(
+        definition.contains("PROCEDURE `no_arg_proc`()"),
+        "expected `PROCEDURE `no_arg_proc`()` in: {definition:?}"
+    );
+}
+
+#[tokio::test]
+async fn test_list_procedures_detailed_security_definer_reports_definer() {
+    let handler = handler(true);
+    let entries = detailed_procedure_entries(&handler, "compute_user_metrics").await;
+    let security = entries
+        .get("compute_user_metrics")
+        .and_then(|e| e.get("security"))
+        .and_then(Value::as_str)
+        .expect("security");
+    assert_eq!(security, "DEFINER", "got {security:?}");
+
+    let entries_invoker = detailed_procedure_entries(&handler, "archive_order").await;
+    let security_invoker = entries_invoker
+        .get("archive_order")
+        .and_then(|e| e.get("security"))
+        .and_then(Value::as_str)
+        .expect("security");
+    assert_eq!(security_invoker, "INVOKER", "got {security_invoker:?}");
+}
+
+#[tokio::test]
+async fn test_list_procedures_detailed_no_comment_yields_null_description() {
+    let handler = handler(true);
+    let entries = detailed_procedure_entries(&handler, "purge_order_archive").await;
+    let description = entries
+        .get("purge_order_archive")
+        .and_then(|e| e.get("description"))
+        .expect("description field present");
+    assert!(
+        description.is_null(),
+        "no-comment procedure must coerce empty ROUTINE_COMMENT to JSON null, got {description:?}"
+    );
+}
+
+#[tokio::test]
+async fn test_list_procedures_detailed_combined_with_search_filters_before_metadata() {
+    let handler = handler(true);
+    let detailed = detailed_procedure_entries(&handler, "archive").await;
+    let brief = brief_procedures(&handler, Some("archive")).await;
+
+    let detailed_keys: Vec<String> = detailed.keys().cloned().collect();
+    assert_eq!(detailed_keys, brief, "detailed key set must equal brief filtered set");
+    for key in detailed.keys() {
+        assert!(
+            key.to_lowercase().contains("archive"),
+            "non-matching procedure {key:?} leaked into detailed payload"
+        );
+    }
+}
+
+#[tokio::test]
+async fn test_list_procedures_detailed_iteration_order_matches_brief_sort() {
+    let handler = handler(true);
+    let brief = brief_procedures(&handler, Some("archive")).await;
+    let detailed = detailed_procedure_entries(&handler, "archive").await;
+    let detailed_keys: Vec<String> = detailed.keys().cloned().collect();
+    assert_eq!(
+        brief, detailed_keys,
+        "detailed iteration order must match brief alphabetical sort"
+    );
+}
+
+#[tokio::test]
+async fn test_list_procedures_detailed_session_context_fields_populated() {
+    let handler = handler(true);
+    let entries = detailed_procedure_entries(&handler, "archive_order").await;
+    let entry = entries.get("archive_order").expect("archive_order");
+    for key in [
+        "sqlMode",
+        "characterSetClient",
+        "collationConnection",
+        "databaseCollation",
+    ] {
+        let value = entry.get(key).and_then(Value::as_str);
+        assert!(
+            matches!(value, Some(s) if !s.is_empty()),
+            "session-context field {key:?} must be a non-empty string, got {value:?}"
+        );
+    }
+}
+
+#[tokio::test]
+async fn test_list_procedures_detailed_round_trips_body_with_quotes_and_newlines() {
+    let handler = handler(true);
+    let entries = detailed_procedure_entries(&handler, "no_arg_proc").await;
+    let definition = entries
+        .get("no_arg_proc")
+        .and_then(|e| e.get("definition"))
+        .and_then(Value::as_str)
+        .expect("definition");
+
+    // MySQL 9 interprets `\n` in the source as a literal newline char in
+    // ROUTINE_DEFINITION; MariaDB 12 preserves the two-byte `\n` escape
+    // sequence verbatim. Accept either form — the contract is "body content
+    // round-trips without truncation".
+    assert!(
+        definition.contains('\n') || definition.contains("\\n"),
+        "expected newline (literal or escape) in body round-trip: {definition:?}"
+    );
+    // MySQL 9 strips SQL-escape doubling on stored bodies (returns `'here'`);
+    // MariaDB 12 preserves the doubled form (returns `''here''`). Both
+    // contain `'here'` as a substring — assert that.
+    assert!(
+        definition.contains("'here'"),
+        "expected `'here'` in body round-trip: {definition:?}"
+    );
+    assert!(
+        definition.contains("first line"),
+        "expected first-line marker in body round-trip: {definition:?}"
+    );
+    assert!(
+        definition.contains("second line"),
+        "expected second-line marker in body round-trip: {definition:?}"
+    );
+}
+
+#[tokio::test]
+async fn test_list_procedures_detailed_definition_uses_canonical_definer_form() {
+    let handler = handler(true);
+    let entries = detailed_procedure_entries(&handler, "archive_order").await;
+    let definition = entries
+        .get("archive_order")
+        .and_then(|e| e.get("definition"))
+        .and_then(Value::as_str)
+        .expect("definition");
+    assert!(
+        definition.starts_with("CREATE DEFINER=`"),
+        "canonical DEFINER form regressed: {definition:?}"
+    );
+    assert!(
+        !definition.starts_with("CREATE DEFINER='"),
+        "legacy single-quoted DEFINER leaked: {definition:?}"
+    );
 }

--- a/tests/functional/postgres.rs
+++ b/tests/functional/postgres.rs
@@ -9,10 +9,12 @@
 
 use dbmcp_config::{DatabaseBackend, DatabaseConfig};
 use dbmcp_postgres::PostgresHandler;
-use dbmcp_postgres::types::{DropTableRequest, ListFunctionsRequest, ListTablesRequest, ListTriggersRequest};
+use dbmcp_postgres::types::{
+    DropTableRequest, ListFunctionsRequest, ListProceduresRequest, ListTablesRequest, ListTriggersRequest,
+};
 use dbmcp_server::types::{
     CreateDatabaseRequest, DropDatabaseRequest, ExplainQueryRequest, ListDatabasesRequest,
-    ListMaterializedViewsRequest, ListProceduresRequest, ListViewsRequest, QueryRequest, ReadQueryRequest,
+    ListMaterializedViewsRequest, ListViewsRequest, QueryRequest, ReadQueryRequest,
 };
 use indexmap::IndexMap;
 use serde_json::Value;
@@ -2393,20 +2395,19 @@ async fn test_list_procedures_returns_seeded_procedures() {
     let response = handler
         .list_procedures(ListProceduresRequest {
             database: Some("app".into()),
-            cursor: None,
+            ..Default::default()
         })
         .await
         .expect("list_procedures");
 
+    let names = response.procedures.as_brief().expect("brief mode").to_vec();
     assert!(
-        response.procedures.contains(&"archive_user".to_string()),
-        "expected seeded archive_user procedure, got {:?}",
-        response.procedures
+        names.contains(&"archive_user".to_string()),
+        "expected seeded archive_user procedure, got {names:?}"
     );
     assert!(
-        response.procedures.contains(&"touch_post".to_string()),
-        "expected seeded touch_post procedure, got {:?}",
-        response.procedures
+        names.contains(&"touch_post".to_string()),
+        "expected seeded touch_post procedure, got {names:?}"
     );
 }
 
@@ -2416,18 +2417,368 @@ async fn test_list_procedures_excludes_functions() {
     let response = handler
         .list_procedures(ListProceduresRequest {
             database: Some("app".into()),
-            cursor: None,
+            ..Default::default()
         })
         .await
         .expect("list_procedures");
 
+    let names = response.procedures.as_brief().expect("brief mode").to_vec();
     for func_name in ["calc_total", "double_it"] {
         assert!(
-            !response.procedures.contains(&func_name.to_string()),
-            "function `{func_name}` leaked into listProcedures output: {:?}",
-            response.procedures
+            !names.contains(&func_name.to_string()),
+            "function `{func_name}` leaked into listProcedures output: {names:?}"
         );
     }
+}
+
+// -----------------------------------------------------------------------
+// listProcedures search + detailed mode (spec 061)
+// -----------------------------------------------------------------------
+
+async fn list_procedures_brief(handler: &PostgresHandler, search: Option<&str>) -> Vec<String> {
+    let response = handler
+        .list_procedures(ListProceduresRequest {
+            database: Some("app".into()),
+            search: search.map(str::to_string),
+            ..Default::default()
+        })
+        .await
+        .expect("list_procedures");
+    response.procedures.as_brief().expect("brief mode").to_vec()
+}
+
+async fn list_procedures_detailed(
+    handler: &PostgresHandler,
+    search: &str,
+) -> indexmap::IndexMap<String, serde_json::Value> {
+    let response = handler
+        .list_procedures(ListProceduresRequest {
+            database: Some("app".into()),
+            search: Some(search.into()),
+            detailed: true,
+            ..Default::default()
+        })
+        .await
+        .expect("list_procedures detailed");
+    response.procedures.as_detailed().expect("detailed mode").clone()
+}
+
+#[tokio::test]
+async fn test_list_procedures_search_filter_returns_only_matches() {
+    let handler = handler(true);
+    let names = list_procedures_brief(&handler, Some("archive_order")).await;
+    assert_eq!(
+        names,
+        vec![
+            "archive_order".to_string(),
+            "archive_order_history".to_string(),
+            "archive_order_history".to_string(),
+        ],
+        "expected three archive_order* matches (overload duplication)"
+    );
+}
+
+#[tokio::test]
+async fn test_list_procedures_search_is_case_insensitive() {
+    let handler = handler(true);
+    let lower = list_procedures_brief(&handler, Some("archive_order")).await;
+    let upper = list_procedures_brief(&handler, Some("ARCHIVE_ORDER")).await;
+    assert_eq!(lower, upper);
+}
+
+#[tokio::test]
+async fn test_list_procedures_search_no_match_returns_empty() {
+    let handler = handler(true);
+    let response = handler
+        .list_procedures(ListProceduresRequest {
+            database: Some("app".into()),
+            search: Some("nonexistent_procedure_xyz".into()),
+            ..Default::default()
+        })
+        .await
+        .expect("list_procedures");
+    assert!(response.procedures.as_brief().expect("brief").is_empty());
+    assert!(response.next_cursor.is_none());
+}
+
+#[tokio::test]
+async fn test_list_procedures_search_supports_wildcard_semantics() {
+    // `_` is the ILIKE single-char wildcard. `a_chive` matches `archive` —
+    // a literal-substring contract would not.
+    let handler = handler(true);
+    let names = list_procedures_brief(&handler, Some("a_chive")).await;
+    assert!(
+        !names.is_empty(),
+        "expected `_` to be honoured as wildcard; empty result implies literal-substring mode"
+    );
+    assert!(
+        names.iter().all(|n| n.contains("archive")),
+        "all wildcard matches should contain `archive`, got {names:?}"
+    );
+}
+
+#[tokio::test]
+async fn test_list_procedures_search_sql_meta_payloads_are_safe() {
+    let handler = handler(true);
+    for payload in ["'", ";", "--", "\\"] {
+        let response = handler
+            .list_procedures(ListProceduresRequest {
+                database: Some("app".into()),
+                search: Some(payload.into()),
+                ..Default::default()
+            })
+            .await
+            .unwrap_or_else(|e| panic!("list_procedures failed for payload {payload:?}: {e:?}"));
+        assert!(
+            response.procedures.as_brief().is_some(),
+            "payload {payload:?} returned non-brief shape"
+        );
+    }
+}
+
+#[tokio::test]
+async fn test_list_procedures_search_paginates_filtered_results() {
+    let paged = handler_with_page_size(1);
+    let mut all = Vec::new();
+    let mut cursor = None;
+    loop {
+        let response = paged
+            .list_procedures(ListProceduresRequest {
+                database: Some("app".into()),
+                cursor,
+                search: Some("archive_order".into()),
+                ..Default::default()
+            })
+            .await
+            .expect("list_procedures paged");
+        all.extend(response.procedures.as_brief().expect("brief").to_vec());
+        cursor = response.next_cursor;
+        if cursor.is_none() {
+            break;
+        }
+    }
+    let single = list_procedures_brief(&handler(true), Some("archive_order")).await;
+    assert_eq!(all, single, "paginated traversal should equal single-page result");
+}
+
+#[tokio::test]
+async fn test_list_procedures_search_empty_is_same_as_no_filter() {
+    let handler = handler(true);
+    let none_filter = list_procedures_brief(&handler, None).await;
+    let empty = list_procedures_brief(&handler, Some("")).await;
+    let whitespace = list_procedures_brief(&handler, Some("   ")).await;
+    assert_eq!(none_filter, empty);
+    assert_eq!(none_filter, whitespace);
+}
+
+#[tokio::test]
+async fn test_list_procedures_excludes_functions_aggregates_and_window() {
+    let handler = handler(true);
+    // Function calc_total (prokind='f') must not appear.
+    let func = list_procedures_brief(&handler, Some("calc_total")).await;
+    assert!(func.is_empty(), "function leaked into listProcedures: {func:?}");
+    // Aggregate sum_demo (prokind='a') must not appear.
+    let agg = list_procedures_brief(&handler, Some("sum_demo")).await;
+    assert!(agg.is_empty(), "aggregate leaked into listProcedures: {agg:?}");
+}
+
+#[tokio::test]
+async fn test_list_procedures_detailed_returns_full_metadata_for_archive_order() {
+    let handler = handler(true);
+    let detailed = list_procedures_detailed(&handler, "archive_order").await;
+    // `archive_order` (single-arg) should be present; the overload pair
+    // `archive_order_history` also matches and shares the search prefix, so the
+    // result has at least three entries — pick the single-arg `archive_order`.
+    let key = detailed
+        .keys()
+        .find(|k| k.starts_with("archive_order(") && !k.starts_with("archive_order_history"))
+        .cloned()
+        .unwrap_or_else(|| {
+            panic!(
+                "archive_order key missing; got {:?}",
+                detailed.keys().collect::<Vec<_>>()
+            )
+        });
+    let entry = &detailed[&key];
+    assert_eq!(entry["schema"], "public");
+    assert_eq!(entry["name"], "archive_order");
+    assert_eq!(entry["language"], "plpgsql");
+    let args = entry["arguments"].as_str().expect("arguments string");
+    assert!(args.contains("order_id integer"), "arguments missing param: {args}");
+    assert_eq!(entry["security"], "INVOKER");
+    assert_eq!(entry["owner"], "app_user");
+    assert_eq!(entry["description"], "Moves an order into the archive table");
+    let definition = entry["definition"].as_str().expect("definition is string");
+    assert!(
+        definition.contains("archive_order"),
+        "definition missing procedure name: {definition}"
+    );
+}
+
+#[tokio::test]
+async fn test_list_procedures_detailed_security_definer() {
+    let handler = handler(true);
+    let detailed = list_procedures_detailed(&handler, "elevate_user_proc").await;
+    let entry = detailed.values().next().expect("elevate_user_proc entry");
+    assert_eq!(entry["security"], "DEFINER");
+    assert_eq!(entry["description"], "Privileged helper - runs as definer.");
+}
+
+#[tokio::test]
+async fn test_list_procedures_detailed_no_comment_yields_null_description() {
+    let handler = handler(true);
+    let detailed = list_procedures_detailed(&handler, "tmp_cleanup").await;
+    let entry = detailed.get("tmp_cleanup()").expect("zero-arg key with empty parens");
+    assert_eq!(entry["arguments"], "");
+    assert!(
+        entry["description"].is_null(),
+        "description should be null, got {:?}",
+        entry["description"]
+    );
+}
+
+#[tokio::test]
+async fn test_list_procedures_detailed_zero_arg_key_uniformity() {
+    let handler = handler(true);
+    let detailed = list_procedures_detailed(&handler, "tmp_cleanup").await;
+    let keys: Vec<&str> = detailed.keys().map(String::as_str).collect();
+    assert!(
+        keys.contains(&"tmp_cleanup()"),
+        "zero-arg key MUST be `tmp_cleanup()` (with empty parens), got {keys:?}"
+    );
+    assert!(
+        !keys.contains(&"tmp_cleanup"),
+        "zero-arg key MUST NOT be bare `tmp_cleanup`; got {keys:?}"
+    );
+}
+
+#[tokio::test]
+async fn test_list_procedures_detailed_multi_arg_signature() {
+    let handler = handler(true);
+    let detailed = list_procedures_detailed(&handler, "summarise_orders").await;
+    let entry = detailed.values().next().expect("summarise_orders entry");
+    let args = entry["arguments"].as_str().expect("arguments string");
+    for substring in [
+        "tenant_id integer",
+        "OUT total integer",
+        "INOUT cursor_name",
+        "VARIADIC tags",
+    ] {
+        assert!(args.contains(substring), "arguments missing {substring:?}: {args}");
+    }
+}
+
+#[tokio::test]
+async fn test_list_procedures_detailed_overload_disambiguation() {
+    let handler = handler(true);
+    let detailed = list_procedures_detailed(&handler, "archive_order_history").await;
+    let keys: Vec<&str> = detailed.keys().map(String::as_str).collect();
+    assert!(
+        keys.iter()
+            .any(|k| k.starts_with("archive_order_history(") && !k.contains("boolean")),
+        "missing single-arg overload key, got {keys:?}"
+    );
+    assert!(
+        keys.iter()
+            .any(|k| k.starts_with("archive_order_history(") && k.contains("boolean")),
+        "missing two-arg overload key (with boolean), got {keys:?}"
+    );
+    assert_eq!(detailed.len(), 2, "expected exactly two overload entries, got {keys:?}");
+}
+
+#[tokio::test]
+async fn test_list_procedures_brief_returns_bare_strings() {
+    let handler = handler(true);
+    let response = handler
+        .list_procedures(ListProceduresRequest {
+            database: Some("app".into()),
+            ..Default::default()
+        })
+        .await
+        .expect("list_procedures");
+    let value = serde_json::to_value(&response).expect("serialise");
+    let arr = value["procedures"]
+        .as_array()
+        .expect("procedures is array in brief mode");
+    for entry in arr {
+        assert!(entry.is_string(), "expected string entry, got {entry:?}");
+    }
+}
+
+#[tokio::test]
+async fn test_list_procedures_detailed_with_search_only_includes_filtered() {
+    let handler = handler(true);
+    let detailed = list_procedures_detailed(&handler, "archive_order_history").await;
+    let keys: Vec<&str> = detailed.keys().map(String::as_str).collect();
+    for excluded in [
+        "archive_user",
+        "archive_order(",
+        "elevate_user_proc",
+        "tmp_cleanup",
+        "summarise_orders",
+        "noop_proc",
+        "touch_post",
+    ] {
+        assert!(
+            !keys.iter().any(|k| k.starts_with(excluded)),
+            "excluded procedure {excluded} leaked: {keys:?}"
+        );
+    }
+}
+
+#[tokio::test]
+async fn test_list_procedures_detailed_paginates() {
+    let paged = handler_with_page_size(1);
+    let mut all_keys = Vec::new();
+    let mut cursor = None;
+    loop {
+        let response = paged
+            .list_procedures(ListProceduresRequest {
+                database: Some("app".into()),
+                cursor,
+                search: Some("archive_order".into()),
+                detailed: true,
+            })
+            .await
+            .expect("list_procedures detailed paged");
+        let page = response.procedures.as_detailed().expect("detailed").clone();
+        assert!(page.len() <= 1, "page size 1 must not exceed 1 entry");
+        all_keys.extend(page.into_keys());
+        cursor = response.next_cursor;
+        if cursor.is_none() {
+            break;
+        }
+    }
+    assert_eq!(
+        all_keys.len(),
+        3,
+        "expected 3 archive_order* entries across pages, got {all_keys:?}"
+    );
+}
+
+#[tokio::test]
+async fn test_list_procedures_detailed_omits_function_only_fields() {
+    let handler = handler(true);
+    let detailed = list_procedures_detailed(&handler, "archive_order").await;
+    let entry = detailed.values().next().expect("at least one entry");
+    let obj = entry.as_object().expect("entry is object");
+    let keys: std::collections::BTreeSet<&str> = obj.keys().map(String::as_str).collect();
+    let expected: std::collections::BTreeSet<&str> = [
+        "schema",
+        "name",
+        "language",
+        "arguments",
+        "security",
+        "owner",
+        "description",
+        "definition",
+    ]
+    .into_iter()
+    .collect();
+    assert_eq!(
+        keys, expected,
+        "detailed entry must carry exactly the eight procedure fields; got {keys:?}"
+    );
 }
 
 #[tokio::test]

--- a/tests/seed/mysql.sql
+++ b/tests/seed/mysql.sql
@@ -206,6 +206,53 @@ CREATE PROCEDURE `app`.`archive_user`(IN uid INT)
 CREATE PROCEDURE `app`.`touch_post`(IN pid INT)
     UPDATE `app`.`posts` SET `title` = `title` WHERE `id` = pid;
 
+-- *archive* / *order* search-target procedures — exercise FR-001 search
+-- semantics and FR-004 detailed-mode coverage (parameter modes, deterministic
+-- flag, sqlDataAccess classification, security mode, comment handling).
+-- Single-statement bodies (no DELIMITER required).
+
+CREATE PROCEDURE `app`.`archive_order_history`(IN order_id INT)
+    DETERMINISTIC
+    CONTAINS SQL
+    SQL SECURITY INVOKER
+    COMMENT 'Archives an order history row'
+    UPDATE `app`.`posts` SET `title` = `title` WHERE `id` = order_id;
+
+CREATE PROCEDURE `app`.`archive_order`(IN n INT, OUT archived_count INT)
+    DETERMINISTIC
+    MODIFIES SQL DATA
+    SQL SECURITY INVOKER
+    COMMENT 'Archives an order and returns the count'
+    SET archived_count = n * 2;
+
+CREATE PROCEDURE `app`.`purge_order_archive`(INOUT counter INT)
+    NOT DETERMINISTIC
+    READS SQL DATA
+    SQL SECURITY INVOKER
+    SET counter = (SELECT COALESCE(MAX(`id`), 0) FROM `app`.`posts`);
+
+CREATE PROCEDURE `app`.`compute_user_metrics`(
+    IN uid INT,
+    OUT metric_total DECIMAL(10,2) UNSIGNED,
+    INOUT metric_avg DECIMAL(10,2)
+)
+    DETERMINISTIC
+    NO SQL
+    SQL SECURITY DEFINER
+    COMMENT 'Multi-mode parameter fixture'
+    SET metric_total = uid * 1.5;
+
+-- Zero-parameter procedure with body containing a literal newline + escaped
+-- single quote — exercises spec Edge Case "procedure body containing literal
+-- newlines, quote characters".
+CREATE PROCEDURE `app`.`no_arg_proc`()
+    DETERMINISTIC
+    NO SQL
+    SQL SECURITY INVOKER
+    COMMENT 'Zero-parameter round-trip fixture'
+    SELECT 'first line
+second line with quote ''here''' AS note;
+
 -- analytics database
 
 DROP DATABASE IF EXISTS `analytics`;

--- a/tests/seed/postgres.sql
+++ b/tests/seed/postgres.sql
@@ -286,6 +286,55 @@ CREATE OR REPLACE PROCEDURE noop_proc()
 LANGUAGE plpgsql
 AS $$ BEGIN END; $$;
 
+-- Additional fixtures for listProcedures search + detailed mode (spec 061):
+-- exercises every metadata field (security/owner/description) and the
+-- overload-disambiguation contract for procedures (prokind='p').
+-- `app_user` role already created above by spec 057's block.
+
+CREATE OR REPLACE PROCEDURE archive_order(order_id integer)
+LANGUAGE plpgsql
+AS $$ BEGIN END; $$;
+COMMENT ON PROCEDURE archive_order(integer) IS 'Moves an order into the archive table';
+ALTER PROCEDURE archive_order(integer) OWNER TO app_user;
+
+-- Overload pair: same name, different parameter signatures.
+CREATE OR REPLACE PROCEDURE archive_order_history(order_id integer)
+LANGUAGE plpgsql AS $$ BEGIN END; $$;
+ALTER PROCEDURE archive_order_history(integer) OWNER TO app_user;
+
+CREATE OR REPLACE PROCEDURE archive_order_history(order_id integer, soft_delete boolean)
+LANGUAGE plpgsql AS $$ BEGIN END; $$;
+ALTER PROCEDURE archive_order_history(integer, boolean) OWNER TO app_user;
+
+-- SECURITY DEFINER procedure (must report security: "DEFINER").
+-- Distinct name from the homonymous function `elevate_user(bigint)`.
+CREATE OR REPLACE PROCEDURE elevate_user_proc(uid bigint)
+LANGUAGE plpgsql
+SECURITY DEFINER
+AS $$ BEGIN END; $$;
+COMMENT ON PROCEDURE elevate_user_proc(bigint) IS 'Privileged helper - runs as definer.';
+
+-- Zero-arg procedure with no comment (description must be null in detailed mode;
+-- detailed-map key must be `tmp_cleanup()`, not `tmp_cleanup`).
+CREATE OR REPLACE PROCEDURE tmp_cleanup()
+LANGUAGE plpgsql
+AS $$ BEGIN END; $$;
+ALTER PROCEDURE tmp_cleanup() OWNER TO app_user;
+
+-- Multi-arg with defaults + IN / OUT / INOUT / VARIADIC.
+-- PostgreSQL forbids OUT parameters after a defaulted IN parameter on
+-- procedures, so `since_days` is non-defaulted here.
+CREATE OR REPLACE PROCEDURE summarise_orders(
+    IN tenant_id integer,
+    IN since_days integer,
+    OUT total integer,
+    INOUT cursor_name text,
+    VARIADIC tags text[]
+)
+LANGUAGE plpgsql
+AS $$ BEGIN total := 0; END; $$;
+ALTER PROCEDURE summarise_orders(integer, integer, text, text[]) OWNER TO app_user;
+
 -- analytics database
 
 DROP DATABASE IF EXISTS analytics;


### PR DESCRIPTION
## Summary

- Adds optional `search` (case-insensitive `LIKE`/`ILIKE` substring; `%`/`_` wildcards honoured) and `detailed: true` to `listProcedures` on PostgreSQL, MySQL, and MariaDB. SQLite has no procedure concept and is untouched.
- Detailed mode returns a JSON object keyed by signature (`name(arguments)` on Postgres to disambiguate overloads; bare name on MySQL/MariaDB) carrying language, arguments, security, definition, and backend-specific extras (Postgres `owner`; MySQL/MariaDB `deterministic`/`sqlDataAccess`/`definer`/session-context fields). Brief-mode wire shape unchanged.
- Drops the now-unused shared `dbmcp_server::types::ListProceduresRequest` (both backends own crate-local request types) and updates README + features.mdx so MySQL capabilities are reflected accurately.

## Test plan

- [x] `cargo fmt --check`
- [x] `cargo clippy --workspace --tests -- -D warnings`
- [x] `cargo test --workspace --lib --bins`
- [ ] `./tests/run.sh` (integration tests against seeded MySQL / MariaDB / Postgres)