### PR TITLE
docs(crates): add per-crate READMEs for crates.io

### DIFF
--- a/crates/config/README.md
+++ b/crates/config/README.md
@@ -1,0 +1,19 @@
+# dbmcp-config
+
+[![Crates.io](https://img.shields.io/crates/v/dbmcp-config.svg)](https://crates.io/crates/dbmcp-config)
+[![Docs.rs](https://docs.rs/dbmcp-config/badge.svg)](https://docs.rs/dbmcp-config)
+[![CI](https://github.com/haymon-ai/dbmcp/actions/workflows/ci.yml/badge.svg)](https://github.com/haymon-ai/dbmcp/actions/workflows/ci.yml)
+[![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](https://github.com/haymon-ai/dbmcp/blob/master/LICENSE)
+
+Typed configuration for [dbmcp](https://dbmcp.haymon.ai) — the single-binary MCP server for MySQL, MariaDB, PostgreSQL, and SQLite.
+
+## What you get
+
+- One config tree, three sections — database, HTTP, PII redaction
+- Backend-aware defaults for port, user, host
+- Secret-safe `Debug` — password redacted by hand
+- Multi-error validation that surfaces every misconfiguration at once
+- `clap::ValueEnum` for `DatabaseBackend` (`mysql`, `mariadb`, `postgres`, `sqlite`)
+- `thiserror`-based error types
+
+See the main crate: **[dbmcp](https://dbmcp.haymon.ai)** · [Website](https://dbmcp.haymon.ai) · [Docs](https://dbmcp.haymon.ai/docs/)

--- a/crates/mysql/README.md
+++ b/crates/mysql/README.md
@@ -1,0 +1,20 @@
+# dbmcp-mysql
+
+[![Crates.io](https://img.shields.io/crates/v/dbmcp-mysql.svg)](https://crates.io/crates/dbmcp-mysql)
+[![Docs.rs](https://docs.rs/dbmcp-mysql/badge.svg)](https://docs.rs/dbmcp-mysql)
+[![CI](https://github.com/haymon-ai/dbmcp/actions/workflows/ci.yml/badge.svg)](https://github.com/haymon-ai/dbmcp/actions/workflows/ci.yml)
+[![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](https://github.com/haymon-ai/dbmcp/blob/master/LICENSE)
+
+MySQL / MariaDB backend for [dbmcp](https://dbmcp.haymon.ai) — the single-binary MCP server that lets your AI assistant talk to SQL databases.
+
+## What you get
+
+- `MysqlHandler` ready to plug into any `rmcp::ServerHandler`-compatible MCP transport
+- Full MCP tool surface: `listDatabases`, `listTables` (with `detailed: true`), `listViews`, `listTriggers`, `listFunctions`, `listProcedures`, `readQuery`, `writeQuery`, `explainQuery`, `createDatabase`, `dropDatabase`, `dropTable`
+- Read-only by default — write tools hidden unless explicitly disabled
+- `MULTI_STATEMENTS` cleared at connect time
+- Parameterised queries everywhere — user values never touch SQL strings
+- Optional PII redaction on every `readQuery` payload
+- MariaDB compatible — same handler
+
+See the main crate: **[dbmcp](https://dbmcp.haymon.ai)** · [Website](https://dbmcp.haymon.ai) · [Docs](https://dbmcp.haymon.ai/docs/)

--- a/crates/pii/README.md
+++ b/crates/pii/README.md
@@ -1,0 +1,19 @@
+# dbmcp-pii
+
+[![Crates.io](https://img.shields.io/crates/v/dbmcp-pii.svg)](https://crates.io/crates/dbmcp-pii)
+[![Docs.rs](https://docs.rs/dbmcp-pii/badge.svg)](https://docs.rs/dbmcp-pii)
+[![CI](https://github.com/haymon-ai/dbmcp/actions/workflows/ci.yml/badge.svg)](https://github.com/haymon-ai/dbmcp/actions/workflows/ci.yml)
+[![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](https://github.com/haymon-ai/dbmcp/blob/master/LICENSE)
+
+Fast, zero-dependency PII detection and anonymisation for Rust. No NLP. No LLM. No network calls. Built for [dbmcp](https://dbmcp.haymon.ai) — the single-binary MCP server for MySQL, MariaDB, PostgreSQL, and SQLite.
+
+## What you get
+
+- 32 built-in entity types across 7 categories (`Personal`, `Financial`, `Government`, `Contact`, `Network`, `DigitalIdentity`, `Crypto`)
+- Checksum-validated matches where it matters (Luhn, mod-97 IBAN, NHS mod-11, bech32, base58-check, German Steuer-ID, US SSN rules)
+- Four anonymisation operators — `replace`, `mask`, `redact`, `hash` (SHA-256, optional HMAC key)
+- Category-scoped analyser builder for tailored recogniser subsets
+- JSON-safe: walks every string leaf at any depth, object keys preserved
+- Pure Rust regex + checksums — zero runtime dependencies, fully auditable
+
+See the main crate: **[dbmcp](https://dbmcp.haymon.ai)** · [Website](https://dbmcp.haymon.ai) · [Docs](https://dbmcp.haymon.ai/docs/)

--- a/crates/postgres/README.md
+++ b/crates/postgres/README.md
@@ -1,0 +1,19 @@
+# dbmcp-postgres
+
+[![Crates.io](https://img.shields.io/crates/v/dbmcp-postgres.svg)](https://crates.io/crates/dbmcp-postgres)
+[![Docs.rs](https://docs.rs/dbmcp-postgres/badge.svg)](https://docs.rs/dbmcp-postgres)
+[![CI](https://github.com/haymon-ai/dbmcp/actions/workflows/ci.yml/badge.svg)](https://github.com/haymon-ai/dbmcp/actions/workflows/ci.yml)
+[![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](https://github.com/haymon-ai/dbmcp/blob/master/LICENSE)
+
+PostgreSQL backend for [dbmcp](https://dbmcp.haymon.ai) — the single-binary MCP server that lets your AI assistant talk to SQL databases.
+
+## What you get
+
+- `PostgresHandler` ready to plug into any `rmcp::ServerHandler`-compatible MCP transport
+- Full MCP tool surface: `listDatabases`, `listTables` (with `detailed: true`), `listViews`, `listTriggers`, `listFunctions`, `listProcedures`, `listMaterializedViews`, `readQuery`, `writeQuery`, `explainQuery`, `createDatabase`, `dropDatabase`, `dropTable`
+- Per-database connection pool cache (`moka`) — cheap per-call `database` switches
+- Read-only by default — write tools hidden unless explicitly disabled
+- Parameterised queries everywhere — user values never touch SQL strings
+- Optional PII redaction on every `readQuery` payload; walks JSON/JSONB recursively
+
+See the main crate: **[dbmcp](https://dbmcp.haymon.ai)** · [Website](https://dbmcp.haymon.ai) · [Docs](https://dbmcp.haymon.ai/docs/)

--- a/crates/server/README.md
+++ b/crates/server/README.md
@@ -1,0 +1,17 @@
+# dbmcp-server
+
+[![Crates.io](https://img.shields.io/crates/v/dbmcp-server.svg)](https://crates.io/crates/dbmcp-server)
+[![Docs.rs](https://docs.rs/dbmcp-server/badge.svg)](https://docs.rs/dbmcp-server)
+[![CI](https://github.com/haymon-ai/dbmcp/actions/workflows/ci.yml/badge.svg)](https://github.com/haymon-ai/dbmcp/actions/workflows/ci.yml)
+[![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](https://github.com/haymon-ai/dbmcp/blob/master/LICENSE)
+
+Shared MCP server primitives for [dbmcp](https://dbmcp.haymon.ai) — the single-binary MCP server for MySQL, MariaDB, PostgreSQL, and SQLite.
+
+## What you get
+
+- Request/response schemas for every dbmcp MCP tool (`readQuery`, `writeQuery`, `listDatabases`, `listTables`, `listViews`, `listTriggers`, `listFunctions`, `listProcedures`, `listMaterializedViews`, `explainQuery`, `createDatabase`, `dropDatabase`, `dropTable`)
+- `schemars`-derived JSON schemas
+- `Cursor` and `Pager` helpers for streaming big result sets across MCP calls
+- `Server` wrapper + `server_info()` advertised to clients
+
+See the main crate: **[dbmcp](https://dbmcp.haymon.ai)** · [Website](https://dbmcp.haymon.ai) · [Docs](https://dbmcp.haymon.ai/docs/)

--- a/crates/sql/README.md
+++ b/crates/sql/README.md
@@ -1,0 +1,19 @@
+# dbmcp-sql
+
+[![Crates.io](https://img.shields.io/crates/v/dbmcp-sql.svg)](https://crates.io/crates/dbmcp-sql)
+[![Docs.rs](https://docs.rs/dbmcp-sql/badge.svg)](https://docs.rs/dbmcp-sql)
+[![CI](https://github.com/haymon-ai/dbmcp/actions/workflows/ci.yml/badge.svg)](https://github.com/haymon-ai/dbmcp/actions/workflows/ci.yml)
+[![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](https://github.com/haymon-ai/dbmcp/blob/master/LICENSE)
+
+SQL validation, identifier quoting, pagination, and timeout helpers powering [dbmcp](https://dbmcp.haymon.ai) — the single-binary MCP server for MySQL, MariaDB, PostgreSQL, and SQLite.
+
+## What you get
+
+- Read-only enforcement: only `SELECT`, `SHOW`, `DESC`, `DESCRIBE`, `USE` allowed
+- AST-based validation via `sqlparser` (comments + string contents stripped first)
+- Blocks file-exfiltration patterns (`LOAD_FILE`, `SELECT INTO OUTFILE/DUMPFILE`)
+- Identifier validation + per-backend quoting — no string interpolation
+- Server-controlled `LIMIT` / `OFFSET` rewriting for paginated `SELECT`s
+- Query-level timeout wrapper shared across backends
+
+See the main crate: **[dbmcp](https://dbmcp.haymon.ai)** · [Website](https://dbmcp.haymon.ai) · [Docs](https://dbmcp.haymon.ai/docs/)

--- a/crates/sqlite/README.md
+++ b/crates/sqlite/README.md
@@ -1,0 +1,20 @@
+# dbmcp-sqlite
+
+[![Crates.io](https://img.shields.io/crates/v/dbmcp-sqlite.svg)](https://crates.io/crates/dbmcp-sqlite)
+[![Docs.rs](https://docs.rs/dbmcp-sqlite/badge.svg)](https://docs.rs/dbmcp-sqlite)
+[![CI](https://github.com/haymon-ai/dbmcp/actions/workflows/ci.yml/badge.svg)](https://github.com/haymon-ai/dbmcp/actions/workflows/ci.yml)
+[![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](https://github.com/haymon-ai/dbmcp/blob/master/LICENSE)
+
+SQLite backend for [dbmcp](https://dbmcp.haymon.ai) — the single-binary MCP server that lets your AI assistant talk to SQL databases.
+
+## What you get
+
+- `SqliteHandler` ready to plug into any `rmcp::ServerHandler`-compatible MCP transport
+- MCP tool surface: `listTables` (with `detailed: true`), `listViews`, `listTriggers`, `readQuery`, `writeQuery`, `explainQuery`, `dropTable`
+- File or `:memory:` — point it at a path or run entirely in RAM
+- Read-only by default — write tools hidden unless explicitly disabled
+- Parameterised queries everywhere — user values never touch SQL strings
+- Optional PII redaction on every `readQuery` payload
+- Zero server — perfect for local AI tools, demos, and CI
+
+See the main crate: **[dbmcp](https://dbmcp.haymon.ai)** · [Website](https://dbmcp.haymon.ai) · [Docs](https://dbmcp.haymon.ai/docs/)

--- a/crates/sqlx-json/README.md
+++ b/crates/sqlx-json/README.md
@@ -1,0 +1,20 @@
+# sqlx-json
+
+[![Crates.io](https://img.shields.io/crates/v/sqlx-json.svg)](https://crates.io/crates/sqlx-json)
+[![Docs.rs](https://docs.rs/sqlx-json/badge.svg)](https://docs.rs/sqlx-json)
+[![CI](https://github.com/haymon-ai/dbmcp/actions/workflows/ci.yml/badge.svg)](https://github.com/haymon-ai/dbmcp/actions/workflows/ci.yml)
+[![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](https://github.com/haymon-ai/dbmcp/blob/master/LICENSE)
+
+One trait, three backends. Turn any [`sqlx`](https://crates.io/crates/sqlx) row into a `serde_json::Value` without writing per-column match arms. Built for [dbmcp](https://dbmcp.haymon.ai) — the single-binary MCP server for MySQL, MariaDB, PostgreSQL, and SQLite.
+
+## What you get
+
+- `RowExt::to_json()` for `SqliteRow`, `PgRow`, and `MySqlRow`
+- Null-aware — `NULL` columns become `Value::Null`, never panic
+- Binary-safe — `BYTEA` / `BLOB` / `VARBINARY` base64-encoded
+- Precision-safe — numeric / decimal go through `BigDecimal`
+- JSON / JSONB columns parsed and inlined as real JSON, not stringified
+- `QueryResult` trait exposes `.rows_affected()` generically across backends
+- Tiny surface — one trait, two methods, no macros
+
+See the main crate: **[dbmcp](https://dbmcp.haymon.ai)** · [Website](https://dbmcp.haymon.ai) · [Docs](https://dbmcp.haymon.ai/docs/)


### PR DESCRIPTION
## Summary

- Every workspace crate currently renders an empty Readme tab on crates.io. This PR adds a short, marketing-focused README per crate so each landing page explains what the crate does and links back to https://dbmcp.haymon.ai.
- One template across all 8 crates: H1, badge row (crates.io · docs.rs · CI · MIT), one-line pitch, **What you get** bullets, link back to the main project.
- Cargo auto-detects `README.md` at the package root, no `Cargo.toml` changes required.

Crates touched: `dbmcp-config`, `dbmcp-sql`, `dbmcp-server`, `dbmcp-mysql`, `dbmcp-postgres`, `dbmcp-sqlite`, `dbmcp-pii`, `sqlx-json`.

## Test plan

- [ ] Visual check each README renders cleanly on GitHub
- [ ] `cargo publish --dry-run -p <crate>` per crate to confirm README is packaged
- [ ] After the next release, confirm crates.io landing pages render the new READMEs