### PR TITLE
fix(pii): reject VAT false positives on uppercase English words

### DIFF
--- a/crates/pii/corpus/vat_number.toml
+++ b/crates/pii/corpus/vat_number.toml
@@ -11,4 +11,5 @@ negatives = [
     "IMPLEMENTATION",
     "ARCHITECTURE",
     "PERMISSIONS",
+    "DEMOGRAPHIC",
 ]

--- a/crates/pii/corpus/vat_number.toml
+++ b/crates/pii/corpus/vat_number.toml
@@ -1,10 +1,14 @@
 positives = [
     "DE123456789",
     "GB123456789",
-    "XX123456789",
 ]
 
 negatives = [
     "DE12345",
     "GB12345",
+    "CERTIFICATE",
+    "INFRASTRUCTURE",
+    "IMPLEMENTATION",
+    "ARCHITECTURE",
+    "PERMISSIONS",
 ]

--- a/crates/pii/src/recognizer/rule/vat_number.rs
+++ b/crates/pii/src/recognizer/rule/vat_number.rs
@@ -48,8 +48,7 @@ mod tests {
 
     #[test]
     fn unknown_prefix_rejected() {
-        // Unknown ISO2 prefix → validator Invalid, match dropped. Stops
-        // all-uppercase English words being tagged as VAT identifiers.
+        // Stops uppercase-word false positives like CERTIFICATE, DEMOGRAPHIC.
         assert!(matches("VAT XX123456789").is_empty());
     }
 

--- a/crates/pii/src/recognizer/rule/vat_number.rs
+++ b/crates/pii/src/recognizer/rule/vat_number.rs
@@ -47,10 +47,10 @@ mod tests {
     }
 
     #[test]
-    fn unknown_prefix_preserved_at_regex_score() {
-        // Unknown prefix → validator returns Unknown → regex score preserved.
-        // The recogniser still emits the span (documented behaviour).
-        assert_eq!(matches("VAT XX123456789"), vec!["XX123456789"]);
+    fn unknown_prefix_rejected() {
+        // Unknown ISO2 prefix → validator Invalid, match dropped. Stops
+        // all-uppercase English words being tagged as VAT identifiers.
+        assert!(matches("VAT XX123456789").is_empty());
     }
 
     #[test]

--- a/crates/pii/src/recognizer/validator/vat_country_length.rs
+++ b/crates/pii/src/recognizer/validator/vat_country_length.rs
@@ -1,11 +1,10 @@
 //! EU / UK VAT-number country-length validator.
 
-use super::digits::collect_upper_alnum;
 use crate::recognizer::ValidationOutcome;
 
-const VAT_COUNTRY_LENGTHS: &[([u8; 2], u32, u32)] = &[
-    (*b"AT", 9, 9),   // U + 8 digits
-    (*b"BE", 10, 10), // 10 digits
+const VAT_COUNTRY_LENGTHS: &[([u8; 2], usize, usize)] = &[
+    (*b"AT", 9, 9),
+    (*b"BE", 10, 10),
     (*b"BG", 9, 10),
     (*b"CY", 9, 9),
     (*b"CZ", 8, 10),
@@ -17,7 +16,7 @@ const VAT_COUNTRY_LENGTHS: &[([u8; 2], u32, u32)] = &[
     (*b"ES", 9, 9),
     (*b"FI", 8, 8),
     (*b"FR", 11, 11),
-    (*b"GB", 9, 12), // 9 short, 12 long
+    (*b"GB", 9, 12),
     (*b"HR", 11, 11),
     (*b"HU", 8, 8),
     (*b"IE", 8, 9),
@@ -36,34 +35,22 @@ const VAT_COUNTRY_LENGTHS: &[([u8; 2], u32, u32)] = &[
     (*b"XI", 9, 12), // Northern Ireland post-Brexit
 ];
 
-/// EU/UK VAT validator: known prefix, in-window body, at least one digit.
+/// EU / UK VAT validator: known prefix, in-window body, at least one digit.
 ///
 /// Format `<ISO2><alphanumeric>`. Returns [`ValidationOutcome::Valid`] only
-/// when the ISO2 prefix is in the EU/UK/XI table, the body length matches
+/// when the prefix is in the EU / UK / XI table, the body length matches
 /// the per-country window, and the body contains at least one ASCII digit.
 /// All other cases return [`ValidationOutcome::Invalid`]. Unknown prefixes
 /// and digit-less bodies are rejected to avoid all-uppercase English words
 /// (e.g. `CERTIFICATE`, `INFRASTRUCTURE`) being tagged as VAT identifiers.
 pub(super) fn validate(candidate: &str) -> ValidationOutcome {
-    // ISO2 prefix + up to 12-char body fits in 14 bytes.
-    let Some((buf, len)) = collect_upper_alnum::<14>(candidate) else {
+    // Candidate is the regex match: 9–14 ASCII uppercase alphanumeric bytes.
+    let Some((prefix, body)) = candidate.as_bytes().split_first_chunk::<2>() else {
         return ValidationOutcome::Invalid;
     };
-    if len < 3 {
-        return ValidationOutcome::Invalid;
-    }
-    let prefix = [buf[0], buf[1]];
-    let Ok(body_len) = u32::try_from(len - 2) else {
+    let Some(&(_, lo, hi)) = VAT_COUNTRY_LENGTHS.iter().find(|(code, ..)| code == prefix) else {
         return ValidationOutcome::Invalid;
     };
-    let body_has_digit = buf[2..len].iter().any(u8::is_ascii_digit);
-    if !body_has_digit {
-        return ValidationOutcome::Invalid;
-    }
-    for &(code, lo, hi) in VAT_COUNTRY_LENGTHS {
-        if code == prefix {
-            return ValidationOutcome::from_bool((lo..=hi).contains(&body_len));
-        }
-    }
-    ValidationOutcome::Invalid
+    let has_digit = body.iter().any(u8::is_ascii_digit);
+    ValidationOutcome::from_bool(has_digit && (lo..=hi).contains(&body.len()))
 }

--- a/crates/pii/src/recognizer/validator/vat_country_length.rs
+++ b/crates/pii/src/recognizer/validator/vat_country_length.rs
@@ -36,11 +36,14 @@ const VAT_COUNTRY_LENGTHS: &[([u8; 2], u32, u32)] = &[
     (*b"XI", 9, 12), // Northern Ireland post-Brexit
 ];
 
-/// EU / UK VAT-number country-length validator.
+/// EU/UK VAT validator: known prefix, in-window body, at least one digit.
 ///
-/// Format `<ISO2><alphanumeric>`. Checks the alphanumeric body length against
-/// a per-country window. Unknown prefix → [`ValidationOutcome::Unknown`] so
-/// niche/new countries are not over-rejected.
+/// Format `<ISO2><alphanumeric>`. Returns [`ValidationOutcome::Valid`] only
+/// when the ISO2 prefix is in the EU/UK/XI table, the body length matches
+/// the per-country window, and the body contains at least one ASCII digit.
+/// All other cases return [`ValidationOutcome::Invalid`]. Unknown prefixes
+/// and digit-less bodies are rejected to avoid all-uppercase English words
+/// (e.g. `CERTIFICATE`, `INFRASTRUCTURE`) being tagged as VAT identifiers.
 pub(super) fn validate(candidate: &str) -> ValidationOutcome {
     // ISO2 prefix + up to 12-char body fits in 14 bytes.
     let Some((buf, len)) = collect_upper_alnum::<14>(candidate) else {
@@ -53,10 +56,14 @@ pub(super) fn validate(candidate: &str) -> ValidationOutcome {
     let Ok(body_len) = u32::try_from(len - 2) else {
         return ValidationOutcome::Invalid;
     };
+    let body_has_digit = buf[2..len].iter().any(u8::is_ascii_digit);
+    if !body_has_digit {
+        return ValidationOutcome::Invalid;
+    }
     for &(code, lo, hi) in VAT_COUNTRY_LENGTHS {
         if code == prefix {
             return ValidationOutcome::from_bool((lo..=hi).contains(&body_len));
         }
     }
-    ValidationOutcome::Unknown
+    ValidationOutcome::Invalid
 }


### PR DESCRIPTION
Closes #148

## Summary
- Reject VAT matches with unknown ISO2 prefix or digit-less body, so all-uppercase English words (CERTIFICATE, INFRASTRUCTURE, IMPLEMENTATION, ARCHITECTURE, PERMISSIONS, DEMOGRAPHIC) no longer surface as `VAT_NUMBER`.
- Simplify the validator: drop the `collect_upper_alnum` buffer copy (regex pre-filter already guarantees ASCII uppercase alphanumeric input), use `split_first_chunk::<2>` for prefix/body, switch the const table from `u32` to `usize`, and exit through a single `from_bool`. Validator body shrinks from 21 lines to 9.
- Extend `corpus/vat_number.toml` negatives with the regression cases.

## Test plan
- [x] `cargo test -p dbmcp-pii` — 148 unit + 34 + 10 integration + 1 doctest pass
- [x] `cargo clippy --workspace --tests -- -D warnings`
- [x] `cargo fmt --check`