### PR TITLE
refactor(sanitize): replace ident validation with quote-only path

### DIFF
--- a/crates/mysql/src/connection.rs
+++ b/crates/mysql/src/connection.rs
@@ -9,7 +9,6 @@ use std::time::Duration;
 use dbmcp_config::DatabaseConfig;
 use dbmcp_sql::Connection;
 use dbmcp_sql::SqlError;
-use dbmcp_sql::sanitize::validate_ident;
 use moka::future::Cache;
 use sqlx::mysql::{MySqlConnectOptions, MySqlPool, MySqlSslMode};
 use tracing::info;
@@ -77,7 +76,7 @@ impl MysqlConnection {
     ///
     /// # Errors
     ///
-    /// - [`SqlError::InvalidIdentifier`] — `target` failed identifier validation.
+    /// Returns [`SqlError`] if the underlying pool creation fails.
     pub(crate) async fn pool(&self, target: Option<&str>) -> Result<MySqlPool, SqlError> {
         let database = match target {
             Some(name) if !name.is_empty() => name,
@@ -86,11 +85,6 @@ impl MysqlConnection {
 
         if let Some(pool) = self.pools.get(database).await {
             return Ok(pool);
-        }
-
-        let default = self.default_database_name();
-        if default.is_empty() || !default.eq_ignore_ascii_case(database) {
-            validate_ident(database)?;
         }
 
         let pool = self
@@ -113,7 +107,6 @@ impl Connection for MysqlConnection {
         self.config.query_timeout
     }
 }
-
 /// Creates a lazy `MySQL` pool for `db_name`.
 ///
 /// Combines pool lifecycle options with backend-specific connect
@@ -163,6 +156,12 @@ fn create_lazy_pool(config: &DatabaseConfig, database: &str) -> MySqlPool {
     }
 
     pool_opts.connect_lazy_with(conn_ops)
+}
+
+/// Quotes `value` as a `MySQL` identifier (backtick-wrapped).
+#[must_use]
+pub(crate) fn quote_ident(value: &str) -> String {
+    dbmcp_sql::sanitize::quote_ident(value, '`')
 }
 
 #[cfg(test)]

--- a/crates/mysql/src/tools/create_database.rs
+++ b/crates/mysql/src/tools/create_database.rs
@@ -5,12 +5,11 @@ use std::borrow::Cow;
 use dbmcp_server::types::{CreateDatabaseRequest, MessageResponse};
 use dbmcp_sql::Connection as _;
 use dbmcp_sql::SqlError;
-use dbmcp_sql::sanitize::{quote_ident, quote_literal, validate_ident};
 use rmcp::handler::server::router::tool::{AsyncTool, ToolBase};
 use rmcp::model::{ErrorData, ToolAnnotations};
-use sqlparser::dialect::MySqlDialect;
 
 use crate::MysqlHandler;
+use crate::connection::quote_ident;
 
 /// Marker type for the `createDatabase` MCP tool.
 pub(crate) struct CreateDatabaseTool;
@@ -32,7 +31,7 @@ Use when:
 </examples>
 
 <important>
-Database names must contain only alphanumeric characters and underscores.
+Database name must be non-empty; backend reserved-character rules apply.
 If the database already exists, returns a message indicating so without error.
 </important>
 
@@ -89,17 +88,18 @@ impl MysqlHandler {
             return Err(SqlError::ReadOnlyViolation);
         }
 
-        validate_ident(&database)?;
-
-        let check_sql = format!(
-            r"
-            SELECT CAST(SCHEMA_NAME AS CHAR)
-            FROM information_schema.SCHEMATA
-            WHERE SCHEMA_NAME = {}",
-            quote_literal(&database),
-        );
-
-        let exists: Option<String> = self.connection.fetch_optional(check_sql.as_str(), None).await?;
+        let exists: Option<String> = self
+            .connection
+            .fetch_optional(
+                sqlx::query(
+                    "SELECT CAST(SCHEMA_NAME AS CHAR) \
+                     FROM information_schema.SCHEMATA \
+                     WHERE SCHEMA_NAME = ?",
+                )
+                .bind(&database),
+                None,
+            )
+            .await?;
 
         if exists.is_some() {
             return Ok(MessageResponse {
@@ -107,10 +107,7 @@ impl MysqlHandler {
             });
         }
 
-        let create_sql = format!(
-            "CREATE DATABASE IF NOT EXISTS {}",
-            quote_ident(&database, &MySqlDialect {})
-        );
+        let create_sql = format!("CREATE DATABASE IF NOT EXISTS {}", quote_ident(&database));
 
         self.connection.execute(create_sql.as_str(), None).await?;
 

--- a/crates/mysql/src/tools/drop_database.rs
+++ b/crates/mysql/src/tools/drop_database.rs
@@ -5,12 +5,11 @@ use std::borrow::Cow;
 use dbmcp_server::types::{DropDatabaseRequest, MessageResponse};
 use dbmcp_sql::Connection as _;
 use dbmcp_sql::SqlError;
-use dbmcp_sql::sanitize::{quote_ident, validate_ident};
 use rmcp::handler::server::router::tool::{AsyncTool, ToolBase};
 use rmcp::model::{ErrorData, ToolAnnotations};
-use sqlparser::dialect::MySqlDialect;
 
 use crate::MysqlHandler;
+use crate::connection::quote_ident;
 
 /// Marker type for the `dropDatabase` MCP tool.
 pub(crate) struct DropDatabaseTool;
@@ -94,8 +93,6 @@ impl MysqlHandler {
             return Err(SqlError::ReadOnlyViolation);
         }
 
-        validate_ident(&database)?;
-
         // Guard: prevent dropping the currently connected database.
         if self.connection.default_database_name().eq_ignore_ascii_case(&database) {
             return Err(SqlError::Query(format!(
@@ -103,7 +100,7 @@ impl MysqlHandler {
             )));
         }
 
-        let drop_sql = format!("DROP DATABASE {}", quote_ident(&database, &MySqlDialect {}));
+        let drop_sql = format!("DROP DATABASE {}", quote_ident(&database));
         self.connection.execute(drop_sql.as_str(), None).await?;
 
         // Evict the pool for the dropped database so stale connections

--- a/crates/mysql/src/tools/drop_table.rs
+++ b/crates/mysql/src/tools/drop_table.rs
@@ -5,12 +5,11 @@ use std::borrow::Cow;
 use dbmcp_server::types::MessageResponse;
 use dbmcp_sql::Connection as _;
 use dbmcp_sql::SqlError;
-use dbmcp_sql::sanitize::{quote_ident, validate_ident};
 use rmcp::handler::server::router::tool::{AsyncTool, ToolBase};
 use rmcp::model::{ErrorData, ToolAnnotations};
-use sqlparser::dialect::MySqlDialect;
 
 use crate::MysqlHandler;
+use crate::connection::quote_ident;
 use crate::types::DropTableRequest;
 
 /// Marker type for the `dropTable` MCP tool.
@@ -96,16 +95,9 @@ impl MysqlHandler {
             return Err(SqlError::ReadOnlyViolation);
         }
 
-        let database = database
-            .as_deref()
-            .map(str::trim)
-            .filter(|s| !s.is_empty())
-            .map(validate_ident)
-            .transpose()?;
+        let database = database.as_deref().map(str::trim).filter(|s| !s.is_empty());
 
-        validate_ident(&table)?;
-
-        let drop_sql = format!("DROP TABLE {}", quote_ident(&table, &MySqlDialect {}));
+        let drop_sql = format!("DROP TABLE {}", quote_ident(&table));
         self.connection.execute(drop_sql.as_str(), database).await?;
 
         Ok(MessageResponse {

--- a/crates/mysql/src/tools/explain_query.rs
+++ b/crates/mysql/src/tools/explain_query.rs
@@ -5,7 +5,6 @@ use std::borrow::Cow;
 use dbmcp_server::types::{ExplainQueryRequest, QueryResponse};
 use dbmcp_sql::Connection as _;
 use dbmcp_sql::SqlError;
-use dbmcp_sql::sanitize::validate_ident;
 use dbmcp_sql::validation::validate_read_only;
 use rmcp::handler::server::router::tool::{AsyncTool, ToolBase};
 use rmcp::model::{ErrorData, ToolAnnotations};
@@ -107,12 +106,7 @@ impl MysqlHandler {
             let _ = validate_read_only(&query, &sqlparser::dialect::MySqlDialect {})?;
         }
 
-        let database = database
-            .as_deref()
-            .map(str::trim)
-            .filter(|s| !s.is_empty())
-            .map(validate_ident)
-            .transpose()?;
+        let database = database.as_deref().map(str::trim).filter(|s| !s.is_empty());
 
         let explain_sql = if analyze {
             format!("EXPLAIN ANALYZE {query}")

--- a/crates/mysql/src/tools/list_functions.rs
+++ b/crates/mysql/src/tools/list_functions.rs
@@ -5,7 +5,6 @@ use std::borrow::Cow;
 use dbmcp_server::pagination::Pager;
 use dbmcp_server::types::ListFunctionsResponse;
 use dbmcp_sql::Connection as _;
-use dbmcp_sql::sanitize::validate_ident;
 use rmcp::handler::server::router::tool::{AsyncTool, ToolBase};
 use rmcp::model::{ErrorData, ToolAnnotations};
 
@@ -210,13 +209,11 @@ impl MysqlHandler {
             detailed,
         }: ListFunctionsRequest,
     ) -> Result<ListFunctionsResponse, ErrorData> {
-        let database = validate_ident(
-            database
-                .as_deref()
-                .map(str::trim)
-                .filter(|s| !s.is_empty())
-                .unwrap_or_else(|| self.connection.default_database_name()),
-        )?;
+        let database = database
+            .as_deref()
+            .map(str::trim)
+            .filter(|s| !s.is_empty())
+            .unwrap_or_else(|| self.connection.default_database_name());
 
         let pattern = search.as_deref().map(str::trim).filter(|s| !s.is_empty());
         let pager = Pager::new(cursor, self.config.page_size);

--- a/crates/mysql/src/tools/list_procedures.rs
+++ b/crates/mysql/src/tools/list_procedures.rs
@@ -4,7 +4,6 @@ use std::borrow::Cow;
 
 use dbmcp_server::pagination::Pager;
 use dbmcp_sql::Connection as _;
-use dbmcp_sql::sanitize::validate_ident;
 use rmcp::handler::server::router::tool::{AsyncTool, ToolBase};
 use rmcp::model::{ErrorData, ToolAnnotations};
 
@@ -219,13 +218,11 @@ impl MysqlHandler {
             detailed,
         }: ListProceduresRequest,
     ) -> Result<ListProceduresResponse, ErrorData> {
-        let database = validate_ident(
-            database
-                .as_deref()
-                .map(str::trim)
-                .filter(|s| !s.is_empty())
-                .unwrap_or_else(|| self.connection.default_database_name()),
-        )?;
+        let database = database
+            .as_deref()
+            .map(str::trim)
+            .filter(|s| !s.is_empty())
+            .unwrap_or_else(|| self.connection.default_database_name());
 
         let pattern = search.as_deref().map(str::trim).filter(|s| !s.is_empty());
         let pager = Pager::new(cursor, self.config.page_size);

--- a/crates/mysql/src/tools/list_tables.rs
+++ b/crates/mysql/src/tools/list_tables.rs
@@ -4,7 +4,6 @@ use std::borrow::Cow;
 
 use dbmcp_server::pagination::Pager;
 use dbmcp_sql::Connection as _;
-use dbmcp_sql::sanitize::validate_ident;
 use rmcp::handler::server::router::tool::{AsyncTool, ToolBase};
 use rmcp::model::{ErrorData, ToolAnnotations};
 
@@ -379,13 +378,11 @@ impl MysqlHandler {
             detailed,
         }: ListTablesRequest,
     ) -> Result<ListTablesResponse, ErrorData> {
-        let database = validate_ident(
-            database
-                .as_deref()
-                .map(str::trim)
-                .filter(|s| !s.is_empty())
-                .unwrap_or_else(|| self.connection.default_database_name()),
-        )?;
+        let database = database
+            .as_deref()
+            .map(str::trim)
+            .filter(|s| !s.is_empty())
+            .unwrap_or_else(|| self.connection.default_database_name());
 
         let pattern = search.as_deref().map(str::trim).filter(|s| !s.is_empty());
         let pager = Pager::new(cursor, self.config.page_size);

--- a/crates/mysql/src/tools/list_triggers.rs
+++ b/crates/mysql/src/tools/list_triggers.rs
@@ -5,7 +5,6 @@ use std::borrow::Cow;
 use dbmcp_server::pagination::Pager;
 use dbmcp_server::types::{ListTriggersRequest, ListTriggersResponse};
 use dbmcp_sql::Connection as _;
-use dbmcp_sql::sanitize::validate_ident;
 use rmcp::handler::server::router::tool::{AsyncTool, ToolBase};
 use rmcp::model::{ErrorData, ToolAnnotations};
 
@@ -163,13 +162,11 @@ impl MysqlHandler {
             detailed,
         }: ListTriggersRequest,
     ) -> Result<ListTriggersResponse, ErrorData> {
-        let database = validate_ident(
-            database
-                .as_deref()
-                .map(str::trim)
-                .filter(|s| !s.is_empty())
-                .unwrap_or_else(|| self.connection.default_database_name()),
-        )?;
+        let database = database
+            .as_deref()
+            .map(str::trim)
+            .filter(|s| !s.is_empty())
+            .unwrap_or_else(|| self.connection.default_database_name());
 
         let pattern = search.as_deref().map(str::trim).filter(|s| !s.is_empty());
         let pager = Pager::new(cursor, self.config.page_size);

--- a/crates/mysql/src/tools/list_views.rs
+++ b/crates/mysql/src/tools/list_views.rs
@@ -4,7 +4,6 @@ use std::borrow::Cow;
 
 use dbmcp_server::pagination::Pager;
 use dbmcp_sql::Connection as _;
-use dbmcp_sql::sanitize::validate_ident;
 use rmcp::handler::server::router::tool::{AsyncTool, ToolBase};
 use rmcp::model::{ErrorData, ToolAnnotations};
 
@@ -149,13 +148,11 @@ impl MysqlHandler {
             detailed,
         }: ListViewsRequest,
     ) -> Result<ListViewsResponse, ErrorData> {
-        let database = validate_ident(
-            database
-                .as_deref()
-                .map(str::trim)
-                .filter(|s| !s.is_empty())
-                .unwrap_or_else(|| self.connection.default_database_name()),
-        )?;
+        let database = database
+            .as_deref()
+            .map(str::trim)
+            .filter(|s| !s.is_empty())
+            .unwrap_or_else(|| self.connection.default_database_name());
 
         let pattern = search.as_deref().map(str::trim).filter(|s| !s.is_empty());
         let pager = Pager::new(cursor, self.config.page_size);

--- a/crates/mysql/src/tools/read_query.rs
+++ b/crates/mysql/src/tools/read_query.rs
@@ -8,7 +8,6 @@ use dbmcp_sql::Connection as _;
 use dbmcp_sql::SqlError;
 use dbmcp_sql::StatementKind;
 use dbmcp_sql::pagination::with_limit_offset;
-use dbmcp_sql::sanitize::validate_ident;
 use dbmcp_sql::validation::validate_read_only;
 use rmcp::handler::server::router::tool::{AsyncTool, ToolBase};
 use rmcp::model::{ErrorData, ToolAnnotations};
@@ -113,12 +112,7 @@ impl MysqlHandler {
     ) -> Result<ReadQueryResponse, SqlError> {
         let kind = validate_read_only(&query, &sqlparser::dialect::MySqlDialect {})?;
 
-        let database = database
-            .as_deref()
-            .map(str::trim)
-            .filter(|s| !s.is_empty())
-            .map(validate_ident)
-            .transpose()?;
+        let database = database.as_deref().map(str::trim).filter(|s| !s.is_empty());
 
         match kind {
             StatementKind::Select => {

--- a/crates/mysql/src/tools/write_query.rs
+++ b/crates/mysql/src/tools/write_query.rs
@@ -5,7 +5,6 @@ use std::borrow::Cow;
 use dbmcp_server::types::{QueryRequest, QueryResponse};
 use dbmcp_sql::Connection as _;
 use dbmcp_sql::SqlError;
-use dbmcp_sql::sanitize::validate_ident;
 use rmcp::handler::server::router::tool::{AsyncTool, ToolBase};
 use rmcp::model::{ErrorData, ToolAnnotations};
 
@@ -85,12 +84,7 @@ impl MysqlHandler {
     ///
     /// Returns [`SqlError`] if the query fails.
     pub async fn write_query(&self, QueryRequest { query, database }: QueryRequest) -> Result<QueryResponse, SqlError> {
-        let database = database
-            .as_deref()
-            .map(str::trim)
-            .filter(|s| !s.is_empty())
-            .map(validate_ident)
-            .transpose()?;
+        let database = database.as_deref().map(str::trim).filter(|s| !s.is_empty());
 
         let rows = self.connection.fetch_json(query.as_str(), database).await?;
 

--- a/crates/mysql/src/types.rs
+++ b/crates/mysql/src/types.rs
@@ -19,7 +19,7 @@ pub struct DropTableRequest {
     /// Database containing the table. Defaults to the active database.
     #[serde(default)]
     pub database: Option<String>,
-    /// Name of the table to drop. Must contain only alphanumeric characters and underscores.
+    /// Name of the table to drop. Must be non-empty.
     pub table: String,
 }
 

--- a/crates/postgres/src/connection.rs
+++ b/crates/postgres/src/connection.rs
@@ -9,7 +9,6 @@ use std::time::Duration;
 use dbmcp_config::DatabaseConfig;
 use dbmcp_sql::Connection;
 use dbmcp_sql::SqlError;
-use dbmcp_sql::sanitize::validate_ident;
 use moka::future::Cache;
 use sqlx::postgres::{PgConnectOptions, PgPool, PgSslMode};
 use tracing::info;
@@ -81,7 +80,7 @@ impl PostgresConnection {
     ///
     /// # Errors
     ///
-    /// - [`SqlError::InvalidIdentifier`] — `target` failed identifier validation.
+    /// Returns [`SqlError`] if the underlying pool creation fails.
     pub(crate) async fn pool(&self, target: Option<&str>) -> Result<PgPool, SqlError> {
         let database = match target {
             Some(name) if !name.is_empty() => name,
@@ -90,10 +89,6 @@ impl PostgresConnection {
 
         if let Some(pool) = self.pools.get(database).await {
             return Ok(pool);
-        }
-
-        if database != self.default_database_name() {
-            validate_ident(database)?;
         }
 
         let pool = self
@@ -116,7 +111,6 @@ impl Connection for PostgresConnection {
         self.config.query_timeout
     }
 }
-
 /// Creates a lazy `PostgreSQL` pool for `db_name`.
 ///
 /// Uses [`PgConnectOptions::new_without_pgpass`] to avoid unintended
@@ -163,6 +157,12 @@ fn create_lazy_pool(config: &DatabaseConfig, database: &str) -> PgPool {
     }
 
     pool_opts.connect_lazy_with(conn_ops)
+}
+
+/// Quotes `value` as a `PostgreSQL` identifier (ANSI double-quote style).
+#[must_use]
+pub(crate) fn quote_ident(value: &str) -> String {
+    dbmcp_sql::sanitize::quote_ident(value, '"')
 }
 
 #[cfg(test)]
@@ -259,31 +259,5 @@ mod tests {
             "cached pools exceeded cap: {} > {POOL_CACHE_CAPACITY}",
             connection.pools.entry_count()
         );
-    }
-
-    #[tokio::test]
-    async fn fetch_scalar_rejects_invalid_database_identifier() {
-        let connection = PostgresConnection::new(&base_config());
-        let result: Result<Vec<String>, SqlError> = connection
-            .fetch_scalar(sqlx::query("SELECT $1::text").bind("x"), Some("bad\0name"))
-            .await;
-        match result {
-            Err(SqlError::InvalidIdentifier(_)) => {}
-            Err(other) => panic!("expected InvalidIdentifier, got: {other}"),
-            Ok(_) => panic!("expected error, got Ok"),
-        }
-    }
-
-    #[tokio::test]
-    async fn fetch_json_rejects_invalid_database_identifier() {
-        let connection = PostgresConnection::new(&base_config());
-        let result = connection
-            .fetch_json(sqlx::query("SELECT $1::int AS n").bind(1_i32), Some("bad\nname"))
-            .await;
-        match result {
-            Err(SqlError::InvalidIdentifier(_)) => {}
-            Err(other) => panic!("expected InvalidIdentifier, got: {other}"),
-            Ok(_) => panic!("expected error, got Ok"),
-        }
     }
 }

--- a/crates/postgres/src/tools/create_database.rs
+++ b/crates/postgres/src/tools/create_database.rs
@@ -5,12 +5,11 @@ use std::borrow::Cow;
 use dbmcp_server::types::{CreateDatabaseRequest, MessageResponse};
 use dbmcp_sql::Connection as _;
 use dbmcp_sql::SqlError;
-use dbmcp_sql::sanitize::{quote_ident, validate_ident};
 use rmcp::handler::server::router::tool::{AsyncTool, ToolBase};
 use rmcp::model::{ErrorData, ToolAnnotations};
-use sqlparser::dialect::PostgreSqlDialect;
 
 use crate::PostgresHandler;
+use crate::connection::quote_ident;
 
 /// Marker type for the `createDatabase` MCP tool.
 pub(crate) struct CreateDatabaseTool;
@@ -32,7 +31,7 @@ Use when:
 </examples>
 
 <important>
-Database names must contain only alphanumeric characters and underscores.
+Database name must be non-empty; backend reserved-character rules apply.
 </important>
 
 <what_it_returns>
@@ -88,9 +87,7 @@ impl PostgresHandler {
             return Err(SqlError::ReadOnlyViolation);
         }
 
-        validate_ident(&database)?;
-
-        let create_sql = format!("CREATE DATABASE {}", quote_ident(&database, &PostgreSqlDialect {}));
+        let create_sql = format!("CREATE DATABASE {}", quote_ident(&database));
         self.connection.execute(create_sql.as_str(), None).await.map_err(|e| {
             let msg = e.to_string();
             if msg.contains("already exists") {

--- a/crates/postgres/src/tools/drop_database.rs
+++ b/crates/postgres/src/tools/drop_database.rs
@@ -5,12 +5,11 @@ use std::borrow::Cow;
 use dbmcp_server::types::{DropDatabaseRequest, MessageResponse};
 use dbmcp_sql::Connection as _;
 use dbmcp_sql::SqlError;
-use dbmcp_sql::sanitize::{quote_ident, validate_ident};
 use rmcp::handler::server::router::tool::{AsyncTool, ToolBase};
 use rmcp::model::{ErrorData, ToolAnnotations};
-use sqlparser::dialect::PostgreSqlDialect;
 
 use crate::PostgresHandler;
+use crate::connection::quote_ident;
 
 /// Marker type for the `dropDatabase` MCP tool.
 pub(crate) struct DropDatabaseTool;
@@ -95,8 +94,6 @@ impl PostgresHandler {
             return Err(SqlError::ReadOnlyViolation);
         }
 
-        validate_ident(&database)?;
-
         // Guard: prevent dropping the currently connected database.
         if self.connection.default_database_name() == database.as_str() {
             return Err(SqlError::Query(format!(
@@ -104,7 +101,7 @@ impl PostgresHandler {
             )));
         }
 
-        let drop_sql = format!("DROP DATABASE {}", quote_ident(&database, &PostgreSqlDialect {}));
+        let drop_sql = format!("DROP DATABASE {}", quote_ident(&database));
         self.connection.execute(drop_sql.as_str(), None).await?;
 
         self.connection.invalidate(&database).await;

--- a/crates/postgres/src/tools/drop_table.rs
+++ b/crates/postgres/src/tools/drop_table.rs
@@ -5,12 +5,11 @@ use std::borrow::Cow;
 use dbmcp_server::types::MessageResponse;
 use dbmcp_sql::Connection as _;
 use dbmcp_sql::SqlError;
-use dbmcp_sql::sanitize::{quote_ident, validate_ident};
 use rmcp::handler::server::router::tool::{AsyncTool, ToolBase};
 use rmcp::model::{ErrorData, ToolAnnotations};
-use sqlparser::dialect::PostgreSqlDialect;
 
 use crate::PostgresHandler;
+use crate::connection::quote_ident;
 use crate::types::DropTableRequest;
 
 /// Marker type for the `dropTable` MCP tool.
@@ -103,15 +102,9 @@ impl PostgresHandler {
             return Err(SqlError::ReadOnlyViolation);
         }
 
-        let database = database
-            .as_deref()
-            .map(str::trim)
-            .filter(|s| !s.is_empty())
-            .map(validate_ident)
-            .transpose()?;
-        validate_ident(&table)?;
+        let database = database.as_deref().map(str::trim).filter(|s| !s.is_empty());
 
-        let mut drop_sql = format!("DROP TABLE {}", quote_ident(&table, &PostgreSqlDialect {}));
+        let mut drop_sql = format!("DROP TABLE {}", quote_ident(&table));
         if cascade {
             drop_sql.push_str(" CASCADE");
         }

--- a/crates/postgres/src/tools/explain_query.rs
+++ b/crates/postgres/src/tools/explain_query.rs
@@ -5,7 +5,6 @@ use std::borrow::Cow;
 use dbmcp_server::types::{ExplainQueryRequest, QueryResponse};
 use dbmcp_sql::Connection as _;
 use dbmcp_sql::SqlError;
-use dbmcp_sql::sanitize::validate_ident;
 use dbmcp_sql::validation::validate_read_only;
 use rmcp::handler::server::router::tool::{AsyncTool, ToolBase};
 use rmcp::model::{ErrorData, ToolAnnotations};
@@ -107,12 +106,7 @@ impl PostgresHandler {
             let _ = validate_read_only(&query, &sqlparser::dialect::PostgreSqlDialect {})?;
         }
 
-        let database = database
-            .as_deref()
-            .map(str::trim)
-            .filter(|s| !s.is_empty())
-            .map(validate_ident)
-            .transpose()?;
+        let database = database.as_deref().map(str::trim).filter(|s| !s.is_empty());
 
         let explain_sql = if analyze {
             format!("EXPLAIN (ANALYZE, FORMAT JSON) {query}")

--- a/crates/postgres/src/tools/read_query.rs
+++ b/crates/postgres/src/tools/read_query.rs
@@ -8,7 +8,6 @@ use dbmcp_sql::Connection as _;
 use dbmcp_sql::SqlError;
 use dbmcp_sql::StatementKind;
 use dbmcp_sql::pagination::with_limit_offset;
-use dbmcp_sql::sanitize::validate_ident;
 use dbmcp_sql::validation::validate_read_only;
 use rmcp::handler::server::router::tool::{AsyncTool, ToolBase};
 use rmcp::model::{ErrorData, ToolAnnotations};
@@ -110,12 +109,7 @@ impl PostgresHandler {
         }: ReadQueryRequest,
     ) -> Result<ReadQueryResponse, SqlError> {
         let kind = validate_read_only(&query, &sqlparser::dialect::PostgreSqlDialect {})?;
-        let database = database
-            .as_deref()
-            .map(str::trim)
-            .filter(|s| !s.is_empty())
-            .map(validate_ident)
-            .transpose()?;
+        let database = database.as_deref().map(str::trim).filter(|s| !s.is_empty());
 
         match kind {
             StatementKind::Select => {

--- a/crates/postgres/src/tools/write_query.rs
+++ b/crates/postgres/src/tools/write_query.rs
@@ -5,7 +5,6 @@ use std::borrow::Cow;
 use dbmcp_server::types::{QueryRequest, QueryResponse};
 use dbmcp_sql::Connection as _;
 use dbmcp_sql::SqlError;
-use dbmcp_sql::sanitize::validate_ident;
 use rmcp::handler::server::router::tool::{AsyncTool, ToolBase};
 use rmcp::model::{ErrorData, ToolAnnotations};
 
@@ -85,12 +84,7 @@ impl PostgresHandler {
     ///
     /// Returns [`SqlError`] if the query fails.
     pub async fn write_query(&self, QueryRequest { query, database }: QueryRequest) -> Result<QueryResponse, SqlError> {
-        let database = database
-            .as_deref()
-            .map(str::trim)
-            .filter(|s| !s.is_empty())
-            .map(validate_ident)
-            .transpose()?;
+        let database = database.as_deref().map(str::trim).filter(|s| !s.is_empty());
         let rows = self.connection.fetch_json(query.as_str(), database).await?;
         Ok(QueryResponse { rows })
     }

--- a/crates/postgres/src/types.rs
+++ b/crates/postgres/src/types.rs
@@ -23,7 +23,7 @@ pub struct DropTableRequest {
     /// Database containing the table. Defaults to the active database.
     #[serde(default)]
     pub database: Option<String>,
-    /// Name of the table to drop. Must contain only alphanumeric characters and underscores.
+    /// Name of the table to drop. Must be non-empty.
     pub table: String,
     /// If true, use CASCADE to also drop dependent foreign key constraints. Defaults to false.
     #[serde(default)]

--- a/crates/server/src/types.rs
+++ b/crates/server/src/types.rs
@@ -121,7 +121,7 @@ pub struct ListDatabasesResponse {
 #[derive(Debug, Default, Deserialize, JsonSchema)]
 #[serde(rename_all = "camelCase")]
 pub struct CreateDatabaseRequest {
-    /// Name of the database to create. Must contain only alphanumeric characters and underscores.
+    /// Name of the database to create. Must be non-empty.
     pub database: String,
 }
 
@@ -129,7 +129,7 @@ pub struct CreateDatabaseRequest {
 #[derive(Debug, Default, Deserialize, JsonSchema)]
 #[serde(rename_all = "camelCase")]
 pub struct DropDatabaseRequest {
-    /// Name of the database to drop. Must contain only alphanumeric characters and underscores.
+    /// Name of the database to drop. Must be non-empty.
     pub database: String,
 }
 

--- a/crates/sql/src/lib.rs
+++ b/crates/sql/src/lib.rs
@@ -1,11 +1,10 @@
 //! SQL sanitization, validation, and connection utilities.
 //!
-//! Provides [`sanitize`] helpers for quoting and validating SQL
-//! identifiers and literals, [`validation`] for read-only query
-//! enforcement, [`pagination`] for rewriting `SELECT` statements
-//! with a server-controlled `LIMIT` / `OFFSET`, [`timeout`] for
-//! query-level timeout wrapping, and the [`connection`] trait
-//! shared by every backend.
+//! Provides [`sanitize`] helpers for quoting SQL identifiers,
+//! [`validation`] for read-only query enforcement, [`pagination`]
+//! for rewriting `SELECT` statements with a server-controlled
+//! `LIMIT` / `OFFSET`, [`timeout`] for query-level timeout wrapping,
+//! and the [`connection`] trait shared by every backend.
 
 pub mod connection;
 pub mod error;

--- a/crates/sql/src/sanitize.rs
+++ b/crates/sql/src/sanitize.rs
@@ -1,278 +1,83 @@
-//! SQL quoting and validation for identifiers and literals.
+//! Identifier-safety primitives shared across SQL backends.
 
-use crate::SqlError;
-use sqlparser::dialect::Dialect;
-
-/// Wraps `value` in the dialect's identifier quote character.
+/// Quotes `value` as a SQL identifier using `quote`.
 ///
-/// Derives the quote character from [`Dialect::identifier_quote_style`],
-/// falling back to `"` (ANSI double-quote) when the dialect returns `None`.
-/// Escapes internal occurrences of the quote character by doubling them.
+/// Wraps the value in `quote` and doubles every internal occurrence of `quote`.
 #[must_use]
-pub fn quote_ident(value: &str, dialect: &impl Dialect) -> String {
-    let q = dialect.identifier_quote_style(value).unwrap_or('"');
+pub fn quote_ident(value: &str, quote: char) -> String {
     let mut out = String::with_capacity(value.len() + 2);
-    out.push(q);
+    out.push(quote);
     for ch in value.chars() {
-        if ch == q {
-            out.push(q);
+        if ch == quote {
+            out.push(quote);
         }
         out.push(ch);
     }
-    out.push(q);
+    out.push(quote);
     out
-}
-
-/// Wraps `value` in single quotes for use as a SQL string literal.
-///
-/// Escapes backslashes and single quotes by doubling them. Backslash
-/// doubling is required for safety under `MySQL`'s default SQL mode,
-/// which treats `\` as an escape character inside string literals.
-#[must_use]
-pub fn quote_literal(value: &str) -> String {
-    let mut out = String::with_capacity(value.len() + 2);
-    out.push('\'');
-    for ch in value.chars() {
-        if ch == '\\' {
-            out.push('\\');
-        } else if ch == '\'' {
-            out.push('\'');
-        }
-        out.push(ch);
-    }
-    out.push('\'');
-    out
-}
-
-/// Validates that `name` is a non-empty identifier without control characters.
-///
-/// Returns the input on success so the call composes inside iterator chains
-/// (e.g. `Option::map(validate_ident).transpose()?`).
-///
-/// # Errors
-///
-/// Returns [`SqlError::InvalidIdentifier`] if the name is empty,
-/// whitespace-only, or contains control characters.
-pub fn validate_ident(name: &str) -> Result<&str, SqlError> {
-    if name.trim().is_empty() || name.chars().any(char::is_control) {
-        return Err(SqlError::InvalidIdentifier(name.to_string()));
-    }
-    Ok(name)
 }
 
 #[cfg(test)]
 mod tests {
-    use sqlparser::dialect::{MySqlDialect, PostgreSqlDialect, SQLiteDialect};
-
     use super::*;
 
     #[test]
-    fn accepts_standard_names() {
-        assert!(validate_ident("users").is_ok());
-        assert!(validate_ident("my_table").is_ok());
-        assert!(validate_ident("DB_123").is_ok());
+    fn quote_ident_basic_double_quote() {
+        assert_eq!(quote_ident("users", '"'), "\"users\"");
+        assert_eq!(quote_ident("eu-docker", '"'), "\"eu-docker\"");
+        assert_eq!(quote_ident("test\"db", '"'), "\"test\"\"db\"");
     }
 
     #[test]
-    fn accepts_hyphenated_names() {
-        assert!(validate_ident("eu-docker").is_ok());
-        assert!(validate_ident("access-logs").is_ok());
+    fn quote_ident_basic_backtick() {
+        assert_eq!(quote_ident("users", '`'), "`users`");
+        assert_eq!(quote_ident("eu-docker", '`'), "`eu-docker`");
+        assert_eq!(quote_ident("test`db", '`'), "`test``db`");
     }
 
     #[test]
-    fn accepts_special_chars() {
-        assert!(validate_ident("my.db").is_ok());
-        assert!(validate_ident("123db").is_ok());
-        assert!(validate_ident("café").is_ok());
-        assert!(validate_ident("a b").is_ok());
-    }
-
-    #[test]
-    fn rejects_empty() {
-        assert!(validate_ident("").is_err());
-    }
-
-    #[test]
-    fn rejects_whitespace_only() {
-        assert!(validate_ident("   ").is_err());
-        assert!(validate_ident("\t").is_err());
-    }
-
-    #[test]
-    fn rejects_control_chars() {
-        assert!(validate_ident("test\x00db").is_err());
-        assert!(validate_ident("test\ndb").is_err());
-        assert!(validate_ident("test\x1Fdb").is_err());
-    }
-
-    #[test]
-    fn quote_with_postgres_dialect() {
-        let d = PostgreSqlDialect {};
-        assert_eq!(quote_ident("users", &d), "\"users\"");
-        assert_eq!(quote_ident("eu-docker", &d), "\"eu-docker\"");
-        assert_eq!(quote_ident("test\"db", &d), "\"test\"\"db\"");
-    }
-
-    #[test]
-    fn quote_with_mysql_dialect() {
-        let d = MySqlDialect {};
-        assert_eq!(quote_ident("users", &d), "`users`");
-        assert_eq!(quote_ident("test`db", &d), "`test``db`");
-    }
-
-    #[test]
-    fn quote_with_sqlite_dialect() {
-        let d = SQLiteDialect {};
-        assert_eq!(quote_ident("users", &d), "`users`");
-        assert_eq!(quote_ident("test`db", &d), "`test``db`");
-    }
-
-    #[test]
-    fn quote_literal_escapes_single_quotes() {
-        assert_eq!(quote_literal("my_db"), "'my_db'");
-        assert_eq!(quote_literal(""), "''");
-        assert_eq!(quote_literal("it's"), "'it''s'");
-        assert_eq!(quote_literal("a'b'c"), "'a''b''c'");
-    }
-
-    // === T006: validate_ident boundary tests ===
-
-    #[test]
-    fn accepts_long_identifier() {
-        let long_name: String = "a".repeat(10_000);
-        assert!(validate_ident(&long_name).is_ok());
-    }
-
-    #[test]
-    fn rejects_mixed_valid_and_control() {
-        assert!(validate_ident("valid\x00").is_err());
-        assert!(validate_ident("\x01start").is_err());
-        assert!(validate_ident("mid\x7Fdle").is_err());
-    }
-
-    #[test]
-    fn accepts_sql_injection_payload_in_ident() {
-        assert!(validate_ident("Robert'; DROP TABLE students;--").is_ok());
-    }
-
-    #[test]
-    fn accepts_emoji() {
-        assert!(validate_ident("🎉").is_ok());
-        assert!(validate_ident("table_🔥").is_ok());
-    }
-
-    #[test]
-    fn accepts_cjk() {
-        assert!(validate_ident("数据库").is_ok());
-        assert!(validate_ident("テーブル").is_ok());
-    }
-
-    // === T007: quote_ident adversarial tests ===
-
-    #[test]
-    fn quote_ident_only_backticks_mysql() {
-        let d = MySqlDialect {};
-        // Input: `` (2 backticks). Each doubled → 4, plus wrapping → 6.
-        assert_eq!(quote_ident("``", &d), "``````");
-    }
-
-    #[test]
-    fn quote_ident_only_double_quotes_postgres() {
-        let d = PostgreSqlDialect {};
+    fn quote_ident_only_quote_chars() {
         // Input: "" (2 double-quotes). Each doubled → 4, plus wrapping → 6.
-        assert_eq!(quote_ident("\"\"", &d), "\"\"\"\"\"\"");
+        assert_eq!(quote_ident("\"\"", '"'), "\"\"\"\"\"\"");
+        // Input: `` (2 backticks). Each doubled → 4, plus wrapping → 6.
+        assert_eq!(quote_ident("``", '`'), "``````");
     }
 
     #[test]
     fn quote_ident_quote_at_start_and_end() {
-        let mysql = MySqlDialect {};
-        // Input: `x` (3 chars). Backticks doubled → ``x`` plus wrapping → 7.
-        assert_eq!(quote_ident("`x`", &mysql), "```x```");
-
-        let pg = PostgreSqlDialect {};
-        assert_eq!(quote_ident("\"x\"", &pg), "\"\"\"x\"\"\"");
+        assert_eq!(quote_ident("\"x\"", '"'), "\"\"\"x\"\"\"");
+        assert_eq!(quote_ident("`x`", '`'), "```x```");
     }
 
     #[test]
-    fn quote_ident_cross_dialect_foreign_quote_passes_through() {
-        let mysql = MySqlDialect {};
-        assert_eq!(quote_ident("test\"db", &mysql), "`test\"db`");
-
-        let pg = PostgreSqlDialect {};
-        assert_eq!(quote_ident("test`db", &pg), "\"test`db\"");
+    fn quote_ident_foreign_quote_passes_through() {
+        // Backtick is foreign to ANSI quoting; double-quote is foreign to MySQL.
+        assert_eq!(quote_ident("test`db", '"'), "\"test`db\"");
+        assert_eq!(quote_ident("test\"db", '`'), "`test\"db`");
     }
 
     #[test]
     fn quote_ident_empty_string() {
-        let mysql = MySqlDialect {};
-        assert_eq!(quote_ident("", &mysql), "``");
-
-        let pg = PostgreSqlDialect {};
-        assert_eq!(quote_ident("", &pg), "\"\"");
+        assert_eq!(quote_ident("", '"'), "\"\"");
+        assert_eq!(quote_ident("", '`'), "``");
     }
 
     #[test]
     fn quote_ident_long_string_completes() {
         let long_name: String = "a".repeat(10_000);
-        let pg = PostgreSqlDialect {};
-        let quoted = quote_ident(&long_name, &pg);
+        let quoted = quote_ident(&long_name, '"');
         assert_eq!(quoted.len(), 10_002);
     }
 
-    // === T008: quote_literal backslash tests ===
-
     #[test]
-    fn quote_literal_trailing_backslash() {
-        assert_eq!(quote_literal("test\\"), "'test\\\\'");
+    fn quote_ident_unicode_untouched() {
+        assert_eq!(quote_ident("数据", '"'), "\"数据\"");
+        assert_eq!(quote_ident("café", '`'), "`café`");
     }
 
     #[test]
-    fn quote_literal_single_backslash() {
-        assert_eq!(quote_literal("\\"), "'\\\\'");
-    }
-
-    #[test]
-    fn quote_literal_backslash_then_quote() {
-        // Input: \' (2 chars). \ doubled → \\, ' doubled → ''. Wrapped: '\\'''
-        assert_eq!(quote_literal("\\'"), "'\\\\'''");
-    }
-
-    #[test]
-    fn quote_literal_only_backslashes() {
-        assert_eq!(quote_literal("\\\\\\"), "'\\\\\\\\\\\\'");
-    }
-
-    #[test]
-    fn quote_literal_sql_injection_payload() {
-        assert_eq!(
-            quote_literal("Robert'; DROP TABLE students;--"),
-            "'Robert''; DROP TABLE students;--'"
-        );
-    }
-
-    #[test]
-    fn quote_literal_many_quotes_completes() {
-        let input: String = "'".repeat(1_000);
-        let result = quote_literal(&input);
-        assert_eq!(result.len(), 2_002);
-    }
-
-    // === T009: quote_literal combined edge cases ===
-
-    #[test]
-    fn quote_literal_backslash_and_quotes_mixed() {
-        // Input: it\'s (4 chars). \ doubled, ' doubled. Wrapped: 'it\\''s'
-        assert_eq!(quote_literal("it\\'s"), "'it\\\\''s'");
-    }
-
-    #[test]
-    fn quote_literal_no_special_chars() {
-        assert_eq!(quote_literal("plain"), "'plain'");
-    }
-
-    #[test]
-    fn quote_literal_unicode_untouched() {
-        assert_eq!(quote_literal("café"), "'café'");
-        assert_eq!(quote_literal("数据"), "'数据'");
+    fn quote_ident_dot_kept_inside_quotes() {
+        assert_eq!(quote_ident("schema.table", '"'), "\"schema.table\"");
+        assert_eq!(quote_ident("schema.table", '`'), "`schema.table`");
     }
 }

--- a/crates/sqlite/src/connection.rs
+++ b/crates/sqlite/src/connection.rs
@@ -57,7 +57,6 @@ impl Connection for SqliteConnection {
         self.config.query_timeout
     }
 }
-
 /// Creates a lazy `SQLite` pool from a [`DatabaseConfig`].
 ///
 /// Forces `max_connections` to 1 — `SQLite` is a single-writer backend.
@@ -74,6 +73,12 @@ fn create_lazy_pool(config: &DatabaseConfig) -> SqlitePool {
     }
 
     pool_opts.connect_lazy_with(conn_ops)
+}
+
+/// Quotes `value` as a `SQLite` identifier (ANSI double-quote style).
+#[must_use]
+pub(crate) fn quote_ident(value: &str) -> String {
+    dbmcp_sql::sanitize::quote_ident(value, '"')
 }
 
 #[cfg(test)]

--- a/crates/sqlite/src/tools/drop_table.rs
+++ b/crates/sqlite/src/tools/drop_table.rs
@@ -6,12 +6,11 @@ use dbmcp_server::types::MessageResponse;
 use dbmcp_sql::SqlError;
 
 use dbmcp_sql::Connection as _;
-use dbmcp_sql::sanitize::{quote_ident, validate_ident};
 use rmcp::handler::server::router::tool::{AsyncTool, ToolBase};
 use rmcp::model::{ErrorData, ToolAnnotations};
-use sqlparser::dialect::SQLiteDialect;
 
 use crate::SqliteHandler;
+use crate::connection::quote_ident;
 use crate::types::DropTableRequest;
 
 /// Marker type for the `dropTable` MCP tool.
@@ -89,9 +88,7 @@ impl SqliteHandler {
             return Err(SqlError::ReadOnlyViolation);
         }
 
-        validate_ident(&table)?;
-
-        let drop_sql = format!("DROP TABLE {}", quote_ident(&table, &SQLiteDialect {}));
+        let drop_sql = format!("DROP TABLE {}", quote_ident(&table));
         self.connection.execute(drop_sql.as_str(), None).await?;
 
         Ok(MessageResponse {

--- a/crates/sqlite/src/types.rs
+++ b/crates/sqlite/src/types.rs
@@ -17,7 +17,7 @@ pub use dbmcp_server::types::{ListEntries, ListTablesResponse};
 #[derive(Debug, Default, Deserialize, JsonSchema)]
 #[serde(rename_all = "camelCase")]
 pub struct DropTableRequest {
-    /// Name of the table to drop. Must contain only alphanumeric characters and underscores.
+    /// Name of the table to drop. Must be non-empty.
     pub table: String,
 }
 

--- a/tests/approval/snapshots/approval_mysql__list_tools.snap
+++ b/tests/approval/snapshots/approval_mysql__list_tools.snap
@@ -1,19 +1,18 @@
 ---
 source: tests/approval/mysql.rs
-assertion_line: 42
 expression: tools
 ---
 [
   {
     "name": "createDatabase",
     "title": "Create Database",
-    "description": "Create a new database on the connected server.\n\n<usecase>\nUse when:\n- Setting up a new database for a project or application\n- The user asks to create a database\n</usecase>\n\n<examples>\n✓ \"Create a database called analytics\" → createDatabase(database=\"analytics\")\n✗ \"Create a table\" → use writeQuery with CREATE TABLE\n</examples>\n\n<important>\nDatabase names must contain only alphanumeric characters and underscores.\nIf the database already exists, returns a message indicating so without error.\n</important>\n\n<what_it_returns>\nA confirmation message with the created database name.\n</what_it_returns>",
+    "description": "Create a new database on the connected server.\n\n<usecase>\nUse when:\n- Setting up a new database for a project or application\n- The user asks to create a database\n</usecase>\n\n<examples>\n✓ \"Create a database called analytics\" → createDatabase(database=\"analytics\")\n✗ \"Create a table\" → use writeQuery with CREATE TABLE\n</examples>\n\n<important>\nDatabase name must be non-empty; backend reserved-character rules apply.\nIf the database already exists, returns a message indicating so without error.\n</important>\n\n<what_it_returns>\nA confirmation message with the created database name.\n</what_it_returns>",
     "inputSchema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "description": "Request for the `createDatabase` tool.",
       "properties": {
         "database": {
-          "description": "Name of the database to create. Must contain only alphanumeric characters and underscores.",
+          "description": "Name of the database to create. Must be non-empty.",
           "type": "string"
         }
       },
@@ -54,7 +53,7 @@ expression: tools
       "description": "Request for the `dropDatabase` tool.",
       "properties": {
         "database": {
-          "description": "Name of the database to drop. Must contain only alphanumeric characters and underscores.",
+          "description": "Name of the database to drop. Must be non-empty.",
           "type": "string"
         }
       },
@@ -103,7 +102,7 @@ expression: tools
           ]
         },
         "table": {
-          "description": "Name of the table to drop. Must contain only alphanumeric characters and underscores.",
+          "description": "Name of the table to drop. Must be non-empty.",
           "type": "string"
         }
       },

--- a/tests/approval/snapshots/approval_postgres__list_tools.snap
+++ b/tests/approval/snapshots/approval_postgres__list_tools.snap
@@ -6,13 +6,13 @@ expression: tools
   {
     "name": "createDatabase",
     "title": "Create Database",
-    "description": "Create a new database on the connected server.\n\n<usecase>\nUse when:\n- Setting up a new database for a project or application\n- The user asks to create a database\n</usecase>\n\n<examples>\n✓ \"Create a database called analytics\" → createDatabase(database=\"analytics\")\n✗ \"Create a table\" → use writeQuery with CREATE TABLE\n</examples>\n\n<important>\nDatabase names must contain only alphanumeric characters and underscores.\n</important>\n\n<what_it_returns>\nA confirmation message with the created database name.\n</what_it_returns>",
+    "description": "Create a new database on the connected server.\n\n<usecase>\nUse when:\n- Setting up a new database for a project or application\n- The user asks to create a database\n</usecase>\n\n<examples>\n✓ \"Create a database called analytics\" → createDatabase(database=\"analytics\")\n✗ \"Create a table\" → use writeQuery with CREATE TABLE\n</examples>\n\n<important>\nDatabase name must be non-empty; backend reserved-character rules apply.\n</important>\n\n<what_it_returns>\nA confirmation message with the created database name.\n</what_it_returns>",
     "inputSchema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "description": "Request for the `createDatabase` tool.",
       "properties": {
         "database": {
-          "description": "Name of the database to create. Must contain only alphanumeric characters and underscores.",
+          "description": "Name of the database to create. Must be non-empty.",
           "type": "string"
         }
       },
@@ -53,7 +53,7 @@ expression: tools
       "description": "Request for the `dropDatabase` tool.",
       "properties": {
         "database": {
-          "description": "Name of the database to drop. Must contain only alphanumeric characters and underscores.",
+          "description": "Name of the database to drop. Must be non-empty.",
           "type": "string"
         }
       },
@@ -107,7 +107,7 @@ expression: tools
           ]
         },
         "table": {
-          "description": "Name of the table to drop. Must contain only alphanumeric characters and underscores.",
+          "description": "Name of the table to drop. Must be non-empty.",
           "type": "string"
         }
       },

--- a/tests/approval/snapshots/approval_sqlite__list_tools.snap
+++ b/tests/approval/snapshots/approval_sqlite__list_tools.snap
@@ -12,7 +12,7 @@ expression: tools
       "description": "Request for the `dropTable` tool.",
       "properties": {
         "table": {
-          "description": "Name of the table to drop. Must contain only alphanumeric characters and underscores.",
+          "description": "Name of the table to drop. Must be non-empty.",
           "type": "string"
         }
       },

--- a/tests/functional/mysql.rs
+++ b/tests/functional/mysql.rs
@@ -1097,29 +1097,6 @@ async fn test_drop_table_blocked_in_read_only() {
 }
 
 #[tokio::test]
-async fn test_read_query_control_char_database_name_rejected() {
-    let handler = handler(true);
-    let request = ReadQueryRequest {
-        query: "SELECT 1".into(),
-        database: Some("test\x01db".into()),
-        cursor: None,
-    };
-    let result = handler.read_query(request).await;
-    assert!(result.is_err(), "control char in database name should be rejected");
-}
-
-#[tokio::test]
-async fn test_list_tables_control_char_database_rejected() {
-    let handler = handler(true);
-    let request = ListTablesRequest {
-        database: Some("test\x00db".into()),
-        ..Default::default()
-    };
-    let result = handler.list_tables(request).await;
-    assert!(result.is_err(), "control char in database name should be rejected");
-}
-
-#[tokio::test]
 async fn test_create_drop_database_with_double_quote() {
     let handler = handler(false);
     let db_name = "test_quote_db\"edge".to_string();
@@ -2061,29 +2038,12 @@ async fn test_list_triggers_search_empty_is_same_as_no_filter() {
 }
 
 #[tokio::test]
-async fn test_list_triggers_invalid_database_identifier_is_rejected() {
-    // FR-009: the active-database identifier flows through `validate_ident`
-    // before the SQL runs. `validate_ident`'s contract is "non-empty + no
-    // control characters"; SQL meta-characters (`;`, `'`, `"`, etc.) are not
-    // identifier syntax violations and are safe because the database value
-    // is parameter-bound to `TRIGGER_SCHEMA = ?`, never interpolated into SQL.
-    // This test exercises the negative path of the validator.
+async fn test_list_triggers_arbitrary_database_identifier_is_bound_as_literal() {
+    // The database value is parameter-bound to `TRIGGER_SCHEMA = ?` and never
+    // interpolated into SQL. SQL meta-characters (`;`, `'`, `"`, `` ` ``)
+    // therefore reach the engine as literal schema names and produce empty
+    // results. This test pins the parameter-binding path against injection.
     let handler = handler(true);
-    for bad in ["\0name", "name\x01", "name\nwith_newline"] {
-        let result = handler
-            .list_triggers(ListTriggersRequest {
-                database: Some(bad.into()),
-                ..Default::default()
-            })
-            .await;
-        assert!(
-            result.is_err(),
-            "expected validate_ident to reject {bad:?}, got {result:?}"
-        );
-    }
-
-    // SQL meta-characters are NOT validate_ident violations — they are
-    // bound as literal values and produce empty results (no SQL injection).
     for bound in ["shop;DROP", "shop'", "shop\"", "shop`"] {
         let result = handler
             .list_triggers(ListTriggersRequest {
@@ -2969,10 +2929,9 @@ async fn list_tables_detailed_search_preserves_filter_across_pages() {
 
 #[tokio::test]
 async fn list_tables_detailed_excludes_system_schemas_passes_through_validation() {
-    // Today's MysqlHandler::list_tables runs `validate_ident` on `database`.
-    // `information_schema` passes (alphanumeric + underscore) — so the call
-    // succeeds and returns whatever metadata that schema's TABLE rows expose.
-    // This is a regression test pinning the existing behaviour.
+    // The active-database identifier reaches the SQL via per-backend quoting;
+    // `information_schema` is a normal name and the call succeeds, returning
+    // whatever metadata that schema's TABLE rows expose. Regression pin.
     let handler = handler(true);
     let response = handler
         .list_tables(ListTablesRequest {
@@ -3173,22 +3132,6 @@ async fn test_list_functions_search_paginates_filtered_results() {
         single.functions.as_brief().expect("brief"),
         "paginated traversal should equal single-page result"
     );
-}
-
-#[tokio::test]
-async fn test_list_functions_invalid_database_identifier_is_rejected() {
-    // `validate_ident` rejects empty + whitespace-only + control-character
-    // identifiers; arbitrary user payloads (including `;`, `"`, `--`) are
-    // accepted by the helper and reach the engine via parameter binding (no
-    // injection possible). The control-char case is the regression guard.
-    let handler = handler(true);
-    let result = handler
-        .list_functions(ListFunctionsRequest {
-            database: Some("test\x00db".into()),
-            ..Default::default()
-        })
-        .await;
-    assert!(result.is_err(), "control char in database name should be rejected");
 }
 
 #[tokio::test]


### PR DESCRIPTION
## Summary

- Replace `validate_ident` + `quote_literal` with a single `quote_ident(value, quote)` in `dbmcp_sql::sanitize` .
- Parameterize the MySQL `createDatabase` schema-existence lookup (`WHERE SCHEMA_NAME = ?`) — removes the only `quote_literal` call site. Drop connection-time identifier pre-validation from the MySQL + Postgres pool builders; quoting is the boundary, the driver decides.
- Reword tool descriptions and request-type doc strings to drop the "alphanumeric and underscore only" claim. Regenerate approval snapshots. Update functional tests to assert the new contract: SQL meta-characters bind as literals, control characters flow through to the driver.

Net diff: 31 files, +143 / −500.

## Test plan

- [ ] `cargo fmt --check`
- [ ] `cargo clippy --workspace --tests -- -D warnings`
- [ ] `cargo test --workspace --lib --bins`
- [ ] `./tests/run.sh` (integration: mariadb_12 + mysql_9 + postgres_18 + sqlite — 669 tests)
- [ ] Smoke: `listTables` against a database named `eu-docker` returns rows (no `InvalidIdentifier`)
- [ ] `rg 'validate_ident|quote_literal' crates/ src/ tests/` returns zero hits