### PR TITLE
docs(pii): document PII redaction across user-facing surfaces

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -31,6 +31,7 @@ Cargo workspace: root binary (`dbmcp`) + 7 library crates under `crates/`. Works
 - **`crates/config/`** (`dbmcp-config`) — `Config`, `DatabaseConfig`, `HttpConfig` structs, `DatabaseBackend` enum (`Mysql`, `Mariadb`, `Postgres`, `Sqlite` via `clap::ValueEnum`). `DatabaseConfig::validate()` and `HttpConfig::validate()` accumulate errors into `Result<(), Vec<ConfigError>>`.
 - **`crates/backend/`** (`dbmcp-sql`) — Shared `AppError` type, SQL read-only validation (`validation` module), identifier quoting/validation (`identifier` module), and request/response types (`types` module).
 - **`crates/server/`** (`dbmcp-server`) — Shared MCP tool implementations (`tools` module) and `server_info()`. Reused by all three database handler crates.
+- **`crates/pii/`** (`dbmcp-pii`) — Regex-based PII detection (eight v1 recognisers: email, credit card, IBAN, IP, URL, phone, crypto, US SSN) and four anonymisation operators (`replace`, `mask`, `redact`, `hash`). Wired into query tool output behind `PiiConfig`.
 - **`crates/mysql/`** (`dbmcp-mysql`) — MySQL/MariaDB backend: connection pooling, query operations, schema introspection, MCP handler via `rmcp::tool_router`.
 - **`crates/postgres/`** (`dbmcp-postgres`) — PostgreSQL backend: per-database connection pool cache (moka), query operations, schema introspection, MCP handler.
 - **`crates/sqlite/`** (`dbmcp-sqlite`) — SQLite backend: single-file connection, query operations, schema introspection, MCP handler.
@@ -44,6 +45,7 @@ Cargo workspace: root binary (`dbmcp`) + 7 library crates under `crates/`. Works
 - Env vars are set by the MCP client (via `env` or `envFile` in server config)
 - Run `cargo run -- --help` for the full list of flags and env var mappings
 - `DB_READ_ONLY` defaults to `true` — write operations blocked unless explicitly disabled
+- `PiiConfig` is a top-level config section alongside `DatabaseConfig` and `HttpConfig`. The toggle (`--pii` / `PII_ENABLE`) defaults to **off**; the operator (`--pii-operator` / `PII_OPERATOR`) defaults to `replace`.
 
 ## Code Style
 
@@ -63,6 +65,7 @@ See [CONTRIBUTING.md](CONTRIBUTING.md) for commit conventions, PR process, and d
 - **MULTI_STATEMENTS**: **NEVER** enable the MULTI_STATEMENTS client flag. The connection MUST clear it to prevent multi-statement SQL injection.
 - **Parameterized queries**: **NEVER** interpolate user values into SQL strings. Use parameterized queries exclusively.
 - **Identifier validation**: **ALWAYS** validate database/table names (alphanumeric and underscore). Never use string interpolation for identifiers — use proper quoting per backend.
+- **PII redaction**: opt-in defense-in-depth applied to query tool output payloads (`readQuery` and any future query tools that route through the redactor). **MUST NOT** be removed or bypassed without an explicit user request. Off by default; operators enable via `--pii` / `PII_ENABLE`.
 
 ## Never Do
 

--- a/README.md
+++ b/README.md
@@ -291,6 +291,7 @@ Returns the execution plan for a SQL query. Supports an optional `analyze` param
 - **Identifier validation** — database/table names validated against control characters and empty strings
 - **Origin + Host allowlists** — server-side rejection (403) plus CORS preflight; configurable for HTTP transport
 - **SSL/TLS** — configured via individual `DB_SSL_*` variables
+- **PII redaction** *(opt-in, off by default)* — when enabled, query tool output passes through a regex-based redactor that rewrites detected PII spans (email, credit card, IBAN, IP, URL, phone, crypto address, US SSN). Toggle: `--pii` / `PII_ENABLE`. Operator: `--pii-operator` / `PII_OPERATOR` — one of `replace` (default, entity-aware placeholders like `<EMAIL_ADDRESS>`), `mask` (length-preserving `*`), `redact` (drop), `hash` (SHA-256 hex). Scope: query tool output payloads only. See [PII configuration](https://dbmcp.haymon.ai/docs/configuration#pii) for the full surface.
 - **Credential redaction** — database password is never shown in logs or debug output
 
 ## Testing 🧪

--- a/docs/content/docs/configuration.mdx
+++ b/docs/content/docs/configuration.mdx
@@ -85,6 +85,26 @@ These options are available only when running in HTTP mode (`dbmcp http`):
 
 A transport subcommand is required — running `dbmcp` with no subcommand prints usage help and exits with a non-zero status. The `stdio` transport requires no additional configuration beyond the database options above.
 
+## PII
+
+Database MCP can rewrite detected PII spans inside query tool output. The feature is **opt-in and off by default** — applies to query tool response payloads (`readQuery` and any future query tools that route through the redactor) and is **not** applied to logs, errors, schema-discovery responses, or tool arguments. See [Features](/docs/features#pii-redaction) for the supported entity list.
+
+| CLI Flag | Environment Variable | Default | Description |
+|----------|---------------------|---------|-------------|
+| `--pii` | `PII_ENABLE` | `false` | Enable PII redaction of query tool output |
+| `--pii-operator` | `PII_OPERATOR` | `replace` | Operator applied to detected PII spans |
+
+### Operator Values
+
+`--pii-operator` accepts one of the following values:
+
+- `replace` — replace each detected span with an entity-aware placeholder (for example, an `EMAIL_ADDRESS` match becomes `<EMAIL_ADDRESS>`)
+- `mask` — mask each detected span with `*` (length-preserving)
+- `redact` — remove each detected span (replace with empty string)
+- `hash` — replace each detected span with a stable hex digest (SHA-256)
+
+> **Default**: redaction is off. Setting `PII_ENABLE=true` (or `--pii true`) is the only way to activate the redactor — `PII_OPERATOR` alone has no effect.
+
 ## Client Configuration Examples
 
 MCP clients configure servers through JSON files. Each tool uses a slightly different file path, but the format is nearly identical. The examples below connect to a local MySQL database.
@@ -110,6 +130,8 @@ Create a `.mcp.json` file in your project root:
   }
 }
 ```
+
+*To enable PII redaction, add `"PII_ENABLE": "true"` and optionally `"PII_OPERATOR": "<replace|mask|redact|hash>"` to the `env` map.*
 
 Claude Code also supports HTTP transport for remote servers:
 
@@ -151,6 +173,8 @@ Using Docker:
 }
 ```
 
+*To enable PII redaction, add `"PII_ENABLE": "true"` and optionally `"PII_OPERATOR": "<replace|mask|redact|hash>"` to the `env` map.*
+
 ### Claude Desktop
 
 Edit the config file at:
@@ -173,6 +197,8 @@ Edit the config file at:
   }
 }
 ```
+
+*To enable PII redaction, add `"PII_ENABLE": "true"` and optionally `"PII_OPERATOR": "<replace|mask|redact|hash>"` to the `env` map.*
 
 Using Docker:
 
@@ -197,6 +223,8 @@ Using Docker:
   }
 }
 ```
+
+*To enable PII redaction, add `"PII_ENABLE": "true"` and optionally `"PII_OPERATOR": "<replace|mask|redact|hash>"` to the `env` map.*
 
 > Claude Desktop only supports stdio transport. For HTTP mode, use the Connectors UI under **Settings > Connectors > Add custom connector**.
 
@@ -223,6 +251,8 @@ Create `.cursor/mcp.json` in your project root, or use `~/.cursor/mcp.json` for 
 }
 ```
 
+*To enable PII redaction, add `"PII_ENABLE": "true"` and optionally `"PII_OPERATOR": "<replace|mask|redact|hash>"` to the `env` map.*
+
 Using Docker:
 
 ```json
@@ -247,6 +277,8 @@ Using Docker:
   }
 }
 ```
+
+*To enable PII redaction, add `"PII_ENABLE": "true"` and optionally `"PII_OPERATOR": "<replace|mask|redact|hash>"` to the `env` map.*
 
 Cursor supports `envFile` to load variables from a `.env` file. Sensitive values like `DB_PASSWORD` can be kept there instead of in the JSON config.
 
@@ -273,6 +305,8 @@ Edit the config file at:
 }
 ```
 
+*To enable PII redaction, add `"PII_ENABLE": "true"` and optionally `"PII_OPERATOR": "<replace|mask|redact|hash>"` to the `env` map.*
+
 Using Docker:
 
 ```json
@@ -296,6 +330,8 @@ Using Docker:
   }
 }
 ```
+
+*To enable PII redaction, add `"PII_ENABLE": "true"` and optionally `"PII_OPERATOR": "<replace|mask|redact|hash>"` to the `env` map.*
 
 Windsurf supports `${env:VARIABLE_NAME}` interpolation to reference values from your shell environment instead of hardcoding them.
 

--- a/docs/content/docs/features.mdx
+++ b/docs/content/docs/features.mdx
@@ -384,6 +384,38 @@ The server runs as an HTTP service with Streamable HTTP transport, CORS prefligh
 
 See [Configuration](/docs/configuration#http-transport) for HTTP-specific options like bind host, port, and allowed origins.
 
+## PII Redaction
+
+Database MCP ships an optional PII redactor that rewrites detected sensitive spans inside query tool output before the result reaches the AI assistant. The feature is **off by default**; enable it per-server via `--pii` / `PII_ENABLE`, and select how spans are rewritten via `--pii-operator` / `PII_OPERATOR`. See [PII configuration](/docs/configuration#pii) for the full flag reference.
+
+### What gets detected
+
+Eight built-in regex recognisers ship in v1. Each recogniser is identified by an entity type that drives the `replace` operator's placeholder:
+
+- `EMAIL_ADDRESS` — email addresses
+- `CREDIT_CARD` — credit card numbers (Luhn-validated)
+- `IBAN_CODE` — International Bank Account Numbers
+- `IP_ADDRESS` — IPv4 and IPv6 addresses
+- `URL` — http / https URLs
+- `PHONE_NUMBER` — international phone numbers
+- `CRYPTO` — Bitcoin and similar wallet addresses
+- `US_SSN` — United States Social Security Numbers
+
+### What gets filtered
+
+Redaction applies only to **query tool output payloads** — `readQuery` results today, and any future query tools that route through the same redactor. Logs, error messages, schema-discovery responses (`listTables`, `listViews`, etc.), and tool arguments are **not** affected.
+
+### How spans are rewritten
+
+The configured operator decides how each detected span is replaced:
+
+- `replace` (default) — entity-aware placeholder. For example, `jane.doe@example.com` becomes `<EMAIL_ADDRESS>`. Plan for this when downstream code parses query output: a column that previously held a plain email now holds the placeholder string for matching rows.
+- `mask` — length-preserving `*` characters.
+- `redact` — span removed (replaced with empty string).
+- `hash` — stable hex digest derived via SHA-256.
+
+See [PII configuration](/docs/configuration#pii) for the toggle, env var, and operator-selection details.
+
 ## Single Binary
 
 Database MCP ships as a single compiled binary with no runtime dependencies. There is no language runtime to install, no package manager to configure, and no dependency tree to manage. Download the binary for your platform and it is ready to use.

--- a/docs/content/docs/index.mdx
+++ b/docs/content/docs/index.mdx
@@ -18,6 +18,7 @@ Database MCP is a [Model Context Protocol](https://modelcontextprotocol.io/) (MC
 - **Read-only by default** — write operations are blocked unless explicitly enabled
 - **Stdio and HTTP transport** — works as a local stdio server or a remote HTTP server with CORS preflight and server-side Origin/Host allowlists
 - **Multi-database support** — connect to MySQL, MariaDB, PostgreSQL, or SQLite with a single binary
+- **Optional PII redaction** — opt-in regex-based redactor for query tool output ([details](/docs/features#pii-redaction))
 
 ## How It Works
 

--- a/docs/content/docs/installation.mdx
+++ b/docs/content/docs/installation.mdx
@@ -131,6 +131,8 @@ docker run -i --rm \
   -e DB_BACKEND=postgres \
   -e DB_HOST=host.docker.internal \
   -e DB_USER=postgres \
+  # -e PII_ENABLE=true \
+  # -e PII_OPERATOR=replace \
   ghcr.io/haymon-ai/dbmcp
 ```
 
@@ -141,6 +143,8 @@ docker run --rm \
   -e DB_BACKEND=postgres \
   -e DB_HOST=host.docker.internal \
   -e DB_USER=postgres \
+  # -e PII_ENABLE=true \
+  # -e PII_OPERATOR=replace \
   -p 9001:9001 \
   ghcr.io/haymon-ai/dbmcp http --host 0.0.0.0
 ```
@@ -151,6 +155,8 @@ docker run --rm \
 docker run -i --rm \
   -e DB_BACKEND=sqlite \
   -e DB_NAME=/data/my.db \
+  # -e PII_ENABLE=true \
+  # -e PII_OPERATOR=replace \
   -v /path/to/local/db:/data \
   ghcr.io/haymon-ai/dbmcp
 ```

--- a/docs/content/docs/security.mdx
+++ b/docs/content/docs/security.mdx
@@ -52,6 +52,23 @@ User-provided values are never interpolated into SQL strings. All values are pas
 
 Database and table names are validated to contain only alphanumeric characters and underscores. Names are then properly quoted using each database backend's native quoting mechanism, preventing injection through crafted identifiers.
 
+## PII Redaction
+
+Database MCP ships an optional PII redactor as defence-in-depth: even when the AI assistant has SELECT access to a table containing sensitive values, those values can be rewritten in tool output before they reach the model. The feature is **opt-in and off by default** — operators must enable it explicitly via `--pii` / `PII_ENABLE`.
+
+### Scope
+
+Redaction applies **only to query tool output payloads** — `readQuery` results, plus any future query tools that route through the same redactor. The following are **not** redacted:
+
+- Server logs and structured tracing output
+- Error messages returned to the client
+- Schema-discovery tool responses (`listTables`, `listViews`, `listTriggers`, etc.)
+- Tool arguments supplied by the assistant
+
+Treat PII redaction as a layer that reduces what an enabled assistant sees in result rows; it is not a blanket guarantee that no sensitive string ever leaves the server. Pair it with database-level controls (least-privilege roles, column masking views) for sensitive datasets.
+
+See [Features](/docs/features#pii-redaction) for the supported entity list and operator semantics, and [Configuration](/docs/configuration#pii) for the toggle and operator-selection flags.
+
 ## Disabling Read-Only Mode
 
 Read-only mode can be explicitly disabled if you need write access. Set the `DB_READ_ONLY` environment variable to `false` or pass the `--db-read-only false` flag. This makes `writeQuery`, `createDatabase`, `dropDatabase`, and `dropTable` (where supported) available to the AI assistant. Only disable read-only mode in environments where you trust the AI assistant to make changes to your data.


### PR DESCRIPTION
## Summary

- PII redaction shipped in #138 + #139 but was undocumented on every user-facing surface (single grep match across README/CLAUDE/docs returned only the unrelated credential-redaction line). This PR adds coverage to README, CLAUDE.md, and five docs pages.
- README: short blurb under Security 🔒 (flag, env var, four operator one-liners, off-by-default note, link to docs). No flag-table duplication.
- Docs site: new `## PII` section in `configuration.mdx`, new `## PII Redaction` sections in `features.mdx` (8 entities + placeholder example) and `security.mdx` (defense-in-depth + explicit scope disclaimers). Landing page gets a single highlight bullet. `installation.mdx` Docker examples gain commented-out `PII_ENABLE` / `PII_OPERATOR` lines so default install behaviour is unchanged.
- CLAUDE.md: `dbmcp-pii` crate listed under Architecture, `PiiConfig` framed as a peer config section, opt-in defense-in-depth bullet under Security Constraints with a "MUST NOT be removed or bypassed" clause.
- `configuration.mdx` JSON `env` blocks (Claude Code / Desktop / Cursor / Windsurf, stdio + Docker each) get one inline MDX note pointing at the env keys — JSON has no comment syntax, so the spec's "or an inline note" branch applies.

## Test plan

- [x] `cargo fmt --check` clean
- [x] `cargo clippy --workspace --tests -- -D warnings` clean
- [x] `cargo test --workspace --lib --bins` green (no Rust changed; canary)
- [x] `cd docs && npm run build` succeeds — Next.js + Fumadocs static export clean, all PII anchors resolve
- [x] `grep -RnE 'db-redact-pii|DB_REDACT_PII|--pii-enable' README.md CLAUDE.md docs/content/docs/` returns zero hits
- [x] All four operator names (`replace`, `mask`, `redact`, `hash`) appear verbatim in `configuration.mdx`
- [x] All eight v1 entity identifiers (`EMAIL_ADDRESS`, `CREDIT_CARD`, `IBAN_CODE`, `IP_ADDRESS`, `URL`, `PHONE_NUMBER`, `CRYPTO`, `US_SSN`) appear verbatim in `features.mdx`
- [x] Every `PII_ENABLE` / `PII_OPERATOR` mention in `installation.mdx` sits on a `#`-prefixed shell line
- [x] All 8 JSON `env` blocks in `configuration.mdx` "Client Configuration Examples" are followed by the inline-note phrasing
- [x] Manual eyeball pass against per-file matrix in `specs/089-pii-docs-update/data-model.md`