### PR TITLE
fix(http): wire --allowed-hosts into rmcp config

### DIFF
--- a/README.md
+++ b/README.md
@@ -173,7 +173,7 @@ A subcommand is required — running `dbmcp` with no subcommand prints usage hel
 | `--host` | `127.0.0.1` | Bind host |
 | `--port` | `9001` | Bind port |
 | `--allowed-origins` | localhost variants | CORS allowed origins (comma-separated) |
-| `--allowed-hosts` | `localhost,127.0.0.1` | Trusted Host headers (comma-separated) |
+| `--allowed-hosts` | `localhost,127.0.0.1,::1` | Trusted Host headers (comma-separated) |
 
 ## MCP Tools 🧩
 

--- a/crates/config/src/config.rs
+++ b/crates/config/src/config.rs
@@ -299,7 +299,7 @@ impl HttpConfig {
     /// Returns default allowed host names.
     #[must_use]
     pub fn default_allowed_hosts() -> Vec<String> {
-        vec!["localhost".into(), "127.0.0.1".into()]
+        vec!["localhost".into(), "127.0.0.1".into(), "::1".into()]
     }
 
     /// Validates the HTTP configuration and returns all errors found.

--- a/docs/content/docs/configuration.mdx
+++ b/docs/content/docs/configuration.mdx
@@ -81,7 +81,7 @@ These options are available only when running in HTTP mode (`dbmcp http`):
 | `--host` | `127.0.0.1` | Bind host for the HTTP server |
 | `--port` | `9001` | Bind port for the HTTP server |
 | `--allowed-origins` | `http://localhost,http://127.0.0.1,https://localhost,https://127.0.0.1` | Allowed CORS origins (comma-separated) |
-| `--allowed-hosts` | `localhost,127.0.0.1` | Allowed host names (comma-separated) |
+| `--allowed-hosts` | `localhost,127.0.0.1,::1` | Allowed host names (comma-separated) |
 
 A transport subcommand is required — running `dbmcp` with no subcommand prints usage help and exits with a non-zero status. The `stdio` transport requires no additional configuration beyond the database options above.
 

--- a/src/commands/http.rs
+++ b/src/commands/http.rs
@@ -117,7 +117,8 @@ impl HttpCommand {
             StreamableHttpServerConfig::default()
                 .with_stateful_mode(false)
                 .with_json_response(true)
-                .with_cancellation_token(cancel_token.child_token()),
+                .with_cancellation_token(cancel_token.child_token())
+                .with_allowed_hosts(http_config.allowed_hosts.clone()),
         );
 
         let router = axum::Router::new()


### PR DESCRIPTION
## Summary

- `HttpConfig.allowed_hosts` (sourced from `--allowed-hosts` / `HTTP_ALLOWED_HOSTS`) was parsed and validated but never reached `rmcp::StreamableHttpServerConfig`. rmcp therefore enforced its hardcoded loopback default and rejected any operator-configured `Host` header with `403 Forbidden: Host header is not allowed`, blocking reverse-proxy deployments behind a real public domain.
- Forward the configured list via `.with_allowed_hosts(...)` on the streamable-HTTP builder.
- Extend the default to `localhost,127.0.0.1,::1` (was `localhost,127.0.0.1`) so existing local-dev workflows over the IPv6 loopback keep working — matches rmcp's prior runtime default. README and `configuration.mdx` updated to match.

Closes #132

## Test plan

- [ ] `cargo fmt && cargo clippy --workspace --tests -- -D warnings` clean
- [ ] `cargo test --workspace --lib --bins` green
- [ ] Manual repro from #132 (no Docker needed):
      ```
      cargo run --release -- http \
          --db-backend sqlite --db-name :memory: \
          --host 127.0.0.1 --port 9001 \
          --allowed-hosts example.public.domain
      curl -i http://127.0.0.1:9001/mcp -H "Host: example.public.domain"
      # post-fix: NOT `403 Forbidden: Host header is not allowed`
      curl -i http://127.0.0.1:9001/mcp -H "Host: other.example"
      # still 403, as intended
      ```
- [ ] Default behavior unchanged for operators who do not set `--allowed-hosts`: `localhost`, `127.0.0.1`, `::1` accepted; everything else rejected.