### PR TITLE
feat(http)!: enforce Origin header server-side via rmcp 1.6.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -482,6 +482,7 @@ dependencies = [
  "thiserror",
  "tokio",
  "tokio-util",
+ "tower",
  "tower-http",
  "tracing",
  "tracing-subscriber",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -51,6 +51,7 @@ sqlx = { version = "0.8", features = ["runtime-tokio", "runtime-tokio-rustls"] }
 thiserror = "2"
 tokio = { version = "1", features = ["full"] }
 tokio-util = { version = "0.7", features = ["rt"] }
+tower = { version = "0.5", features = ["util"] }
 tower-http = { version = "0.6", features = ["cors"] }
 tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }
@@ -103,6 +104,7 @@ indexmap = { workspace = true }
 insta = { workspace = true }
 rmcp = { workspace = true, features = ["client"] }
 serde_json = { workspace = true }
+tower = { workspace = true }
 
 [[test]]
 name = "functional_mysql"

--- a/README.md
+++ b/README.md
@@ -172,8 +172,8 @@ A subcommand is required — running `dbmcp` with no subcommand prints usage hel
 |------|---------|-------------|
 | `--host` | `127.0.0.1` | Bind host |
 | `--port` | `9001` | Bind port |
-| `--allowed-origins` | localhost variants | CORS allowed origins (comma-separated) |
-| `--allowed-hosts` | `localhost,127.0.0.1,::1` | Trusted Host headers (comma-separated) |
+| `--allowed-origins` | localhost variants | Allowed browser origins (comma-separated). Drives both CORS preflight and server-side Origin rejection. |
+| `--allowed-hosts` | `localhost,127.0.0.1,::1` | Trusted Host headers (comma-separated). Enforced server-side; HTTP/2 `:authority` is honored. |
 
 ## MCP Tools 🧩
 
@@ -289,7 +289,7 @@ Returns the execution plan for a SQL query. Supports an optional `analyze` param
 - **Single-statement enforcement** — multi-statement injection blocked at parse level
 - **Dangerous function blocking** — `LOAD_FILE()`, `INTO OUTFILE`, `INTO DUMPFILE` detected in the AST
 - **Identifier validation** — database/table names validated against control characters and empty strings
-- **CORS + trusted hosts** — configurable for HTTP transport
+- **Origin + Host allowlists** — server-side rejection (403) plus CORS preflight; configurable for HTTP transport
 - **SSL/TLS** — configured via individual `DB_SSL_*` variables
 - **Credential redaction** — database password is never shown in logs or debug output
 

--- a/crates/config/src/config.rs
+++ b/crates/config/src/config.rs
@@ -272,7 +272,7 @@ pub struct HttpConfig {
     /// Bind port for HTTP transport.
     pub port: u16,
 
-    /// Allowed CORS origins.
+    /// Allowed browser origins for both CORS preflight and rmcp server-side validation.
     pub allowed_origins: Vec<String>,
 
     /// Allowed host names.

--- a/docs/content/docs/configuration.mdx
+++ b/docs/content/docs/configuration.mdx
@@ -80,8 +80,8 @@ These options are available only when running in HTTP mode (`dbmcp http`):
 |----------|---------|-------------|
 | `--host` | `127.0.0.1` | Bind host for the HTTP server |
 | `--port` | `9001` | Bind port for the HTTP server |
-| `--allowed-origins` | `http://localhost,http://127.0.0.1,https://localhost,https://127.0.0.1` | Allowed CORS origins (comma-separated) |
-| `--allowed-hosts` | `localhost,127.0.0.1,::1` | Allowed host names (comma-separated) |
+| `--allowed-origins` | `http://localhost,http://127.0.0.1,https://localhost,https://127.0.0.1` | Allowed browser origins (comma-separated). Drives both CORS preflight and server-side `Origin` header rejection. |
+| `--allowed-hosts` | `localhost,127.0.0.1,::1` | Allowed host names (comma-separated). Enforced server-side; HTTP/2 `:authority` is honored. |
 
 A transport subcommand is required — running `dbmcp` with no subcommand prints usage help and exits with a non-zero status. The `stdio` transport requires no additional configuration beyond the database options above.
 

--- a/docs/content/docs/features.mdx
+++ b/docs/content/docs/features.mdx
@@ -378,7 +378,7 @@ The server communicates over standard input/output. This mode works with local M
 
 ### HTTP
 
-The server runs as an HTTP service with Streamable HTTP transport and CORS support. This mode is useful for remote access or shared environments where multiple clients connect to the same server.
+The server runs as an HTTP service with Streamable HTTP transport, CORS preflight, and server-side `Origin`/`Host` header allowlists. This mode is useful for remote access or shared environments where multiple clients connect to the same server.
 
 **Best for**: Remote servers, shared team databases, environments where the MCP client cannot launch local processes.
 

--- a/docs/content/docs/index.mdx
+++ b/docs/content/docs/index.mdx
@@ -16,7 +16,7 @@ Database MCP is a [Model Context Protocol](https://modelcontextprotocol.io/) (MC
 
 - **Single binary** — no runtime dependencies, no language runtimes to install
 - **Read-only by default** — write operations are blocked unless explicitly enabled
-- **Stdio and HTTP transport** — works as a local stdio server or a remote HTTP server with CORS support
+- **Stdio and HTTP transport** — works as a local stdio server or a remote HTTP server with CORS preflight and server-side Origin/Host allowlists
 - **Multi-database support** — connect to MySQL, MariaDB, PostgreSQL, or SQLite with a single binary
 
 ## How It Works

--- a/src/commands/http.rs
+++ b/src/commands/http.rs
@@ -45,7 +45,11 @@ struct HttpArguments {
     )]
     port: u16,
 
-    /// Allowed CORS origins (comma-separated).
+    /// Allowed browser origins (comma-separated, RFC 6454 `<scheme>://<host>[:<port>]` or `null`).
+    ///
+    /// Drives BOTH the CORS preflight allowlist AND the rmcp server-side
+    /// Origin validator. Pass an empty list (`--allowed-origins ""`) to
+    /// disable both layers — only do this for non-browser deployments.
     #[arg(
         long = "allowed-origins",
         env = "HTTP_ALLOWED_ORIGINS",
@@ -111,19 +115,7 @@ impl HttpCommand {
         let server = common::create_server(&db_config);
         let cancel_token = CancellationToken::new();
 
-        let service = StreamableHttpService::new(
-            move || Ok(server.clone()),
-            Arc::new(LocalSessionManager::default()),
-            StreamableHttpServerConfig::default()
-                .with_stateful_mode(false)
-                .with_json_response(true)
-                .with_cancellation_token(cancel_token.child_token())
-                .with_allowed_hosts(http_config.allowed_hosts.clone()),
-        );
-
-        let router = axum::Router::new()
-            .nest_service("/mcp", service)
-            .layer(build_cors_layer(&http_config));
+        let router = build_http_router(&http_config, server, &cancel_token);
 
         let bind_addr = format!("{}:{}", http_config.host, http_config.port);
         info!("Starting MCP server via HTTP transport on {bind_addr}...");
@@ -140,6 +132,32 @@ impl HttpCommand {
 
         Ok(())
     }
+}
+
+/// Builds the axum router that serves MCP over Streamable HTTP.
+///
+/// Wires the configured allowed-origins list into BOTH the rmcp 1.6.0
+/// server-side Origin validator and the tower-http CORS preflight layer
+/// so the two layers cannot disagree by accident.
+fn build_http_router(
+    http_config: &HttpConfig,
+    server: common::Server,
+    cancel_token: &CancellationToken,
+) -> axum::Router {
+    let service = StreamableHttpService::new(
+        move || Ok(server.clone()),
+        Arc::new(LocalSessionManager::default()),
+        StreamableHttpServerConfig::default()
+            .with_stateful_mode(false)
+            .with_json_response(true)
+            .with_cancellation_token(cancel_token.child_token())
+            .with_allowed_hosts(http_config.allowed_hosts.clone())
+            .with_allowed_origins(http_config.allowed_origins.clone()),
+    );
+
+    axum::Router::new()
+        .nest_service("/mcp", service)
+        .layer(build_cors_layer(http_config))
 }
 
 /// Builds a CORS layer from the configured allowed origins.
@@ -185,5 +203,160 @@ async fn shutdown_signal() {
     tokio::select! {
         () = ctrl_c => info!("Ctrl-C received, shutting down..."),
         () = terminate => info!("SIGTERM received, shutting down..."),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    use axum::body::{Body, to_bytes};
+    use axum::http::{HeaderValue, Method, Request, StatusCode, header, request::Builder};
+    use clap::Parser;
+    use dbmcp_config::DatabaseBackend;
+    use tower::ServiceExt;
+
+    #[derive(Parser)]
+    #[command(no_binary_name = true)]
+    struct TestCli {
+        #[command(flatten)]
+        http: HttpArguments,
+    }
+
+    fn parse_http_args(args: &[&str]) -> HttpArguments {
+        // SAFETY: tests don't run concurrently against these env vars.
+        unsafe {
+            std::env::remove_var("HTTP_ALLOWED_ORIGINS");
+            std::env::remove_var("HTTP_ALLOWED_HOSTS");
+        }
+        TestCli::try_parse_from(args).expect("clap parse").http
+    }
+
+    fn sqlite_memory_db_config() -> DatabaseConfig {
+        DatabaseConfig {
+            backend: DatabaseBackend::Sqlite,
+            name: Some(":memory:".into()),
+            ..DatabaseConfig::default()
+        }
+    }
+
+    fn router_with_origins(origins: Vec<String>) -> axum::Router {
+        let http_config = HttpConfig {
+            host: HttpConfig::DEFAULT_HOST.into(),
+            port: HttpConfig::DEFAULT_PORT,
+            allowed_origins: origins,
+            allowed_hosts: HttpConfig::default_allowed_hosts(),
+        };
+        let server = common::create_server(&sqlite_memory_db_config());
+        let cancel = CancellationToken::new();
+        build_http_router(&http_config, server, &cancel)
+    }
+
+    async fn send(router: axum::Router, request: Request<Body>) -> (StatusCode, String) {
+        let response = router.oneshot(request).await.expect("oneshot");
+        let status = response.status();
+        let bytes = to_bytes(response.into_body(), 1024 * 1024).await.expect("body bytes");
+        (status, String::from_utf8_lossy(&bytes).into_owned())
+    }
+
+    fn mcp_post(uri: &str) -> Builder {
+        Request::builder()
+            .method(Method::POST)
+            .uri(uri)
+            .header(header::HOST, "localhost")
+            .header(header::CONTENT_TYPE, "application/json")
+            .header(header::ACCEPT, "application/json, text/event-stream")
+    }
+
+    #[test]
+    fn clap_default_yields_four_loopback_origins() {
+        let args = parse_http_args(&[]);
+        let config = HttpConfig::try_from(&args).expect("default config valid");
+        assert_eq!(config.allowed_origins, HttpConfig::default_allowed_origins());
+    }
+
+    #[tokio::test]
+    async fn disallowed_origin_returns_403() {
+        let router = router_with_origins(HttpConfig::default_allowed_origins());
+        let request = mcp_post("/mcp/")
+            .header(header::ORIGIN, "https://evil.example")
+            .body(Body::from("{}"))
+            .expect("build request");
+        let (status, body) = send(router, request).await;
+        assert_eq!(status, StatusCode::FORBIDDEN, "body={body}");
+        assert_eq!(body, "Forbidden: Origin header is not allowed");
+    }
+
+    #[tokio::test]
+    async fn disallowed_host_returns_403() {
+        let router = router_with_origins(HttpConfig::default_allowed_origins());
+        let request = Request::builder()
+            .method(Method::POST)
+            .uri("/mcp/")
+            .header(header::HOST, "evil.example")
+            .header(header::CONTENT_TYPE, "application/json")
+            .header(header::ACCEPT, "application/json, text/event-stream")
+            .body(Body::from("{}"))
+            .expect("build request");
+        let (status, body) = send(router, request).await;
+        assert_eq!(status, StatusCode::FORBIDDEN, "body={body}");
+        assert_eq!(body, "Forbidden: Host header is not allowed");
+    }
+
+    #[tokio::test]
+    async fn malformed_origin_non_utf8_returns_400() {
+        let router = router_with_origins(HttpConfig::default_allowed_origins());
+        let mut request = mcp_post("/mcp/").body(Body::from("{}")).expect("build request");
+        request.headers_mut().insert(
+            header::ORIGIN,
+            HeaderValue::from_bytes(&[0xFF, 0xFE]).expect("non-utf8 header value"),
+        );
+        let (status, body) = send(router, request).await;
+        assert_eq!(status, StatusCode::BAD_REQUEST, "body={body}");
+        assert_eq!(body, "Bad Request: Invalid Origin header encoding");
+    }
+
+    #[tokio::test]
+    async fn malformed_origin_unparseable_returns_400() {
+        let router = router_with_origins(HttpConfig::default_allowed_origins());
+        let request = mcp_post("/mcp/")
+            .header(header::ORIGIN, "not a url")
+            .body(Body::from("{}"))
+            .expect("build request");
+        let (status, body) = send(router, request).await;
+        assert_eq!(status, StatusCode::BAD_REQUEST, "body={body}");
+        assert_eq!(body, "Bad Request: Invalid Origin header");
+    }
+
+    #[tokio::test]
+    async fn allowed_origin_passes_validator() {
+        let router = router_with_origins(HttpConfig::default_allowed_origins());
+        let request = mcp_post("/mcp/")
+            .header(header::ORIGIN, "http://localhost")
+            .body(Body::from("{}"))
+            .expect("build request");
+        let (status, _body) = send(router, request).await;
+        assert_ne!(status, StatusCode::FORBIDDEN);
+        assert_ne!(status, StatusCode::BAD_REQUEST);
+    }
+
+    #[tokio::test]
+    async fn missing_origin_passes_validator() {
+        let router = router_with_origins(HttpConfig::default_allowed_origins());
+        let request = mcp_post("/mcp/").body(Body::from("{}")).expect("build request");
+        let (status, _body) = send(router, request).await;
+        assert_ne!(status, StatusCode::FORBIDDEN);
+        assert_ne!(status, StatusCode::BAD_REQUEST);
+    }
+
+    #[tokio::test]
+    async fn empty_allowlist_skips_origin_check() {
+        let router = router_with_origins(vec![]);
+        let request = mcp_post("/mcp/")
+            .header(header::ORIGIN, "https://evil.example")
+            .body(Body::from("{}"))
+            .expect("build request");
+        let (status, _body) = send(router, request).await;
+        assert_ne!(status, StatusCode::FORBIDDEN, "empty allowlist must not reject Origin");
     }
 }


### PR DESCRIPTION
## Summary

- Wire `--allowed-origins` into rmcp 1.6.0's `StreamableHttpServerConfig::with_allowed_origins` so the same allowlist that powers tower-http CORS preflight now also drives server-side `Origin` rejection. The two layers cannot drift because they share a single `Vec<String>`.
- Extract `build_http_router` from `HttpCommand::execute` to make the router callable from tests via `tower::ServiceExt::oneshot` — hermetic, network-free coverage of the rejection paths and the allowed/missing-Origin pass-through.
- No new CLI flags. No config-time validation; allowlist entries are passed through to rmcp the same way `--allowed-hosts` already is. rmcp silently filters malformed entries on each request, matching the existing `--allowed-hosts` behavior.
- HTTP/2 `:authority` fallback for the host check is absorbed transparently from the rmcp 1.6 bump.

## BREAKING CHANGE

Requests carrying a forbidden `Origin` are now rejected with `403 Forbidden` at the MCP transport layer, not just blocked at CORS preflight. The default `--allowed-origins` list (loopback variants) is unchanged, so local AI-assistant integrations are not affected. Operators who need broader access must extend `--allowed-origins` or disable validation explicitly via `--allowed-origins ""`.

## Test plan

- [x] `cargo fmt --check`
- [x] `cargo clippy --workspace --tests -- -D warnings`
- [x] `cargo test --workspace --lib --bins` (config: 22 tests; binary: 23 tests including 7 new in-memory `Router::oneshot` integration tests covering disallowed Origin → 403, disallowed Host → 403, malformed Origin (non-UTF-8) → 400, malformed Origin (parse fail) → 400, allowed Origin → pass, missing Origin → pass, empty allowlist → pass)
- [ ] `./tests/run.sh --filter sqlite` smoke check (Docker-backed; not run locally — verify in CI)
- [ ] Manual quickstart walkthrough via `cargo run -- http --db-backend sqlite --db-name :memory:` + `curl` per `specs/080-http-origin-validation/quickstart.md`

## Docs updated

- `README.md` — flag table + Security bullet
- `docs/content/docs/configuration.mdx` — flag table
- `docs/content/docs/features.mdx` — HTTP transport description
- `docs/content/docs/index.mdx` — Key Features bullet
- `crates/config/src/config.rs` — `HttpConfig.allowed_origins` doc comment

## Out of scope (deferred)

- `init_timeout` flag (dropped per `specs/080-http-origin-validation/spec.md` clarifications)
- Snapshot test of `dbmcp http --help`
- HTTP/2 `:authority` regression test
- Tracing-capture test asserting rmcp's `WARN` rejection emissions (rmcp emits them upstream; verified by reading source)
- Expanding `docs/content/docs/security.mdx` to cover HTTP transport security