### PR TITLE
feat(pii)!: walk nested json/jsonb leaves during redaction

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -65,7 +65,7 @@ See [CONTRIBUTING.md](CONTRIBUTING.md) for commit conventions, PR process, and d
 - **MULTI_STATEMENTS**: **NEVER** enable the MULTI_STATEMENTS client flag. The connection MUST clear it to prevent multi-statement SQL injection.
 - **Parameterized queries**: **NEVER** interpolate user values into SQL strings. Use parameterized queries exclusively.
 - **Identifier validation**: **ALWAYS** validate database/table names (alphanumeric and underscore). Never use string interpolation for identifiers — use proper quoting per backend.
-- **PII redaction**: opt-in defense-in-depth applied to query tool output payloads (`readQuery` and any future query tools that route through the redactor). **MUST NOT** be removed or bypassed without an explicit user request. Off by default; operators enable via `--pii` / `PII_ENABLE`.
+- **PII redaction**: opt-in defense-in-depth applied to query tool output payloads (`readQuery` and any future query tools that route through the redactor). **MUST NOT** be removed or bypassed without an explicit user request. Off by default; operators enable via `--pii` / `PII_ENABLE`. The redactor walks every string leaf at any depth inside `json`/`jsonb` columns; JSON object keys are preserved verbatim (only values are inspected).
 
 ## Never Do
 

--- a/crates/pii/src/redact.rs
+++ b/crates/pii/src/redact.rs
@@ -114,10 +114,7 @@ impl Redactor {
     pub fn apply(&self, rows: &mut [Value]) -> Result<RedactionStats, RedactionError> {
         let mut stats = RedactionStats::default();
         let result = catch_unwind(AssertUnwindSafe(|| {
-            let mut stack: Vec<&mut Value> = Vec::with_capacity(rows.len());
-            for row in rows.iter_mut() {
-                stack.push(row);
-            }
+            let mut stack: Vec<&mut Value> = rows.iter_mut().collect();
             while let Some(v) = stack.pop() {
                 match v {
                     Value::String(s) => {
@@ -136,16 +133,8 @@ impl Redactor {
                         }
                         *s = anon.text;
                     }
-                    Value::Object(map) => {
-                        for (_k, child) in map.iter_mut() {
-                            stack.push(child);
-                        }
-                    }
-                    Value::Array(arr) => {
-                        for child in arr.iter_mut() {
-                            stack.push(child);
-                        }
-                    }
+                    Value::Object(map) => stack.extend(map.values_mut()),
+                    Value::Array(arr) => stack.extend(arr.iter_mut()),
                     Value::Number(_) | Value::Bool(_) | Value::Null => {}
                 }
             }
@@ -209,7 +198,6 @@ mod tests {
         assert_eq!(rows[0]["obj"], json!({"k": "<EMAIL_ADDRESS>"}));
         assert_eq!(stats.total, 2);
         assert_eq!(stats.by_entity.get("EMAIL_ADDRESS").copied(), Some(2));
-        // Five string leaves scanned: arr[0], obj.k. Other fields are non-strings.
         assert_eq!(stats.string_leaves_scanned, 2);
     }
 
@@ -319,18 +307,10 @@ mod tests {
         // intermediate `Map` is left empty by the `remove` call below, so its
         // own `Drop` is shallow).
         let mut head = rows.pop().expect("one row");
-        drop(rows);
-        loop {
-            let next = match head {
-                Value::Object(ref mut m) => m.remove("a"),
-                _ => None,
-            };
-            match next {
-                Some(n) => head = n,
-                None => break,
-            }
+        while let Value::Object(ref mut m) = head {
+            let Some(child) = m.remove("a") else { break };
+            head = child;
         }
-        drop(head);
 
         match outcome {
             Ok(stats) => {

--- a/crates/pii/src/redact.rs
+++ b/crates/pii/src/redact.rs
@@ -1,12 +1,16 @@
 //! PII redaction for query tool response payloads.
 //!
-//! Walks each row's top-level string scalars through the [`Analyzer`]
-//! plus the default per-entity operator (`Replace { "<TYPE>" }`),
-//! mutating the input slice in place. Object keys, non-string values,
-//! and nested structures are passed through verbatim.
+//! Walks every reachable [`Value::String`] leaf in each row through the
+//! [`Analyzer`] plus the configured per-entity operator (default
+//! `Replace { "<TYPE>" }`), mutating the input slice in place. Object
+//! keys, non-string scalars (`Number`, `Bool`, `Null`), and the JSON
+//! shape (container ordering, key names, array indexes) are preserved
+//! verbatim. The traversal is iterative — it uses an explicit
+//! heap-resident stack of `&mut Value` work items, so deeply nested
+//! payloads never blow the call stack.
 //!
 //! Failure mode is fail-closed at request granularity: any panic from
-//! the analyzer pipeline is caught and surfaced as
+//! the analyzer pipeline at any depth is caught and surfaced as
 //! [`RedactionError::Internal`], so no rows leak to the client when the
 //! pipeline misbehaves. One `tracing::info!` event with target
 //! `dbmcp::pii` is emitted per [`Redactor::apply`] call when at least
@@ -41,8 +45,13 @@ pub struct RedactionStats {
     pub total: u64,
     /// Per-entity-type counts; `BTreeMap` keeps tracing output stable.
     pub by_entity: BTreeMap<String, u64>,
-    /// Number of `Value::Object` rows iterated.
-    pub rows_scanned: u64,
+    /// Number of `Value::String` leaves examined by the analyzer.
+    ///
+    /// Counts every leaf the walker reached, even ones that produced no
+    /// PII spans. Operators can use it to distinguish "scanned 0 leaves"
+    /// (e.g. row was a top-level number) from "scanned N, redacted 0"
+    /// (no PII present).
+    pub string_leaves_scanned: u64,
 }
 
 /// Redacts PII from query tool response rows.
@@ -82,16 +91,20 @@ impl Redactor {
         }
     }
 
-    /// Walks every row's top-level string values through the analyzer pipeline.
+    /// Walks every reachable string leaf in `rows` through the analyzer pipeline.
     ///
-    /// Mutates `rows` in place. Object keys are never touched; non-string
-    /// values pass through. Emits one `tracing::info!` event per call when
-    /// at least one span was rewritten.
+    /// Mutates `rows` in place. Recurses into [`Value::Object`] values
+    /// and [`Value::Array`] elements at any depth using an iterative
+    /// heap stack — call-stack depth does not scale with payload depth.
+    /// Object keys are never inspected or modified; non-string scalars
+    /// pass through unchanged. Emits one `tracing::info!` event per
+    /// call when at least one span was rewritten.
     ///
     /// # Errors
     ///
     /// Returns [`RedactionError::Internal`] when the analyzer pipeline
-    /// panics; the request must be failed without returning any row.
+    /// panics at any depth; the request must be failed without
+    /// returning any row.
     ///
     /// # Panics
     ///
@@ -101,28 +114,39 @@ impl Redactor {
     pub fn apply(&self, rows: &mut [Value]) -> Result<RedactionStats, RedactionError> {
         let mut stats = RedactionStats::default();
         let result = catch_unwind(AssertUnwindSafe(|| {
+            let mut stack: Vec<&mut Value> = Vec::with_capacity(rows.len());
             for row in rows.iter_mut() {
-                let Some(obj) = row.as_object_mut() else {
-                    continue;
-                };
-                stats.rows_scanned += 1;
-                for (_key, value) in obj.iter_mut() {
-                    let Some(s) = value.as_str() else {
-                        continue;
-                    };
-                    let results = self.analyzer.analyze(s, &AnalyzeOptions::default());
-                    if results.is_empty() {
-                        continue;
+                stack.push(row);
+            }
+            while let Some(v) = stack.pop() {
+                match v {
+                    Value::String(s) => {
+                        stats.string_leaves_scanned += 1;
+                        let results = self.analyzer.analyze(s, &AnalyzeOptions::default());
+                        if results.is_empty() {
+                            continue;
+                        }
+                        let anon = anonymize(s, results, &self.operator);
+                        if anon.operations.is_empty() {
+                            continue;
+                        }
+                        for op in &anon.operations {
+                            stats.total += 1;
+                            *stats.by_entity.entry(op.entity_type.as_str().to_owned()).or_default() += 1;
+                        }
+                        *s = anon.text;
                     }
-                    let anon = anonymize(s, results, &self.operator);
-                    if anon.operations.is_empty() {
-                        continue;
+                    Value::Object(map) => {
+                        for (_k, child) in map.iter_mut() {
+                            stack.push(child);
+                        }
                     }
-                    for op in &anon.operations {
-                        stats.total += 1;
-                        *stats.by_entity.entry(op.entity_type.as_str().to_owned()).or_default() += 1;
+                    Value::Array(arr) => {
+                        for child in arr.iter_mut() {
+                            stack.push(child);
+                        }
                     }
-                    *value = Value::String(anon.text);
+                    Value::Number(_) | Value::Bool(_) | Value::Null => {}
                 }
             }
         }));
@@ -135,7 +159,8 @@ impl Redactor {
                 target: "dbmcp::pii",
                 redactions = stats.total,
                 by_entity = %by_entity,
-                rows_scanned = stats.rows_scanned,
+                rows = rows.len(),
+                string_leaves_scanned = stats.string_leaves_scanned,
                 "pii.redacted"
             );
         }
@@ -148,6 +173,7 @@ impl Redactor {
 mod tests {
     use super::*;
     use crate::{EntityType, Recognizer, RecognizerResult};
+    use dbmcp_config::PiiOperator;
     use serde_json::json;
 
     fn email_row() -> Value {
@@ -162,11 +188,11 @@ mod tests {
         assert_eq!(rows[0]["msg"], "ping me at <EMAIL_ADDRESS>");
         assert_eq!(stats.total, 1);
         assert_eq!(stats.by_entity.get("EMAIL_ADDRESS").copied(), Some(1));
-        assert_eq!(stats.rows_scanned, 1);
+        assert_eq!(stats.string_leaves_scanned, 1);
     }
 
     #[test]
-    fn passes_through_non_string_values() {
+    fn redacts_strings_inside_nested_array_and_object() {
         let r = Redactor::with_defaults();
         let mut rows = vec![json!({
             "n": 42,
@@ -179,9 +205,170 @@ mod tests {
         assert_eq!(rows[0]["n"], 42);
         assert_eq!(rows[0]["flag"], true);
         assert!(rows[0]["missing"].is_null());
-        assert_eq!(rows[0]["arr"], json!(["jane.doe@example.com"]));
-        assert_eq!(rows[0]["obj"], json!({"k": "jane.doe@example.com"}));
+        assert_eq!(rows[0]["arr"], json!(["<EMAIL_ADDRESS>"]));
+        assert_eq!(rows[0]["obj"], json!({"k": "<EMAIL_ADDRESS>"}));
+        assert_eq!(stats.total, 2);
+        assert_eq!(stats.by_entity.get("EMAIL_ADDRESS").copied(), Some(2));
+        // Five string leaves scanned: arr[0], obj.k. Other fields are non-strings.
+        assert_eq!(stats.string_leaves_scanned, 2);
+    }
+
+    #[test]
+    fn redacts_email_at_depth_1_inside_array() {
+        let r = Redactor::with_defaults();
+        let mut rows = vec![json!({"emails": ["a@b.com", "c@d.com"]})];
+        let stats = r.apply(&mut rows).expect("apply ok");
+        assert_eq!(rows[0], json!({"emails": ["<EMAIL_ADDRESS>", "<EMAIL_ADDRESS>"]}));
+        assert_eq!(stats.total, 2);
+        assert_eq!(stats.string_leaves_scanned, 2);
+    }
+
+    #[test]
+    fn redacts_email_at_depth_4_inside_chained_objects() {
+        let r = Redactor::with_defaults();
+        let mut rows = vec![json!({"a": {"b": {"c": {"d": "x@y.com"}}}})];
+        let stats = r.apply(&mut rows).expect("apply ok");
+        assert_eq!(rows[0], json!({"a": {"b": {"c": {"d": "<EMAIL_ADDRESS>"}}}}));
+        assert_eq!(stats.total, 1);
+        assert_eq!(stats.string_leaves_scanned, 1);
+    }
+
+    #[test]
+    fn mixed_array_only_strings_with_pii_rewritten() {
+        let r = Redactor::with_defaults();
+        let mut rows = vec![json!([42, "a@b.com", true, null, {"ip": "1.2.3.4"}])];
+        let stats = r.apply(&mut rows).expect("apply ok");
+        assert_eq!(rows[0][0], 42);
+        assert_eq!(rows[0][1], "<EMAIL_ADDRESS>");
+        assert_eq!(rows[0][2], true);
+        assert!(rows[0][3].is_null());
+        assert_eq!(rows[0][4], json!({"ip": "<IP_ADDRESS>"}));
+        assert_eq!(stats.total, 2);
+        assert_eq!(stats.by_entity.get("EMAIL_ADDRESS").copied(), Some(1));
+        assert_eq!(stats.by_entity.get("IP_ADDRESS").copied(), Some(1));
+        assert_eq!(stats.string_leaves_scanned, 2);
+    }
+
+    #[test]
+    fn top_level_array_row_walked() {
+        let r = Redactor::with_defaults();
+        let mut rows = vec![json!(["a@b.com"])];
+        let stats = r.apply(&mut rows).expect("apply ok");
+        assert_eq!(rows[0], json!(["<EMAIL_ADDRESS>"]));
+        assert_eq!(stats.total, 1);
+        assert_eq!(stats.string_leaves_scanned, 1);
+    }
+
+    #[test]
+    fn top_level_string_row_walked() {
+        let r = Redactor::with_defaults();
+        let mut rows = vec![json!("a@b.com")];
+        let stats = r.apply(&mut rows).expect("apply ok");
+        assert_eq!(rows[0], json!("<EMAIL_ADDRESS>"));
+        assert_eq!(stats.total, 1);
+        assert_eq!(stats.string_leaves_scanned, 1);
+    }
+
+    #[test]
+    fn empty_containers_pass_through_unchanged() {
+        let r = Redactor::with_defaults();
+        let mut rows = vec![json!({}), json!([]), json!({"k": []}), json!({"k": {}})];
+        let stats = r.apply(&mut rows).expect("apply ok");
+        assert_eq!(rows[0], json!({}));
+        assert_eq!(rows[1], json!([]));
+        assert_eq!(rows[2], json!({"k": []}));
+        assert_eq!(rows[3], json!({"k": {}}));
         assert_eq!(stats.total, 0);
+        assert_eq!(stats.string_leaves_scanned, 0);
+    }
+
+    #[test]
+    fn non_string_scalars_unchanged() {
+        let r = Redactor::with_defaults();
+        let mut rows = vec![json!({
+            "n": 42,
+            "f": 2.71,
+            "b": false,
+            "z": null,
+            "arr": [1, 2.0, true, null],
+            "deep": {"x": [{"y": 7}]},
+        })];
+        let original = rows.clone();
+        let stats = r.apply(&mut rows).expect("apply ok");
+        assert_eq!(rows, original);
+        assert_eq!(stats.total, 0);
+        assert_eq!(stats.string_leaves_scanned, 0);
+    }
+
+    #[test]
+    fn deep_50000_nested_object_no_overflow() {
+        let r = Redactor::with_defaults();
+        let mut v = Value::String("x".to_owned());
+        for _ in 0..50_000 {
+            let mut map = serde_json::Map::new();
+            map.insert("a".to_owned(), v);
+            v = Value::Object(map);
+        }
+        let mut rows = vec![v];
+        // Either Ok(_) (redacted/no-PII) or Err(Internal) acceptable per SC-005.
+        // What MUST NOT happen: process crash or stack overflow inside `apply`.
+        let outcome = r.apply(&mut rows);
+
+        // serde_json's derived `Drop for Value` walks recursively; flatten
+        // before scope exit so the deep tree drops level-by-level (each
+        // intermediate `Map` is left empty by the `remove` call below, so its
+        // own `Drop` is shallow).
+        let mut head = rows.pop().expect("one row");
+        drop(rows);
+        loop {
+            let next = match head {
+                Value::Object(ref mut m) => m.remove("a"),
+                _ => None,
+            };
+            match next {
+                Some(n) => head = n,
+                None => break,
+            }
+        }
+        drop(head);
+
+        match outcome {
+            Ok(stats) => {
+                assert_eq!(stats.total, 0);
+                assert_eq!(stats.string_leaves_scanned, 1);
+            }
+            Err(RedactionError::Internal(_)) => {}
+        }
+    }
+
+    #[test]
+    fn string_leaves_scanned_counts_correctly() {
+        let r = Redactor::with_defaults();
+        let mut rows = vec![json!({
+            "s1": "one",
+            "s2": "two",
+            "n": 1,
+            "arr": ["three", "four"],
+            "nested": {"s5": "five"},
+        })];
+        let stats = r.apply(&mut rows).expect("apply ok");
+        assert_eq!(stats.total, 0);
+        assert_eq!(stats.string_leaves_scanned, 5);
+        assert!(stats.string_leaves_scanned >= stats.total);
+    }
+
+    #[test]
+    fn stats_total_invariant_holds_across_nested_payload() {
+        let r = Redactor::with_defaults();
+        let mut rows = vec![json!({
+            "user": {"email": "a@b.com", "ip": "1.2.3.4"},
+            "log": ["c@d.com", "no-pii"],
+        })];
+        let stats = r.apply(&mut rows).expect("apply ok");
+        let summed: u64 = stats.by_entity.values().sum();
+        assert_eq!(stats.total, summed);
+        assert!(stats.string_leaves_scanned >= stats.total);
+        assert_eq!(stats.total, 3);
     }
 
     #[test]
@@ -191,6 +378,16 @@ mod tests {
         let stats = r.apply(&mut rows).expect("apply ok");
         assert_eq!(rows[0], json!({"jane.doe@example.com": 1}));
         assert_eq!(stats.total, 0);
+    }
+
+    #[test]
+    fn same_pii_string_as_key_and_value_only_value_redacted() {
+        let r = Redactor::with_defaults();
+        let mut rows = vec![json!({"a@b.com": "a@b.com"})];
+        let stats = r.apply(&mut rows).expect("apply ok");
+        assert_eq!(rows[0], json!({"a@b.com": "<EMAIL_ADDRESS>"}));
+        assert_eq!(stats.total, 1);
+        assert_eq!(stats.string_leaves_scanned, 1);
     }
 
     #[test]
@@ -209,6 +406,68 @@ mod tests {
         let stats = r.apply(&mut rows).expect("apply ok");
         assert_eq!(rows, original);
         assert_eq!(stats.total, 0);
+        assert_eq!(stats.string_leaves_scanned, 1);
+    }
+
+    #[test]
+    fn flat_string_top_level_path_unchanged() {
+        let r = Redactor::with_defaults();
+        let mut rows = vec![json!({"email": "a@b.com", "age": 42})];
+        let stats = r.apply(&mut rows).expect("apply ok");
+        assert_eq!(rows[0], json!({"email": "<EMAIL_ADDRESS>", "age": 42}));
+        assert_eq!(stats.total, 1);
+        assert_eq!(stats.string_leaves_scanned, 1);
+    }
+
+    #[test]
+    fn whole_leaf_match_replace_emits_placeholder_token() {
+        let r = Redactor::with_defaults();
+        let mut rows = vec![json!({"v": "x@y.com"})];
+        let _ = r.apply(&mut rows).expect("apply ok");
+        assert_eq!(rows[0]["v"], "<EMAIL_ADDRESS>");
+    }
+
+    #[test]
+    fn whole_leaf_match_redact_emits_empty_string() {
+        let r = Redactor::with_operator_config(OperatorConfig::from(PiiOperator::Redact));
+        let mut rows = vec![json!({"v": "x@y.com"})];
+        let _ = r.apply(&mut rows).expect("apply ok");
+        // Whole-leaf match under `redact` → "" (Value::String, key preserved).
+        assert_eq!(rows[0]["v"], "");
+        assert!(rows[0]["v"].is_string());
+        assert!(rows[0].get("v").is_some());
+    }
+
+    #[test]
+    fn whole_leaf_match_mask_matches_text_column() {
+        let r = Redactor::with_operator_config(OperatorConfig::from(PiiOperator::Mask));
+        let mut json_rows = vec![json!({"v": "x@y.com"})];
+        let mut text_rows = vec![Value::String("x@y.com".to_owned())];
+        let _ = r.apply(&mut json_rows).expect("apply ok");
+        let _ = r.apply(&mut text_rows).expect("apply ok");
+        assert_eq!(json_rows[0]["v"], text_rows[0]);
+    }
+
+    #[test]
+    fn whole_leaf_match_hash_matches_text_column() {
+        let r = Redactor::with_operator_config(OperatorConfig::from(PiiOperator::Hash));
+        let mut json_rows = vec![json!({"v": "x@y.com"})];
+        let mut text_rows = vec![Value::String("x@y.com".to_owned())];
+        let _ = r.apply(&mut json_rows).expect("apply ok");
+        let _ = r.apply(&mut text_rows).expect("apply ok");
+        assert_eq!(json_rows[0]["v"], text_rows[0]);
+    }
+
+    #[test]
+    fn mixed_row_redacts_text_and_json_columns_consistently() {
+        let r = Redactor::with_defaults();
+        let mut rows = vec![json!({
+            "text_col": "a@b.com",
+            "json_col": {"email": "a@b.com"},
+        })];
+        let _ = r.apply(&mut rows).expect("apply ok");
+        assert_eq!(rows[0]["text_col"], rows[0]["json_col"]["email"]);
+        assert_eq!(rows[0]["text_col"], "<EMAIL_ADDRESS>");
     }
 
     /// Custom recognizer that panics on first analyze call — used to exercise
@@ -235,6 +494,19 @@ mod tests {
         let r = Redactor::with_analyzer(analyzer);
         let mut rows = vec![json!({"msg": "anything"})];
         let err = r.apply(&mut rows).expect_err("must fail-closed");
+        match err {
+            RedactionError::Internal(msg) => assert!(msg.contains("panicked")),
+        }
+    }
+
+    #[test]
+    fn panic_at_depth_propagates_internal_error() {
+        let mut analyzer = Analyzer::empty();
+        analyzer.register(Box::new(PanickingRecognizer));
+        let r = Redactor::with_analyzer(analyzer);
+        // PII-bearing string lives 4 levels deep.
+        let mut rows = vec![json!({"a": {"b": {"c": {"d": "anything"}}}})];
+        let err = r.apply(&mut rows).expect_err("must fail-closed at any depth");
         match err {
             RedactionError::Internal(msg) => assert!(msg.contains("panicked")),
         }

--- a/docs/content/docs/features.mdx
+++ b/docs/content/docs/features.mdx
@@ -414,6 +414,12 @@ The configured operator decides how each detected span is replaced:
 - `redact` — span removed (replaced with empty string).
 - `hash` — stable hex digest derived via SHA-256.
 
+### Nested JSON values
+
+Redaction walks every string leaf in `json` and `jsonb` columns (and any other column the backend hands the server as a structured `serde_json::Value::Object` or `Value::Array`). A PII string redacts identically whether it arrives as a plain `text` column, a JSON literal cast to `text`, or a leaf nested inside a `jsonb` value at any depth. Non-string scalars (numbers, booleans, `null`) and the JSON shape (key names, array indexes, container ordering) are preserved.
+
+JSON object **keys** are never inspected or modified — only values are redacted. A row like `{"jane.doe@example.com": "value"}` returns with the key intact. If you need key redaction, please open an issue; today's contract is values-only.
+
 See [PII configuration](/docs/configuration#pii) for the toggle, env var, and operator-selection details.
 
 ## Single Binary

--- a/docs/content/docs/security.mdx
+++ b/docs/content/docs/security.mdx
@@ -65,6 +65,8 @@ Redaction applies **only to query tool output payloads** — `readQuery` results
 - Schema-discovery tool responses (`listTables`, `listViews`, `listTriggers`, etc.)
 - Tool arguments supplied by the assistant
 
+Redaction recurses into `json` and `jsonb` columns: every string leaf at any depth is rewritten with the same operator a flat `text` column would use. JSON object keys are preserved verbatim — only values are inspected. Non-string scalars (numbers, booleans, `null`) and the surrounding JSON shape (key names, array indexes, container ordering) are unchanged.
+
 Treat PII redaction as a layer that reduces what an enabled assistant sees in result rows; it is not a blanket guarantee that no sensitive string ever leaves the server. Pair it with database-level controls (least-privilege roles, column masking views) for sensitive datasets.
 
 See [Features](/docs/features#pii-redaction) for the supported entity list and operator semantics, and [Configuration](/docs/configuration#pii) for the toggle and operator-selection flags.


### PR DESCRIPTION
## Summary
- Extend the redactor from a flat top-level pass to full traversal: every reachable `Value::String` leaf inside `Value::Object` and `Value::Array` runs through the analyzer pipeline. Iterative `Vec<&mut Value>` heap stack — call-stack depth does not scale with payload depth.
- Object keys and non-string scalars (`Number`, `Bool`, `Null`) preserved verbatim. Fail-closed via `catch_unwind` at any depth.
- **Breaking:** drop redundant `RedactionStats::rows_scanned` field (was identical to `rows.len()` after the semantic change). Add `RedactionStats::string_leaves_scanned` for per-request leaf-count telemetry. Tracing event now logs `rows = rows.len()` directly.
- Doc updates in `CLAUDE.md`, `docs/content/docs/features.mdx`, `docs/content/docs/security.mdx` covering nested-walk behaviour and the values-only contract.

## Test plan
- [x] `cargo fmt --check`
- [x] `cargo clippy --workspace --tests -- -D warnings`
- [x] `cargo test --workspace --lib --bins` (all runners 0 failures)
- [x] `./tests/run.sh` — 700 integration tests pass across mariadb_12, mysql_9, postgres_18, sqlite
- [x] New unit tests cover: depth-1/depth-4 nesting, top-level array/string rows, mixed-type arrays, empty containers, non-string scalars, 50k-deep object stack-safety, panic-at-depth fail-closed, leaf-count invariants, whole-leaf operator parity (`replace`/`redact`/`mask`/`hash`) between `text` and `json` columns