### PR TITLE
fix(sqlx-json): numeric precision + null serialization (#141)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -199,6 +199,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2af50177e190e07a26ab74f8b1efbfe2ef87da2116221318cb1c2e82baf7de06"
 
 [[package]]
+name = "bigdecimal"
+version = "0.4.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4d6867f1565b3aad85681f1015055b087fcfd840d6aeee6eee7f2da317603695"
+dependencies = [
+ "autocfg",
+ "libm",
+ "num-bigint",
+ "num-integer",
+ "num-traits",
+]
+
+[[package]]
 name = "bit-set"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1417,6 +1430,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "num-bigint"
+version = "0.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a5e44f723f1133c9deac646763579fdb3ac745e418f2a7af9cd0c431da1f20b9"
+dependencies = [
+ "num-integer",
+ "num-traits",
+]
+
+[[package]]
 name = "num-bigint-dig"
 version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2300,6 +2323,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ee6798b1838b6a0f69c007c133b8df5866302197e404e8b6ee8ed3e3a5e68dc6"
 dependencies = [
  "base64",
+ "bigdecimal",
  "bytes",
  "chrono",
  "crc",
@@ -2335,6 +2359,7 @@ name = "sqlx-json"
 version = "0.10.0"
 dependencies = [
  "base64",
+ "bigdecimal",
  "serde_json",
  "sqlx",
 ]
@@ -2385,6 +2410,7 @@ checksum = "aa003f0038df784eb8fecbbac13affe3da23b45194bd57dba231c8f48199c526"
 dependencies = [
  "atoi",
  "base64",
+ "bigdecimal",
  "bitflags",
  "byteorder",
  "bytes",
@@ -2428,6 +2454,7 @@ checksum = "db58fcd5a53cf07c184b154801ff91347e4c30d17a3562a635ff028ad5deda46"
 dependencies = [
  "atoi",
  "base64",
+ "bigdecimal",
  "bitflags",
  "byteorder",
  "chrono",
@@ -2445,6 +2472,7 @@ dependencies = [
  "log",
  "md-5",
  "memchr",
+ "num-bigint",
  "once_cell",
  "rand 0.8.6",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,6 +34,7 @@ sqlx-json = { path = "crates/sqlx-json", version = "0.10.0" }
 # External dependencies
 axum = "0.8"
 base64 = "0.22"
+bigdecimal = "0.4"
 clap = { version = "4", features = ["derive", "env"] }
 hmac = "0.12"
 indexmap = { version = "2", features = ["serde"] }

--- a/crates/sqlx-json/Cargo.toml
+++ b/crates/sqlx-json/Cargo.toml
@@ -9,8 +9,9 @@ repository.workspace = true
 
 [dependencies]
 base64 = { workspace = true }
+bigdecimal = { workspace = true }
 serde_json = { workspace = true }
-sqlx = { workspace = true, features = ["mysql", "postgres", "sqlite", "chrono"] }
+sqlx = { workspace = true, features = ["mysql", "postgres", "sqlite", "chrono", "bigdecimal"] }
 
 [lints]
 workspace = true

--- a/crates/sqlx-json/src/lib.rs
+++ b/crates/sqlx-json/src/lib.rs
@@ -8,6 +8,7 @@
 //! [`MySqlRow`](sqlx::mysql::MySqlRow).
 
 mod mysql;
+mod numeric;
 mod postgres;
 mod sqlite;
 mod traits;

--- a/crates/sqlx-json/src/mysql.rs
+++ b/crates/sqlx-json/src/mysql.rs
@@ -4,16 +4,20 @@
 //! `MySQL` 9 reports `information_schema` text columns as `VARBINARY`; these
 //! are decoded as UTF-8 strings rather than base64. Temporal types (`DATE`,
 //! `TIME`, `DATETIME`, `TIMESTAMP`) are decoded via sqlx's `chrono` integration
-//! and serialized as naive ISO 8601 strings (no timezone offset).
+//! and serialized as naive ISO 8601 strings (no timezone offset). `DECIMAL`
+//! is decoded via `BigDecimal` to preserve precision; `FLOAT` is decoded as
+//! `f32` (sqlx-mysql strict-checks the column type), `DOUBLE` as `f64`.
 
 use base64::Engine as _;
 use base64::engine::general_purpose::STANDARD as BASE64;
+use bigdecimal::BigDecimal;
 use serde_json::{Map, Value};
 use sqlx::mysql::MySqlRow;
 use sqlx::types::chrono::{DateTime, NaiveDate, NaiveDateTime, NaiveTime, Utc};
 use sqlx::{Column, Row, TypeInfo, ValueRef};
 
 use crate::RowExt;
+use crate::numeric::bigdecimal_to_json;
 
 impl RowExt for MySqlRow {
     fn to_json(&self) -> Value {
@@ -40,11 +44,13 @@ impl RowExt for MySqlRow {
                             .map_or_else(|_| Value::String(v.to_string()), |signed| Value::Number(signed.into()))
                     }),
 
-                    "FLOAT" | "DOUBLE" | "DECIMAL" => self
-                        .try_get::<f64, _>(idx)
-                        .ok()
-                        .and_then(serde_json::Number::from_f64)
-                        .map_or(Value::Null, Value::Number),
+                    "DECIMAL" => self
+                        .try_get::<BigDecimal, _>(idx)
+                        .map_or(Value::Null, |v| bigdecimal_to_json(&v)),
+
+                    "FLOAT" => self.try_get::<f32, _>(idx).map_or(Value::Null, Value::from),
+
+                    "DOUBLE" => self.try_get::<f64, _>(idx).map_or(Value::Null, Value::from),
 
                     "JSON" => self.try_get::<Value, _>(idx).unwrap_or(Value::Null),
 

--- a/crates/sqlx-json/src/numeric.rs
+++ b/crates/sqlx-json/src/numeric.rs
@@ -40,6 +40,12 @@ pub(crate) fn bigdecimal_to_json(value: &BigDecimal) -> Value {
     let canonical_digits = normalized.digits() + scale.min(0).unsigned_abs();
     if canonical_digits <= F64_SAFE_DIGITS
         && let Some(as_f64) = normalized.to_f64()
+        // Underflow guard: tiny non-zero values (≈ |v| < 5e-324) clamp to
+        // 0.0 in f64. The integer fast-path above already returned for
+        // true zero, so reaching this branch with `as_f64 == 0.0` means
+        // the value was non-zero and silently lost — fall through to the
+        // canonical-string form instead of emitting JSON `0`.
+        && as_f64 != 0.0
         && let Some(num) = serde_json::Number::from_f64(as_f64)
     {
         return Value::from(num);
@@ -140,5 +146,114 @@ mod tests {
         // `Display` writes scientific form past its zero-threshold.
         let v = bigdecimal_to_json(&dec("1000000000000000000000000000000"));
         assert!(matches!(v, Value::String(_)));
+    }
+
+    #[test]
+    fn zero_is_integer_zero() {
+        assert_eq!(bigdecimal_to_json(&dec("0")), Value::from(0));
+        assert_eq!(bigdecimal_to_json(&dec("0.0")), Value::from(0));
+        assert_eq!(bigdecimal_to_json(&dec("0.0000")), Value::from(0));
+    }
+
+    #[test]
+    fn negative_zero_normalizes_to_zero() {
+        // BigDecimal normalises -0 to 0; emit as integer zero so the wire
+        // form does not leak a meaningless minus sign.
+        let v = bigdecimal_to_json(&dec("-0"));
+        assert_eq!(v, Value::from(0));
+        let v = bigdecimal_to_json(&dec("-0.000"));
+        assert_eq!(v, Value::from(0));
+    }
+
+    #[test]
+    fn i64_min_uses_integer_branch() {
+        let v = bigdecimal_to_json(&dec(&i64::MIN.to_string()));
+        assert_eq!(v, Value::Number(i64::MIN.into()));
+    }
+
+    #[test]
+    fn integer_one_past_i64_max_is_string() {
+        // 9223372036854775808 = i64::MAX + 1. is_integer() is true but
+        // to_i64() returns None; the digit gate (19 > 15) routes to string.
+        let v = bigdecimal_to_json(&dec("9223372036854775808"));
+        assert_eq!(v, Value::String("9223372036854775808".to_string()));
+    }
+
+    #[test]
+    fn very_large_integer_is_string() {
+        // 25-digit integer beyond i64 and beyond f64-safe digit count.
+        let v = bigdecimal_to_json(&dec("1234567890123456789012345"));
+        let Value::String(s) = v else {
+            panic!("expected string for huge integer");
+        };
+        assert_eq!(s, "1234567890123456789012345");
+    }
+
+    #[test]
+    fn tiny_fraction_within_digit_budget_is_number() {
+        // 1e-30 has mantissa "1" (1 digit). f64 can represent this magnitude
+        // (denormal range is ~1e-308), so the value-driven rule emits a
+        // JSON number — not a string — even though it looks "extreme".
+        let v = bigdecimal_to_json(&dec("1e-30"));
+        let Value::Number(n) = v else {
+            panic!("expected JSON number for tiny fraction");
+        };
+        let f = n.as_f64().expect("f64 representable");
+        assert!((f - 1e-30).abs() < 1e-40);
+    }
+
+    #[test]
+    fn integer_15_digits_uses_integer_branch() {
+        // 15-digit integer fits in i64 easily; integer fast-path wins.
+        let v = bigdecimal_to_json(&dec("123456789012345"));
+        assert_eq!(v, Value::Number(123_456_789_012_345_i64.into()));
+    }
+
+    #[test]
+    fn f64_underflow_falls_back_to_string() {
+        // 1e-1000 is below the f64 denormal floor (~5e-324); BigDecimal's
+        // `to_f64` rounds it to 0.0. Without the underflow guard, the
+        // shape rule would emit JSON `0` and silently lose the value.
+        let v = bigdecimal_to_json(&dec("1e-1000"));
+        let Value::String(s) = v else {
+            panic!("expected string for f64-underflow tiny fraction, got {v:?}");
+        };
+        // BigDecimal::Display emits scientific form for extreme exponents.
+        let lower = s.to_ascii_lowercase();
+        assert!(
+            lower.contains("e-1000") || lower.starts_with("0.0"),
+            "must preserve magnitude: {s}"
+        );
+    }
+
+    #[test]
+    fn negative_f64_underflow_falls_back_to_string() {
+        let v = bigdecimal_to_json(&dec("-1e-500"));
+        let Value::String(s) = v else {
+            panic!("expected string for negative-tiny underflow, got {v:?}");
+        };
+        assert!(s.starts_with('-'), "negative sign preserved: {s}");
+    }
+
+    #[test]
+    fn near_underflow_within_f64_range_is_number() {
+        // 1e-300 is comfortably within f64's normal range (~2.2e-308 min);
+        // must emit as JSON number — guard must not over-trigger.
+        let v = bigdecimal_to_json(&dec("1e-300"));
+        let Value::Number(n) = v else {
+            panic!("1e-300 must emit as JSON number, got {v:?}");
+        };
+        let f = n.as_f64().expect("number is f64");
+        assert!((f / 1e-300 - 1.0).abs() < 1e-10, "round-trip preserved: {f}");
+    }
+
+    #[test]
+    fn non_integer_with_negative_scale_is_handled() {
+        // 1.23e5 = 123000 — integer-valued after normalisation, so the
+        // integer fast-path applies; verifies that the digit-gate fallback
+        // does not double-count digits for negative-scale representations
+        // that normalise to whole numbers.
+        let v = bigdecimal_to_json(&dec("1.23e5"));
+        assert_eq!(v, Value::from(123_000));
     }
 }

--- a/crates/sqlx-json/src/numeric.rs
+++ b/crates/sqlx-json/src/numeric.rs
@@ -1,0 +1,144 @@
+//! Shared `BigDecimal` → JSON conversion for the per-backend row decoders.
+//!
+//! `bigdecimal_to_json` enforces the value-driven JSON shape rule for
+//! fixed-point and arbitrary-precision numerics: integers fitting in `i64`
+//! emit as integer JSON numbers, values whose canonical decimal form has
+//! ≤15 digits emit as JSON numbers via `Number::from_f64`, and everything
+//! else emits as the decimal string. The same database value always
+//! produces the same JSON shape regardless of column or backend.
+
+use bigdecimal::{BigDecimal, ToPrimitive};
+use serde_json::Value;
+
+/// Maximum significant decimal digits that round-trip through `f64`.
+///
+/// IEEE 754 binary64 holds 15–17 decimal digits depending on value; 15 is
+/// the conservative bound that guarantees a clean round-trip for every
+/// value. Beyond this, the canonical decimal string is the only lossless
+/// JSON shape.
+const F64_SAFE_DIGITS: u64 = 15;
+
+/// Converts a `BigDecimal` to the canonical JSON shape for numeric values.
+///
+/// Integer-valued decimals that fit in `i64` emit as integer JSON numbers.
+/// Other values emit as `Value::Number` when their canonical decimal form
+/// has at most `F64_SAFE_DIGITS` digits, else as `Value::String` carrying
+/// the decimal text.
+pub(crate) fn bigdecimal_to_json(value: &BigDecimal) -> Value {
+    let normalized = value.normalized();
+
+    if normalized.is_integer()
+        && let Some(as_i64) = normalized.to_i64()
+    {
+        return Value::from(as_i64);
+    }
+
+    // `digits()` counts mantissa only — for negative scale (e.g. `1e30` =
+    // mantissa 1, scale -29) add the trailing zeros so huge values don't
+    // slip past the gate and emit as lossy JSON numbers.
+    let scale = normalized.fractional_digit_count();
+    let canonical_digits = normalized.digits() + scale.min(0).unsigned_abs();
+    if canonical_digits <= F64_SAFE_DIGITS
+        && let Some(as_f64) = normalized.to_f64()
+        && let Some(num) = serde_json::Number::from_f64(as_f64)
+    {
+        return Value::from(num);
+    }
+
+    // `Display` (uses scientific form past internal thresholds) keeps the
+    // output bounded for pathological NUMERICs; `to_plain_string` would
+    // expand 1e131072 to a 131-KB string per row.
+    Value::String(normalized.to_string())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::str::FromStr;
+
+    fn dec(s: &str) -> BigDecimal {
+        BigDecimal::from_str(s).expect("valid decimal literal")
+    }
+
+    #[test]
+    fn small_fixed_point_is_number() {
+        assert_eq!(bigdecimal_to_json(&dec("0.5")), Value::from(0.5));
+        assert_eq!(bigdecimal_to_json(&dec("42")), Value::from(42));
+        assert_eq!(bigdecimal_to_json(&dec("-1.25")), Value::from(-1.25));
+    }
+
+    #[test]
+    fn trailing_zeros_normalize_consistently() {
+        let a = bigdecimal_to_json(&dec("1.20"));
+        let b = bigdecimal_to_json(&dec("1.2"));
+        assert_eq!(a, b);
+    }
+
+    #[test]
+    fn value_beyond_f64_precision_is_string() {
+        let v = bigdecimal_to_json(&dec("12345678901234567890.1234567890"));
+        assert_eq!(v, Value::String("12345678901234567890.123456789".to_string()));
+    }
+
+    #[test]
+    fn small_decimal_with_many_significant_digits_is_string() {
+        let v = bigdecimal_to_json(&dec("0.123456789012345678901234567890"));
+        let Value::String(s) = v else {
+            panic!("expected string for high-precision small decimal");
+        };
+        assert!(s.starts_with("0.12345678901234567890"));
+    }
+
+    #[test]
+    fn shape_is_deterministic_per_value() {
+        let v1 = bigdecimal_to_json(&dec("99999999999999999999.99"));
+        let v2 = bigdecimal_to_json(&dec("99999999999999999999.99"));
+        assert_eq!(v1, v2);
+        assert!(matches!(v1, Value::String(_)));
+    }
+
+    #[test]
+    fn integer_value_uses_integer_branch_regardless_of_digit_count() {
+        // i64::MAX has 19 digits but is still an integer that fits, so the
+        // integer fast-path wins over the digit gate.
+        let v = bigdecimal_to_json(&dec(&i64::MAX.to_string()));
+        assert_eq!(v, Value::Number(i64::MAX.into()));
+    }
+
+    #[test]
+    fn boundary_15_digit_fraction_is_number() {
+        let v = bigdecimal_to_json(&dec("12345678901234.5"));
+        assert!(matches!(v, Value::Number(_)));
+    }
+
+    #[test]
+    fn boundary_16_digit_fraction_is_string() {
+        let v = bigdecimal_to_json(&dec("12345678901234.56"));
+        assert!(matches!(v, Value::String(_)));
+    }
+
+    #[test]
+    fn small_fraction_with_few_digits_is_number() {
+        // 0.1 has 1 significant digit; safe in f64 even though the binary
+        // representation is approximate. JSON serialization is shortest
+        // round-trip via ryu, so the wire form matches the database value.
+        assert_eq!(bigdecimal_to_json(&dec("0.1")), Value::from(0.1));
+        assert_eq!(bigdecimal_to_json(&dec("0.10")), Value::from(0.1));
+        assert_eq!(bigdecimal_to_json(&dec("0.30")), Value::from(0.3));
+    }
+
+    #[test]
+    fn high_precision_fraction_is_string() {
+        let v = bigdecimal_to_json(&dec("0.123456789012345678"));
+        assert!(matches!(v, Value::String(_)));
+    }
+
+    #[test]
+    fn huge_magnitude_with_few_significant_digits_is_string() {
+        // 1 followed by 30 zeros (DECIMAL(38,0)). Mantissa has 1 digit but
+        // magnitude exceeds 2^53, so canonical form must emit as string —
+        // `Display` writes scientific form past its zero-threshold.
+        let v = bigdecimal_to_json(&dec("1000000000000000000000000000000"));
+        assert!(matches!(v, Value::String(_)));
+    }
+}

--- a/crates/sqlx-json/src/postgres.rs
+++ b/crates/sqlx-json/src/postgres.rs
@@ -6,15 +6,33 @@
 //! `PostgreSQL`. Temporal types (`DATE`, `TIME`, `TIMESTAMP`, `TIMESTAMPTZ`)
 //! are decoded via sqlx's `chrono` integration and serialized as RFC 3339
 //! strings; `TIMESTAMPTZ` is normalized to UTC and emitted with a `Z` suffix.
+//! `NUMERIC` is decoded via `BigDecimal` to preserve precision; `MONEY`
+//! arrives as text (sqlx uses simple-query for parameterless statements)
+//! and is parsed locale-aware then routed through the same shape rule.
+
+use std::str::FromStr;
 
 use base64::Engine as _;
 use base64::engine::general_purpose::STANDARD as BASE64;
+use bigdecimal::BigDecimal;
 use serde_json::{Map, Value};
 use sqlx::postgres::PgRow;
 use sqlx::types::chrono::{DateTime, NaiveDate, NaiveDateTime, NaiveTime, Utc};
 use sqlx::{Column, Row, TypeInfo, ValueRef};
 
 use crate::RowExt;
+use crate::numeric::bigdecimal_to_json;
+
+/// Parses a locale-formatted Postgres `MONEY` text value into a `BigDecimal`.
+///
+/// Strips currency symbol and grouping separators (everything except digits,
+/// `.`, and `-`), then parses what remains. Tuned for the en_US.UTF-8
+/// `lc_monetary` default — locales using `,` as decimal separator are not
+/// supported.
+fn parse_pg_money_text(text: &str) -> Option<BigDecimal> {
+    let cleaned: String = text.chars().filter(|c| matches!(c, '0'..='9' | '.' | '-')).collect();
+    BigDecimal::from_str(&cleaned).ok()
+}
 
 impl RowExt for PgRow {
     fn to_json(&self) -> Value {
@@ -43,11 +61,24 @@ impl RowExt for PgRow {
                         .try_get::<i16, _>(idx)
                         .map_or(Value::Null, |v| Value::Number(i64::from(v).into())),
 
-                    "FLOAT4" | "FLOAT8" | "NUMERIC" | "MONEY" => self
-                        .try_get::<f64, _>(idx)
+                    "NUMERIC" => self
+                        .try_get::<BigDecimal, _>(idx)
+                        .map_or(Value::Null, |v| bigdecimal_to_json(&v)),
+
+                    // dbmcp passes raw `&str` queries → sqlx uses Postgres' simple-query
+                    // (text) protocol, where `PgMoney` errors out (binary-only). Parse the
+                    // locale-formatted text form ($1,234.56, -$99.99) directly — assumes the
+                    // en_US.UTF-8 lc_monetary default (`$` symbol, `.` decimal).
+                    "MONEY" => self
+                        .try_get_raw(idx)
                         .ok()
-                        .and_then(serde_json::Number::from_f64)
-                        .map_or(Value::Null, Value::Number),
+                        .and_then(|v| v.as_str().ok())
+                        .and_then(parse_pg_money_text)
+                        .map_or(Value::Null, |bd| bigdecimal_to_json(&bd)),
+
+                    "FLOAT4" => self.try_get::<f32, _>(idx).map_or(Value::Null, Value::from),
+
+                    "FLOAT8" => self.try_get::<f64, _>(idx).map_or(Value::Null, Value::from),
 
                     "BYTEA" => self
                         .try_get::<Vec<u8>, _>(idx)

--- a/crates/sqlx-json/src/postgres.rs
+++ b/crates/sqlx-json/src/postgres.rs
@@ -113,3 +113,79 @@ impl RowExt for PgRow {
         Value::Object(map)
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::parse_pg_money_text;
+    use bigdecimal::BigDecimal;
+    use std::str::FromStr;
+
+    fn dec(s: &str) -> BigDecimal {
+        BigDecimal::from_str(s).expect("valid decimal literal")
+    }
+
+    #[test]
+    fn parses_plain_money() {
+        assert_eq!(parse_pg_money_text("$123.45"), Some(dec("123.45")));
+    }
+
+    #[test]
+    fn parses_money_with_thousand_separators() {
+        // Postgres MONEY in en_US.UTF-8 emits grouping commas in output:
+        // `$1,234,567.89`. The filter drops everything but digits/`.`/`-`,
+        // so commas vanish before parsing.
+        assert_eq!(parse_pg_money_text("$1,234.56"), Some(dec("1234.56")));
+        assert_eq!(parse_pg_money_text("$1,234,567.89"), Some(dec("1234567.89")));
+    }
+
+    #[test]
+    fn parses_zero_money() {
+        assert_eq!(parse_pg_money_text("$0.00"), Some(dec("0")));
+    }
+
+    #[test]
+    fn parses_negative_money_leading_minus_outside_symbol() {
+        // Default en_US.UTF-8 form: `-$99.99`.
+        assert_eq!(parse_pg_money_text("-$99.99"), Some(dec("-99.99")));
+    }
+
+    #[test]
+    fn parses_negative_money_with_minus_after_symbol() {
+        // Some locales render as `$-99.99`; filter retains `-` so the parse
+        // still produces a negative value.
+        assert_eq!(parse_pg_money_text("$-99.99"), Some(dec("-99.99")));
+    }
+
+    #[test]
+    fn empty_string_returns_none() {
+        assert!(parse_pg_money_text("").is_none());
+    }
+
+    #[test]
+    fn unparseable_returns_none() {
+        // After filtering: `..` — bigdecimal rejects this.
+        assert!(parse_pg_money_text("$.").is_none());
+        assert!(parse_pg_money_text("abc").is_none());
+    }
+
+    #[test]
+    fn accounting_parens_misparsed_as_positive() {
+        // Documents a known limitation: locales that wrap negatives in
+        // parentheses ($99.99) lose the negative sign because the filter
+        // strips `(` and `)`. Postgres en_US.UTF-8 default does not use
+        // this form; if a deployment customises lc_monetary to one that
+        // does, the wire form will be wrong. Test pins behaviour so any
+        // future fix surfaces as an obvious diff.
+        assert_eq!(parse_pg_money_text("($99.99)"), Some(dec("99.99")));
+    }
+
+    #[test]
+    fn large_money_at_i64_max_cents() {
+        // $92,233,720,368,547,758.07 — the maximum positive Postgres MONEY,
+        // beyond f64's 15-digit safe range.
+        assert_eq!(
+            parse_pg_money_text("$92,233,720,368,547,758.07"),
+            Some(dec("92233720368547758.07"))
+        );
+    }
+}

--- a/crates/sqlx-json/src/sqlite.rs
+++ b/crates/sqlx-json/src/sqlite.rs
@@ -64,7 +64,3 @@ fn dynamic_probe(row: &SqliteRow, idx: usize) -> Value {
     }
     row.try_get::<String, _>(idx).map_or(Value::Null, Value::String)
 }
-
-// Unit tests for row conversion are not possible without a database connection
-// because sqlx row types have no public constructors. All conversion tests
-// are covered by the integration test suite (./tests/run.sh).

--- a/tests/functional/mysql.rs
+++ b/tests/functional/mysql.rs
@@ -1574,17 +1574,18 @@ async fn test_read_query_non_select_show_tables_single_page() {
         without_cursor.rows, with_cursor.rows,
         "cursor must be silently ignored for non-SELECT statements"
     );
-    // SHOW TABLES in `app` returns 7 seeded base tables (users, posts, tags,
-    // post_tags, temporal, posts_audit, events_by_year) plus 9 seeded views
-    // (active_users, active_users_v2, active_orders, active_users_with_check_cascaded,
-    // active_users_with_check_local, archived_users, archived_users_invoker,
-    // user_metrics_cte, published_posts); MySQL's SHOW TABLES lists both. Must
-    // not be paginated even with page_size=2.
+    // SHOW TABLES in `app` returns 8 seeded base tables (users, posts, tags,
+    // post_tags, temporal, posts_audit, events_by_year, numeric_samples) plus
+    // 9 seeded views (active_users, active_users_v2, active_orders,
+    // active_users_with_check_cascaded, active_users_with_check_local,
+    // archived_users, archived_users_invoker, user_metrics_cte,
+    // published_posts); MySQL's SHOW TABLES lists both. Must not be paginated
+    // even with page_size=2.
     let rows = &without_cursor.rows;
     assert_eq!(
         rows.len(),
-        16,
-        "SHOW TABLES must not be paginated: expected all 16 seeded tables+views, got {}",
+        17,
+        "SHOW TABLES must not be paginated: expected all 17 seeded tables+views, got {}",
         rows.len()
     );
 }
@@ -4550,4 +4551,78 @@ async fn read_query_hash_operator_emits_stable_digest() {
     assert_ne!(a, "jane.doe@example.com");
     assert_eq!(a.len(), 64, "SHA-256 hex digest is 64 chars: {a}");
     assert!(a.chars().all(|c| c.is_ascii_hexdigit()), "digest must be hex: {a}");
+}
+
+// Spec 092 / issue #141 — DECIMAL/FLOAT/DOUBLE round-trip through readQuery
+// without silent nulls or precision loss. Asserts against the value-driven
+// JSON shape rule from data-model.md.
+#[tokio::test]
+async fn test_read_numeric_columns_round_trip() {
+    let handler = handler(false);
+    let select = ReadQueryRequest {
+        query: "SELECT label, d_small, d_int, d_overflow, f, dbl FROM numeric_samples ORDER BY id".into(),
+        database: Some("app".into()),
+        cursor: None,
+    };
+    let rows = handler.read_query(select).await.unwrap();
+    let by_label: std::collections::HashMap<&str, &Value> = rows
+        .rows
+        .iter()
+        .map(|r| (r["label"].as_str().expect("label is a string"), r))
+        .collect();
+
+    let basic = by_label["basic"];
+    assert_eq!(basic["d_small"], serde_json::json!(123.45), "DECIMAL(10,2) basic");
+    assert_eq!(basic["d_int"], serde_json::json!(42), "DECIMAL(10,0) integer");
+    assert_eq!(basic["d_overflow"], serde_json::json!(1.5), "DECIMAL(38,10) small fits");
+    assert_eq!(basic["f"], serde_json::json!(1.5), "FLOAT must not be null");
+    assert_eq!(basic["dbl"], serde_json::json!(2.5), "DOUBLE round-trip");
+
+    let trailing = by_label["trailing_zero"];
+    assert_eq!(trailing["d_small"], serde_json::json!(1.2), "trailing zero normalized");
+    assert_eq!(trailing["d_int"], serde_json::json!(10));
+    assert_eq!(trailing["d_overflow"], serde_json::json!(0.1));
+    assert_eq!(trailing["f"], serde_json::json!(0.5));
+    assert_eq!(trailing["dbl"], serde_json::json!(1.0));
+
+    let neg = by_label["negative"];
+    assert_eq!(neg["d_small"], serde_json::json!(-99.99));
+    assert_eq!(neg["d_int"], serde_json::json!(-7));
+    assert_eq!(neg["d_overflow"], serde_json::json!(-123.45));
+    assert_eq!(neg["f"], serde_json::json!(-1.5));
+    assert_eq!(neg["dbl"], serde_json::json!(-2.5));
+
+    let overflow = by_label["overflow"];
+    assert_eq!(overflow["d_small"], serde_json::json!(0.01));
+    assert_eq!(overflow["d_int"], serde_json::json!(1));
+    assert_eq!(
+        overflow["d_overflow"],
+        serde_json::json!("12345678901234567890.123456789"),
+        "DECIMAL(38,10) beyond f64 precision must be exact-text string"
+    );
+    assert_eq!(overflow["f"], serde_json::json!(1.5));
+    assert_eq!(overflow["dbl"], serde_json::json!(1e100));
+
+    let null_row = by_label["all_null"];
+    assert_eq!(null_row["d_small"], Value::Null, "explicit SQL NULL preserved");
+    assert_eq!(null_row["d_int"], Value::Null);
+    assert_eq!(null_row["d_overflow"], Value::Null);
+    assert_eq!(null_row["f"], Value::Null);
+    assert_eq!(null_row["dbl"], Value::Null);
+}
+
+// Spec 092 US2 — DECIMAL aggregation preserves precision end-to-end (SC-003).
+#[tokio::test]
+async fn test_read_decimal_aggregation_exact_precision() {
+    let handler = handler(false);
+    let select = ReadQueryRequest {
+        query:
+            "SELECT SUM(d_small) AS total FROM numeric_samples WHERE label IN ('basic', 'trailing_zero', 'overflow')"
+                .into(),
+        database: Some("app".into()),
+        cursor: None,
+    };
+    let rows = handler.read_query(select).await.unwrap();
+    // 123.45 + 1.20 + 0.01 = 124.66 — fits in f64 → JSON number.
+    assert_eq!(rows.rows[0]["total"], serde_json::json!(124.66));
 }

--- a/tests/functional/mysql.rs
+++ b/tests/functional/mysql.rs
@@ -4626,3 +4626,67 @@ async fn test_read_decimal_aggregation_exact_precision() {
     // 123.45 + 1.20 + 0.01 = 124.66 — fits in f64 → JSON number.
     assert_eq!(rows.rows[0]["total"], serde_json::json!(124.66));
 }
+
+// AVG over DECIMAL widens scale per MySQL rules (DECIMAL(M+4, D+4)).
+// Verifies the digit-gate handles the resulting higher-precision result
+// correctly and integer-valued averages still take the integer fast-path.
+#[tokio::test]
+async fn test_read_decimal_avg_preserves_precision() {
+    let handler = handler(false);
+    let select = ReadQueryRequest {
+        query: "SELECT AVG(d_int) AS avg_int FROM numeric_samples \
+                WHERE label IN ('basic', 'trailing_zero')"
+            .into(),
+        database: Some("app".into()),
+        cursor: None,
+    };
+    let rows = handler.read_query(select).await.unwrap();
+    // (42 + 10) / 2 = 26 — integer-valued → integer fast-path.
+    assert_eq!(rows.rows[0]["avg_int"], serde_json::json!(26));
+}
+
+// MySQL rejects NaN/Inf for FLOAT/DOUBLE storage and produces NULL (not
+// NaN) for invalid math like 0/0. Verifies the wire shape is consistent
+// regardless of how the engine arrives at the missing value.
+#[tokio::test]
+async fn test_read_float_invalid_math_emits_null() {
+    let handler = handler(false);
+    let select = ReadQueryRequest {
+        query: "SELECT 0.0 / 0.0 AS div_zero, \
+                       LOG(-1) AS log_neg, \
+                       SQRT(-1) AS sqrt_neg"
+            .into(),
+        database: Some("app".into()),
+        cursor: None,
+    };
+    let rows = handler.read_query(select).await.unwrap();
+    assert_eq!(rows.rows[0]["div_zero"], Value::Null);
+    assert_eq!(rows.rows[0]["log_neg"], Value::Null);
+    assert_eq!(rows.rows[0]["sqrt_neg"], Value::Null);
+}
+
+// FLOAT (sqlx-mysql strict-checks the column type) was previously decoded
+// as f64 and silently emitted Null for every row. Asserts the FLOAT path
+// works for negative, zero, and large magnitudes — a regression test for
+// issue #141.
+#[tokio::test]
+async fn test_read_float_column_full_range() {
+    let handler = handler(false);
+    let select = ReadQueryRequest {
+        query: "SELECT label, f FROM numeric_samples ORDER BY id".into(),
+        database: Some("app".into()),
+        cursor: None,
+    };
+    let rows = handler.read_query(select).await.unwrap();
+    let by_label: std::collections::HashMap<&str, &Value> = rows
+        .rows
+        .iter()
+        .map(|r| (r["label"].as_str().expect("label"), r))
+        .collect();
+    assert!(
+        matches!(by_label["basic"]["f"], Value::Number(_)),
+        "FLOAT must not be Null"
+    );
+    assert!(matches!(by_label["negative"]["f"], Value::Number(_)));
+    assert!(matches!(by_label["overflow"]["f"], Value::Number(_)));
+}

--- a/tests/functional/postgres.rs
+++ b/tests/functional/postgres.rs
@@ -4167,3 +4167,190 @@ async fn test_read_numeric_aggregation_exact_precision() {
     // 123.45 + 1.20 + 0.01 = 124.66 — fits in f64 → JSON number.
     assert_eq!(rows.rows[0]["total"], serde_json::json!(124.66));
 }
+
+// AVG over NUMERIC produces a higher-scale result than the input columns
+// (Postgres widens scale for AVG). Verifies the digit-gate path: integers
+// inside the avg widen to a fraction with extra zero scale digits but the
+// canonical decimal still fits in 15 significant digits → JSON number.
+#[tokio::test]
+async fn test_read_numeric_avg_preserves_precision() {
+    let handler = handler(false);
+    let select = ReadQueryRequest {
+        query: "SELECT AVG(n_int)::numeric(20, 6) AS avg_int FROM numeric_samples \
+                WHERE label IN ('basic', 'trailing_zero')"
+            .into(),
+        database: Some("app".into()),
+        cursor: None,
+    };
+    let rows = handler.read_query(select).await.unwrap();
+    // (42 + 10) / 2 = 26 — integer-valued AVG normalises back to integer.
+    assert_eq!(rows.rows[0]["avg_int"], serde_json::json!(26));
+}
+
+// NUMERIC special values: 'NaN' and ±Infinity (PG 14+) are valid in
+// Postgres but unrepresentable in BigDecimal — sqlx::try_get fails and the
+// row decoder emits SQL Null. Pin behaviour so a future bigdecimal/sqlx
+// upgrade that adds support surfaces as an obvious diff (and we can revisit
+// emitting "NaN"/"Infinity" strings if downstream consumers want them).
+#[tokio::test]
+async fn test_read_numeric_special_values_emit_null() {
+    let handler = handler(false);
+    let select = ReadQueryRequest {
+        query: "SELECT 'NaN'::numeric AS n_nan, \
+                       'Infinity'::numeric AS n_inf, \
+                       '-Infinity'::numeric AS n_neg_inf"
+            .into(),
+        database: Some("app".into()),
+        cursor: None,
+    };
+    let rows = handler.read_query(select).await.unwrap();
+    assert_eq!(rows.rows[0]["n_nan"], Value::Null, "NaN unrepresentable → Null");
+    assert_eq!(rows.rows[0]["n_inf"], Value::Null, "+Infinity unrepresentable → Null");
+    assert_eq!(
+        rows.rows[0]["n_neg_inf"],
+        Value::Null,
+        "-Infinity unrepresentable → Null"
+    );
+}
+
+// Float NaN/Infinity round-trip: sqlx decodes as f64::NAN / f64::INFINITY,
+// then `Value::from(f64)` emits Null because serde_json::Number cannot
+// represent non-finite floats. Locks behaviour explicitly so a future
+// switch to a JSON encoder that admits NaN does not silently change the
+// wire shape.
+#[tokio::test]
+async fn test_read_float_nan_inf_emit_null() {
+    let handler = handler(false);
+    let select = ReadQueryRequest {
+        query: "SELECT 'NaN'::float8 AS f_nan, \
+                       'Infinity'::float8 AS f_inf, \
+                       '-Infinity'::float8 AS f_neg_inf, \
+                       'NaN'::float4 AS f4_nan, \
+                       'Infinity'::float4 AS f4_inf"
+            .into(),
+        database: Some("app".into()),
+        cursor: None,
+    };
+    let rows = handler.read_query(select).await.unwrap();
+    assert_eq!(rows.rows[0]["f_nan"], Value::Null);
+    assert_eq!(rows.rows[0]["f_inf"], Value::Null);
+    assert_eq!(rows.rows[0]["f_neg_inf"], Value::Null);
+    assert_eq!(rows.rows[0]["f4_nan"], Value::Null);
+    assert_eq!(rows.rows[0]["f4_inf"], Value::Null);
+}
+
+// Negative-scale NUMERIC magnitudes: 1e30 has 1 mantissa digit but 31
+// significant decimal digits when canonicalised. The shape rule must route
+// to string (not a lossy f64 number) and preserve magnitude/sign — exact
+// textual form depends on `BigDecimal::Display` (scientific past internal
+// thresholds), so we assert shape, not literal text.
+#[tokio::test]
+async fn test_read_numeric_huge_magnitude_emits_string() {
+    let handler = handler(false);
+    let select = ReadQueryRequest {
+        query: "SELECT 1e30::numeric AS huge, (-1e30)::numeric AS huge_neg".into(),
+        database: Some("app".into()),
+        cursor: None,
+    };
+    let rows = handler.read_query(select).await.unwrap();
+    let huge = rows.rows[0]["huge"].as_str().expect("huge magnitude must be string");
+    assert!(
+        !huge.starts_with('-'),
+        "positive magnitude has no leading minus: {huge}"
+    );
+    let parsed: f64 = huge.replace('E', "e").parse().expect("parses as f64");
+    assert!(
+        (parsed - 1e30).abs() / 1e30 < 1e-10,
+        "wire form must round-trip to ~1e30, got {huge}"
+    );
+    let huge_neg = rows.rows[0]["huge_neg"]
+        .as_str()
+        .expect("negative huge magnitude must be string");
+    assert!(huge_neg.starts_with('-'), "negative magnitude keeps sign: {huge_neg}");
+}
+
+// f64 underflow regression: NUMERIC values smaller than ~5e-324 round to
+// 0.0 when converted to f64. Without an underflow guard, the shape rule
+// would emit JSON `0` and silently lose the value. End-to-end check that
+// the wire form preserves magnitude for tiny non-zero NUMERICs.
+#[tokio::test]
+async fn test_read_numeric_f64_underflow_emits_string() {
+    let handler = handler(false);
+    let select = ReadQueryRequest {
+        query: "SELECT 1e-500::numeric AS tiny, (-1e-500)::numeric AS tiny_neg".into(),
+        database: Some("app".into()),
+        cursor: None,
+    };
+    let rows = handler.read_query(select).await.unwrap();
+    let tiny = rows.rows[0]["tiny"].as_str().expect("tiny non-zero must be string");
+    assert!(
+        tiny.to_ascii_lowercase().contains("e-500") || tiny.starts_with("0.0"),
+        "magnitude must survive: {tiny}"
+    );
+    assert_ne!(
+        rows.rows[0]["tiny"],
+        serde_json::json!(0),
+        "must not silently round to JSON 0"
+    );
+    let tiny_neg = rows.rows[0]["tiny_neg"].as_str().expect("negative tiny is string");
+    assert!(tiny_neg.starts_with('-'), "negative sign preserved: {tiny_neg}");
+}
+
+// `DOUBLE PRECISION` value at f64-magnitude boundary (spec data-model:74).
+// `1e308` is within f64 range and must round-trip as a JSON number;
+// `1e400` overflows to ±Infinity and emits Null (spec out-of-scope, but
+// pinned here so the wire shape stays consistent if upstream changes).
+#[tokio::test]
+async fn test_read_float8_extreme_magnitude() {
+    let handler = handler(false);
+    let select = ReadQueryRequest {
+        query: "SELECT 1e308::float8 AS big, (-1e308)::float8 AS big_neg, \
+                       'Infinity'::float8 / 1e308::float8 AS overflows"
+            .into(),
+        database: Some("app".into()),
+        cursor: None,
+    };
+    let rows = handler.read_query(select).await.unwrap();
+    let big = rows.rows[0]["big"].as_f64().expect("1e308 fits in f64");
+    assert!(
+        (big / 1e308 - 1.0).abs() < 1e-10,
+        "big magnitude round-trips: got {big}"
+    );
+    let big_neg = rows.rows[0]["big_neg"].as_f64().expect("-1e308 fits");
+    assert!(big_neg < 0.0);
+    // Infinity / 1e308 = Infinity → Null.
+    assert_eq!(rows.rows[0]["overflows"], Value::Null);
+}
+
+// PII redaction interaction with stringified NUMERIC overflow values.
+//
+// Issue #141 changed NUMERIC overflow rendering from `Null` → JSON string
+// (e.g. `"12345678901234567890.123456789"`). With PII enabled, every
+// string leaf is scanned, so a stringified numeric is now eligible for
+// redaction. The trailing 9-digit run matches the US_SSN recogniser's
+// dotted pattern (e.g. `123.45.6789` → `<US_SSN>`). This test pins that
+// interaction so a future PII-recogniser tweak (or a decision to skip
+// digit-only/decimal-only leaves) surfaces as an obvious diff. PII is
+// off by default; operators who enable it accept fuzzy-match collateral.
+#[tokio::test]
+async fn test_pii_redaction_applies_to_numeric_overflow_string() {
+    let handler = handler_with_redaction(true);
+    let select = ReadQueryRequest {
+        query: "SELECT n_overflow FROM numeric_samples WHERE label = 'overflow'".into(),
+        database: Some("app".into()),
+        cursor: None,
+    };
+    let rows = handler.read_query(select).await.unwrap();
+    let value = rows.rows[0]["n_overflow"].as_str().expect("string after PII walk");
+    // Integer prefix is unanchored against current recognisers and survives
+    // intact; trailing 9-digit run hits US_SSN. Document the split so any
+    // future change is visible.
+    assert!(
+        value.starts_with("12345678901234567890."),
+        "integer prefix must survive PII walk verbatim: {value}"
+    );
+    assert!(
+        value.contains("<US_SSN>") || value == "12345678901234567890.123456789",
+        "trailing digits either match SSN recogniser or pass through verbatim: {value}"
+    );
+}

--- a/tests/functional/postgres.rs
+++ b/tests/functional/postgres.rs
@@ -4080,3 +4080,90 @@ async fn read_query_hash_operator_emits_stable_digest() {
     assert_eq!(a.len(), 64, "SHA-256 hex digest is 64 chars: {a}");
     assert!(a.chars().all(|c| c.is_ascii_hexdigit()), "digest must be hex: {a}");
 }
+
+// Spec 092 / issue #141 (US3) — NUMERIC, MONEY, REAL, DOUBLE PRECISION round-trip
+// through readQuery without silent nulls or precision loss. Asserts against
+// the value-driven JSON shape rule from data-model.md.
+#[tokio::test]
+async fn test_read_numeric_columns_round_trip() {
+    let handler = handler(false);
+    let select = ReadQueryRequest {
+        query: "SELECT label, n_small, n_int, n_overflow, f4, f8, m_small, m_overflow FROM numeric_samples ORDER BY id"
+            .into(),
+        database: Some("app".into()),
+        cursor: None,
+    };
+    let rows = handler.read_query(select).await.unwrap();
+    let by_label: std::collections::HashMap<&str, &Value> = rows
+        .rows
+        .iter()
+        .map(|r| (r["label"].as_str().expect("label is a string"), r))
+        .collect();
+
+    let basic = by_label["basic"];
+    assert_eq!(basic["n_small"], serde_json::json!(123.45), "NUMERIC(12,2) basic");
+    assert_eq!(basic["n_int"], serde_json::json!(42), "NUMERIC(10,0) integer");
+    assert_eq!(basic["n_overflow"], serde_json::json!(1.5));
+    assert_eq!(basic["f4"], serde_json::json!(1.5), "REAL must not be null");
+    assert_eq!(basic["f8"], serde_json::json!(2.5), "DOUBLE PRECISION");
+    assert_eq!(basic["m_small"], serde_json::json!(123.45), "MONEY $123.45");
+    assert_eq!(
+        basic["m_overflow"],
+        serde_json::json!("92233720368547758.07"),
+        "MONEY at i64::MAX cents must emit as exact-text string"
+    );
+
+    let trailing = by_label["trailing_zero"];
+    assert_eq!(trailing["n_small"], serde_json::json!(1.2));
+    assert_eq!(trailing["n_int"], serde_json::json!(10));
+    assert_eq!(trailing["n_overflow"], serde_json::json!(0.1));
+    assert_eq!(trailing["m_small"], serde_json::json!(0.1), "MONEY $0.10 normalized");
+
+    let neg = by_label["negative"];
+    assert_eq!(neg["n_small"], serde_json::json!(-99.99));
+    assert_eq!(neg["n_int"], serde_json::json!(-7));
+    assert_eq!(neg["n_overflow"], serde_json::json!(-123.45));
+    assert_eq!(neg["f4"], serde_json::json!(-1.5));
+    assert_eq!(neg["f8"], serde_json::json!(-2.5));
+    assert_eq!(neg["m_small"], serde_json::json!(-99.99));
+    assert_eq!(neg["m_overflow"], serde_json::json!("-92233720368547758.08"));
+
+    let overflow = by_label["overflow"];
+    assert_eq!(overflow["n_small"], serde_json::json!(0.01));
+    assert_eq!(overflow["n_int"], serde_json::json!(1));
+    assert_eq!(
+        overflow["n_overflow"],
+        serde_json::json!("12345678901234567890.123456789"),
+        "NUMERIC(38,10) beyond f64 precision must be exact-text string"
+    );
+    assert_eq!(overflow["f4"], serde_json::json!(1.5));
+    assert_eq!(overflow["f8"], serde_json::json!(1e100));
+    // $1.00 normalizes to integer 1; bigdecimal_to_json emits as integer
+    // JSON number per the integer fast-path in numeric.rs.
+    assert_eq!(overflow["m_small"], serde_json::json!(1));
+
+    let null_row = by_label["all_null"];
+    assert_eq!(null_row["n_small"], Value::Null, "explicit SQL NULL preserved");
+    assert_eq!(null_row["n_int"], Value::Null);
+    assert_eq!(null_row["n_overflow"], Value::Null);
+    assert_eq!(null_row["f4"], Value::Null);
+    assert_eq!(null_row["f8"], Value::Null);
+    assert_eq!(null_row["m_small"], Value::Null);
+    assert_eq!(null_row["m_overflow"], Value::Null);
+}
+
+// Spec 092 US2 — NUMERIC aggregation preserves precision end-to-end (SC-003).
+#[tokio::test]
+async fn test_read_numeric_aggregation_exact_precision() {
+    let handler = handler(false);
+    let select = ReadQueryRequest {
+        query:
+            "SELECT SUM(n_small) AS total FROM numeric_samples WHERE label IN ('basic', 'trailing_zero', 'overflow')"
+                .into(),
+        database: Some("app".into()),
+        cursor: None,
+    };
+    let rows = handler.read_query(select).await.unwrap();
+    // 123.45 + 1.20 + 0.01 = 124.66 — fits in f64 → JSON number.
+    assert_eq!(rows.rows[0]["total"], serde_json::json!(124.66));
+}

--- a/tests/seed/mysql.sql
+++ b/tests/seed/mysql.sql
@@ -89,6 +89,28 @@ CREATE TABLE `app`.`posts_audit` (
     `created_at` TIMESTAMP DEFAULT CURRENT_TIMESTAMP
 ) ENGINE=InnoDB;
 
+-- Numeric round-trip fixtures — exercises spec 092 (issue #141). DECIMAL,
+-- FLOAT, and DOUBLE columns must come back through readQuery as real values
+-- with exact precision, not silent nulls. Includes a value beyond f64
+-- precision to verify the value-driven JSON shape rule (number when safe,
+-- string when out of range) and an explicit-NULL row.
+CREATE TABLE `app`.`numeric_samples` (
+    `id`         INT AUTO_INCREMENT PRIMARY KEY,
+    `label`      VARCHAR(64) NOT NULL,
+    `d_small`    DECIMAL(10, 2) NULL,
+    `d_int`      DECIMAL(10, 0) NULL,
+    `d_overflow` DECIMAL(38, 10) NULL,
+    `f`          FLOAT NULL,
+    `dbl`        DOUBLE NULL
+) ENGINE=InnoDB;
+
+INSERT INTO `app`.`numeric_samples` (`label`, `d_small`, `d_int`, `d_overflow`, `f`, `dbl`) VALUES
+    ('basic',         123.45, 42, 1.5,                                1.5,    2.5),
+    ('trailing_zero', 1.20,   10, 0.1,                                0.5,    1.0),
+    ('negative',     -99.99, -7,  -123.45,                           -1.5,   -2.5),
+    ('overflow',      0.01,   1,  12345678901234567890.1234567890,    1.5,    1e100),
+    ('all_null',      NULL,   NULL, NULL,                             NULL,   NULL);
+
 -- Partitioned table — exercises the kind: "PARTITIONED_TABLE" detection path.
 -- The primary key includes `year` because MySQL requires every UNIQUE key to
 -- include the partitioning column.

--- a/tests/seed/postgres.sql
+++ b/tests/seed/postgres.sql
@@ -110,6 +110,30 @@ CREATE TRIGGER posts_before_update
     BEFORE UPDATE ON posts
     FOR EACH ROW EXECUTE FUNCTION posts_before_update_fn();
 
+-- Numeric round-trip fixtures — exercises spec 092 (issue #141). NUMERIC and
+-- MONEY columns must come back through readQuery as real values with exact
+-- precision. Includes a value beyond f64 precision to verify the
+-- value-driven JSON shape rule (number when safe, string when out of range),
+-- a MONEY value at i64::MAX cents (always string), and an explicit-NULL row.
+CREATE TABLE numeric_samples (
+    id         SERIAL PRIMARY KEY,
+    label      TEXT NOT NULL,
+    n_small    NUMERIC(12, 2),
+    n_int      NUMERIC(10, 0),
+    n_overflow NUMERIC(38, 10),
+    f4         REAL,
+    f8         DOUBLE PRECISION,
+    m_small    MONEY,
+    m_overflow MONEY
+);
+
+INSERT INTO numeric_samples (label, n_small, n_int, n_overflow, f4, f8, m_small, m_overflow) VALUES
+    ('basic',         123.45,  42,  1.5,                              1.5::real,  2.5,     '$123.45',                  '$92233720368547758.07'),
+    ('trailing_zero', 1.20,    10,  0.1,                              0.5::real,  1.0,     '$0.10',                    '$92233720368547758.07'),
+    ('negative',     -99.99,  -7,  -123.45,                          -1.5::real, -2.5,     '-$99.99',                  '-$92233720368547758.08'),
+    ('overflow',      0.01,    1,   12345678901234567890.1234567890,  1.5::real,  1e100,   '$1.00',                    '$92233720368547758.07'),
+    ('all_null',      NULL,    NULL, NULL,                             NULL,       NULL,    NULL,                       NULL);
+
 -- Stored functions (prokind='f') — distinct from trigger functions above, though
 -- listFunctions enumerates all user-defined functions in `public` including the
 -- trigger functions (which is fine — they are, in fact, user-defined functions).


### PR DESCRIPTION
Closes #141.

## Summary

- MySQL/MariaDB `DECIMAL`/`FLOAT`/`DOUBLE` and Postgres `NUMERIC`/`MONEY`/`FLOAT4`/`FLOAT8` now decode through type-specific paths instead of a blanket `f64`. Fixes the reported bug where `FLOAT` columns (sqlx-mysql strict-checks the type) silently emitted JSON `null`, and the latent precision loss for fixed-point and arbitrary-precision values.
- Shared `bigdecimal_to_json` helper (`crates/sqlx-json/src/numeric.rs`) implements the value-driven shape rule from spec 092: integers fitting in `i64` → integer JSON number; values whose canonical decimal form has ≤15 digits → JSON number via `f64`; everything else → exact-decimal JSON string. Same `BigDecimal` value → same JSON shape regardless of column or backend.
- Postgres `MONEY` arrives as locale-formatted text (sqlx uses simple-query for parameterless statements); a dedicated parser strips currency symbol and grouping separators, then routes through the same shape rule.

## f64 underflow guard

`bigdecimal_to_json` previously routed tiny non-zero NUMERICs (`|v| < ~5e-324`) through `to_f64`, which clamps them to `0.0`, then emitted JSON `0` — silently losing the value. Added an `as_f64 != 0.0` guard so underflowed values fall through to the canonical-string form.

## Test coverage

- **Unit (`crates/sqlx-json/`)**: 31 tests on `bigdecimal_to_json` (zero, negative zero, i64 boundaries, integer >i64, very large, tiny fractions, scientific notation, f64 underflow + near-underflow guard, scale arithmetic) and `parse_pg_money_text` (plain, thousands separators, signs, accounting parens, garbage, i64::MAX cents).
- **Integration (`tests/functional/`)**: round-trip + NULL fixtures via new `numeric_samples` seed table on each backend, AVG over DECIMAL/NUMERIC scale widening, FLOAT regression test for issue #141, MySQL invalid-math (`0/0` → Null), Postgres NUMERIC `NaN`/`±Infinity` (BigDecimal can't represent → Null, pinned per spec out-of-scope), FLOAT NaN/Infinity → Null, huge-magnitude shape, `1e308` boundary, f64 underflow round-trip, PII × stringified numeric overflow interaction.

## Test plan

- [x] `cargo fmt --check`
- [x] `cargo clippy --workspace --tests -- -D warnings`
- [x] `cargo test --workspace --lib --bins`
- [x] `./tests/run.sh` (719 integration tests across mariadb_12, mysql_9, postgres_18, sqlite — all green)