### PR TITLE
feat: externalize tool descriptions + read-only-aware instructions

### DIFF
--- a/crates/mysql/assets/instructions.md
+++ b/crates/mysql/assets/instructions.md
@@ -1,0 +1,21 @@
+## Workflow
+
+1. Call `listDatabases` to discover available databases.
+2. Call `listTables` to see tables. Pass `search` to filter by name (case-insensitive substring). Pass `detailed: true` to get columns, constraints, indexes, and triggers in the same call — this supersedes the legacy `getTableSchema` workflow.
+3. Call `listViews` to see views.
+4. Call `listTriggers` to see triggers.
+5. Call `listFunctions` to see stored functions.
+6. Call `listProcedures` to see stored procedures.
+7. Use `readQuery` for read-only SQL (SELECT, SHOW, DESCRIBE, USE, EXPLAIN).
+8. Use `writeQuery` for data changes (INSERT, UPDATE, DELETE, CREATE, ALTER, DROP).
+9. Use `explainQuery` to analyze query execution plans and diagnose slow queries.
+10. Use `createDatabase` to create a new database.
+11. Use `dropDatabase` to drop an existing database.
+12. Use `dropTable` to remove a table from a database.
+
+Per-database tools default to the active database; pass `database` to target another.
+
+## Constraints
+
+- The `writeQuery`, `createDatabase`, `dropDatabase`, and `dropTable` tools are hidden when read-only mode is active.
+- Multi-statement queries are not supported. Send one statement per request.

--- a/crates/mysql/assets/instructions.readonly.md
+++ b/crates/mysql/assets/instructions.readonly.md
@@ -1,0 +1,17 @@
+## Workflow
+
+1. Call `listDatabases` to discover available databases.
+2. Call `listTables` to see tables. Pass `search` to filter by name (case-insensitive substring). Pass `detailed: true` to get columns, constraints, indexes, and triggers in the same call — this supersedes the legacy `getTableSchema` workflow.
+3. Call `listViews` to see views.
+4. Call `listTriggers` to see triggers.
+5. Call `listFunctions` to see stored functions.
+6. Call `listProcedures` to see stored procedures.
+7. Use `readQuery` for read-only SQL (SELECT, SHOW, DESCRIBE, USE, EXPLAIN).
+8. Use `explainQuery` to analyze query execution plans and diagnose slow queries.
+
+Per-database tools default to the active database; pass `database` to target another.
+
+## Constraints
+
+- The server runs in read-only mode. Data and schema changes are not possible.
+- Multi-statement queries are not supported. Send one statement per request.

--- a/crates/mysql/assets/tools/create_database.md
+++ b/crates/mysql/assets/tools/create_database.md
@@ -1,0 +1,21 @@
+Create a new database on the connected server.
+
+<usecase>
+Use when:
+- Setting up a new database for a project or application
+- The user asks to create a database
+</usecase>
+
+<examples>
+✓ "Create a database called analytics" → createDatabase(database="analytics")
+✗ "Create a table" → use writeQuery with CREATE TABLE
+</examples>
+
+<important>
+Database name must be non-empty; backend reserved-character rules apply.
+If the database already exists, returns a message indicating so without error.
+</important>
+
+<what_it_returns>
+A confirmation message with the created database name.
+</what_it_returns>

--- a/crates/mysql/assets/tools/drop_database.md
+++ b/crates/mysql/assets/tools/drop_database.md
@@ -1,0 +1,21 @@
+Drop an existing database from the connected server.
+
+<usecase>
+Use when:
+- Removing a database that is no longer needed
+- Cleaning up test or temporary databases
+</usecase>
+
+<examples>
+✓ "Drop the test_db database" → dropDatabase(database="test_db")
+✗ "Drop a table" → use dropTable instead
+</examples>
+
+<safety>
+IMPORTANT: This permanently deletes the database and ALL its data. This action cannot be undone.
+Cannot drop the database you are currently connected to.
+</safety>
+
+<what_it_returns>
+A confirmation message with the dropped database name.
+</what_it_returns>

--- a/crates/mysql/assets/tools/drop_table.md
+++ b/crates/mysql/assets/tools/drop_table.md
@@ -1,0 +1,22 @@
+Drop a table from a database.
+
+<usecase>
+Use when:
+- Removing a table that is no longer needed
+- Cleaning up test or temporary tables
+</usecase>
+
+<examples>
+✓ "Drop the temp_logs table from mydb" → dropTable(database="mydb", table="temp_logs")
+✗ "Delete rows from a table" → use writeQuery with DELETE
+✗ "Drop a database" → use dropDatabase instead
+</examples>
+
+<safety>
+IMPORTANT: This permanently deletes the table and ALL its data. This action cannot be undone.
+If the table has foreign key dependencies, the drop will fail — resolve dependencies first.
+</safety>
+
+<what_it_returns>
+A confirmation message with the dropped table name.
+</what_it_returns>

--- a/crates/mysql/assets/tools/explain_query.md
+++ b/crates/mysql/assets/tools/explain_query.md
@@ -1,0 +1,30 @@
+Return the execution plan for a SQL query to diagnose performance. Use this tool instead of running EXPLAIN directly through readQuery — it provides structured output.
+
+<usecase>
+Use when:
+- A query runs slowly and you need to understand why
+- Investigating performance bottlenecks
+- Planning index creation to optimize queries
+- Analyzing join methods, table scan strategies, and sort operations
+</usecase>
+
+<when_not_to_use>
+- Running actual queries → use readQuery or writeQuery
+- Checking table structure → use listTables(detailed=true)
+</when_not_to_use>
+
+<examples>
+✓ "Why is my SELECT on orders slow?" → explainQuery(query="SELECT ...")
+✓ "Should I add an index?" → explainQuery with analyze=true
+✗ "Run this SELECT" → use readQuery
+</examples>
+
+<safety>
+Set `analyze` to true for actual execution statistics (EXPLAIN ANALYZE).
+IMPORTANT: EXPLAIN ANALYZE actually executes the query! In read-only mode, only read-only statements are allowed with analyze.
+When analyze is false, returns EXPLAIN FORMAT=JSON output without executing.
+</safety>
+
+<what_it_returns>
+A JSON array of execution plan rows showing access methods, join types, row estimates, and costs.
+</what_it_returns>

--- a/crates/mysql/assets/tools/list_databases.md
+++ b/crates/mysql/assets/tools/list_databases.md
@@ -1,0 +1,21 @@
+List all accessible databases on the connected server. Use this tool to discover what databases are available before using other tools.
+
+<usecase>
+ALWAYS call this tool FIRST when:
+- You need to explore what databases exist on the server
+- You need a database name for listTables or query tools
+- The user asks what data is available
+</usecase>
+
+<examples>
+✓ "What databases are on this server?"
+✓ "Show me what's available" → call listDatabases first
+</examples>
+
+<what_it_returns>
+A sorted JSON array of database name strings.
+</what_it_returns>
+
+<pagination>
+Paginated. Pass the prior response's `nextCursor` as `cursor` to fetch the next page.
+</pagination>

--- a/crates/mysql/assets/tools/list_functions.md
+++ b/crates/mysql/assets/tools/list_functions.md
@@ -1,0 +1,32 @@
+List user-defined SQL functions in a database, optionally filtered and/or with full metadata. Loadable UDFs (`mysql.func`) and stored procedures are excluded.
+
+<usecase>
+Use when:
+- Auditing stored functions across a database (brief mode, default).
+- Searching for a function by partial name (pass `search`).
+- Inspecting a function's language, signature, return type, determinism, SQL-data-access classification, security mode, definer, comment, session context, and full reconstructed `CREATE FUNCTION` text before reasoning about correctness or invocation safety (pass `detailed: true`). Detailed mode supersedes ad-hoc `readQuery` against `information_schema.ROUTINES` / `information_schema.PARAMETERS`.
+</usecase>
+
+<parameters>
+- `database` — Database to target. Defaults to the active database.
+- `cursor` — Opaque pagination cursor; echo the prior response's `nextCursor`.
+- `search` — Case-insensitive filter on function names via `LIKE`. `%` matches any sequence; `_` matches a single character.
+- `detailed` — When `true`, returns full metadata objects keyed by function name instead of bare name strings. Default `false`.
+</parameters>
+
+<examples>
+✓ "What functions are in the mydb database?" → listFunctions(database="mydb")
+✓ "Find the order-total calculation" → listFunctions(search="order")
+✓ "What does calc_order_total do?" → listFunctions(search="calc_order_total", detailed=true)
+✗ "List stored procedures" → use listProcedures instead
+✗ "List loadable UDFs from mysql.func" → not supported; only routines in information_schema.ROUTINES are returned
+</examples>
+
+<what_it_returns>
+Brief mode (default): a sorted JSON array of function-name strings, e.g. `["calc_order_subtotal", "calc_order_total", "double_it"]`.
+Detailed mode: a JSON object keyed by bare function name (MySQL/MariaDB do not allow function overloading, so no signature suffix is needed); each value carries `schema`, `language` (typically `"SQL"`; MariaDB external-language functions report the external language name), `arguments` (comma-separated `name type` pairs from `information_schema.PARAMETERS`, empty string for zero-parameter functions), `returnType` (full `DTD_IDENTIFIER` including length/precision/unsigned/enum/set members), `deterministic` (boolean), `sqlDataAccess` (one of `CONTAINS_SQL`, `NO_SQL`, `READS_SQL_DATA`, `MODIFIES_SQL_DATA`), `security` (`INVOKER` or `DEFINER`), `definer` (`user@host`), `description` (the `COMMENT` text or `null` when no comment was set — the empty string MySQL stores is coerced to JSON `null`), `definition` (the canonical reconstructed `CREATE FUNCTION` text including `DEFINER=` in `` `user`@`host` `` form), `sqlMode`, `characterSetClient`, `collationConnection`, and `databaseCollation`. Versus the Postgres detailed payload: `volatility`, `parallelSafety`, and `strict` are intentionally absent (no MySQL/MariaDB analogues), `owner` is renamed to `definer` (more accurate for the MySQL `DEFINER` concept), keys are bare names rather than `name(arguments)` (no overloads possible), and the four session-context fields (`sqlMode`, `characterSetClient`, `collationConnection`, `databaseCollation`) are MySQL/MariaDB-only additions.
+</what_it_returns>
+
+<pagination>
+Paginated. Pass the prior response's `nextCursor` as `cursor` to fetch the next page. The `search` filter must stay the same across pages for cursor continuity.
+</pagination>

--- a/crates/mysql/assets/tools/list_procedures.md
+++ b/crates/mysql/assets/tools/list_procedures.md
@@ -1,0 +1,32 @@
+List user-defined stored procedures in a database, optionally filtered and/or with full metadata. Stored functions and loadable UDFs (`mysql.func`) are excluded.
+
+<usecase>
+Use when:
+- Auditing stored procedures across a database (brief mode, default).
+- Searching for a procedure by partial name (pass `search`).
+- Inspecting a procedure's language, parameter list (with `IN`/`OUT`/`INOUT` modes), determinism, SQL-data-access classification, security mode, definer, comment, session context, and full reconstructed `CREATE PROCEDURE` text before reasoning about correctness or invocation safety (pass `detailed: true`). Detailed mode supersedes ad-hoc `readQuery` against `information_schema.ROUTINES` / `information_schema.PARAMETERS`.
+</usecase>
+
+<parameters>
+- `database` — Database to target. Defaults to the active database.
+- `cursor` — Opaque pagination cursor; echo the prior response's `nextCursor`.
+- `search` — Case-insensitive filter on procedure names via `LIKE`. `%` matches any sequence; `_` matches a single character.
+- `detailed` — When `true`, returns full metadata objects keyed by procedure name instead of bare name strings. Default `false`.
+</parameters>
+
+<examples>
+✓ "What procedures are in the mydb database?" → listProcedures(database="mydb")
+✓ "Find the order archival routine" → listProcedures(search="archive")
+✓ "What does archive_order do?" → listProcedures(search="archive_order", detailed=true)
+✗ "List functions" → use listFunctions instead
+✗ "List loadable UDFs from mysql.func" → not supported; only routines in information_schema.ROUTINES are returned
+</examples>
+
+<what_it_returns>
+Brief mode (default): a sorted JSON array of procedure-name strings, e.g. `["archive_order", "archive_order_history", "purge_order_archive", "touch_post"]`.
+Detailed mode: a JSON object keyed by bare procedure name (MySQL/MariaDB do not allow procedure overloading, so no signature suffix is needed); each value carries `schema`, `language` (typically `"SQL"`; MariaDB external-language procedures report the external language name), `arguments` (comma-separated `MODE name type` triples from `information_schema.PARAMETERS` — `MODE` is one of `IN`, `OUT`, `INOUT`; empty string for zero-parameter procedures), `deterministic` (boolean), `sqlDataAccess` (one of `CONTAINS_SQL`, `NO_SQL`, `READS_SQL_DATA`, `MODIFIES_SQL_DATA`), `security` (`INVOKER` or `DEFINER`), `definer` (`user@host`), `description` (the `COMMENT` text or `null` when no comment was set — the empty string MySQL stores is coerced to JSON `null`), `definition` (the canonical reconstructed `CREATE PROCEDURE` text including `DEFINER=` in `` `user`@`host` `` form; no `RETURNS` clause — procedures have no return type), `sqlMode`, `characterSetClient`, `collationConnection`, and `databaseCollation`. Versus the Postgres `listProcedures` detailed payload: `volatility`, `parallelSafety`, `strict`, and `returnType` are intentionally absent (no MySQL/MariaDB analogues for the first three; procedures have no return type for the fourth — the Postgres-side payload also omits all four), `owner` is renamed to `definer` (more accurate for the MySQL `DEFINER` concept), keys are bare names rather than `name(arguments)` (no overloads possible), the four session-context fields (`sqlMode`, `characterSetClient`, `collationConnection`, `databaseCollation`) are MySQL/MariaDB-only additions, and `deterministic` plus `sqlDataAccess` are MySQL/MariaDB-only additions versus the Postgres `listProcedures` detailed payload (which omits both because Postgres procedures have no equivalent attributes).
+</what_it_returns>
+
+<pagination>
+Paginated. Pass the prior response's `nextCursor` as `cursor` to fetch the next page. The `search` filter must stay the same across pages for cursor continuity.
+</pagination>

--- a/crates/mysql/assets/tools/list_tables.md
+++ b/crates/mysql/assets/tools/list_tables.md
@@ -1,0 +1,30 @@
+List tables in a database, optionally filtered and/or with full metadata.
+
+<usecase>
+Use when:
+- Exploring a database to find relevant tables (brief mode, default).
+- Searching for a table by partial name (pass `search`).
+- Inspecting a table's columns, constraints, indexes, and triggers before writing a query (pass `detailed: true`). This supersedes the legacy `getTableSchema` tool.
+</usecase>
+
+<parameters>
+- `database` — Database to target. Defaults to the active database.
+- `cursor` — Opaque pagination cursor; echo the prior response's `nextCursor`.
+- `search` — Case-insensitive filter on table names via `LIKE`. `%` matches any sequence; `_` matches a single character.
+- `detailed` — When `true`, returns full metadata objects keyed by table name instead of bare name strings. Default `false`.
+</parameters>
+
+<examples>
+✓ "What tables are in mydb?" → listTables(database="mydb")
+✓ "Find the orders table" → listTables(search="order")
+✓ "What columns does orders have?" → listTables(search="orders", detailed=true)
+</examples>
+
+<what_it_returns>
+Brief mode (default): a sorted JSON array of table-name strings, e.g. `["customers", "orders"]`.
+Detailed mode: a JSON object keyed by table name; each value carries `schema`, `kind`, `owner`, `comment`, `columns`, `constraints`, `indexes`, and `triggers` (the name is the key and is not repeated inside the value). Keys iterate in the same alphabetical order brief mode uses. Example: `{"orders": {"schema": "mydb", "kind": "TABLE", …}}`.
+</what_it_returns>
+
+<pagination>
+Paginated. Pass the prior response's `nextCursor` as `cursor` to fetch the next page. The `search` filter must stay the same across pages for cursor continuity.
+</pagination>

--- a/crates/mysql/assets/tools/list_triggers.md
+++ b/crates/mysql/assets/tools/list_triggers.md
@@ -1,0 +1,31 @@
+List user-defined triggers in a database, optionally filtered and/or with full metadata.
+
+<usecase>
+Use when:
+- Auditing trigger coverage across a database (brief mode, default).
+- Searching for a trigger by partial name (pass `search`).
+- Inspecting a trigger's timing, event, activation level, full `CREATE TRIGGER` text, and the session context active at trigger-creation time before reasoning about side-effects (pass `detailed: true`). Detailed mode supersedes ad-hoc `readQuery` against `information_schema.TRIGGERS`.
+</usecase>
+
+<parameters>
+- `database` — Database to target. Defaults to the active database.
+- `cursor` — Opaque pagination cursor; echo the prior response's `nextCursor`.
+- `search` — Case-insensitive filter on trigger names via `LIKE`. `%` matches any sequence; `_` matches a single character.
+- `detailed` — When `true`, returns full metadata objects keyed by trigger name instead of bare name strings. Default `false`.
+</parameters>
+
+<examples>
+✓ "What triggers are in the mydb database?" → listTriggers(database="mydb")
+✓ "Find the audit triggers" → listTriggers(search="audit")
+✓ "What does orders_audit_after_insert do?" → listTriggers(search="orders_audit_after_insert", detailed=true)
+✗ "Show me a trigger's body" → use detailed mode; the `definition` field carries the full `CREATE TRIGGER` text
+</examples>
+
+<what_it_returns>
+Brief mode (default): a sorted JSON array of trigger-name strings, e.g. `["customers_audit_after_insert", "orders_audit_after_insert"]`.
+Detailed mode: a JSON object keyed by trigger name; each value carries `schema`, `table`, `timing` (BEFORE/AFTER), `events` (single-element array — `INSERT`, `UPDATE`, or `DELETE`), `activationLevel` (always `ROW` on MySQL/MariaDB), `definition` (the canonical `CREATE TRIGGER` text including `DEFINER=` in `` `user`@`host` `` form), `sqlMode`, `characterSetClient`, `collationConnection`, and `databaseCollation`. The Postgres-only `status` and `functionName` fields are intentionally absent (no per-trigger enabled/disabled flag and no separate handler-function reference on MySQL/MariaDB); the four session-context fields are MySQL/MariaDB-only additions versus the Postgres detailed payload.
+</what_it_returns>
+
+<pagination>
+Paginated. Pass the prior response's `nextCursor` as `cursor` to fetch the next page. The `search` filter must stay the same across pages for cursor continuity.
+</pagination>

--- a/crates/mysql/assets/tools/list_views.md
+++ b/crates/mysql/assets/tools/list_views.md
@@ -1,0 +1,34 @@
+List user-defined views in a database, optionally filtered and/or with full metadata. Base tables and system-schema views are excluded.
+
+<usecase>
+Use when:
+- Auditing views across a database (brief mode, default).
+- Searching for a view by partial name (pass `search`).
+- Inspecting a view's definer, security mode, check-option level, updatable flag, session character set/collation, and full SELECT body before querying it (pass `detailed: true`). Detailed mode supersedes ad-hoc `readQuery` against `information_schema.VIEWS`.
+</usecase>
+
+<parameters>
+- `database` — Database to target. Defaults to the active database.
+- `cursor` — Opaque pagination cursor; echo the prior response's `nextCursor`.
+- `search` — Case-insensitive filter on view names via `LIKE`. `%` matches any sequence; `_` matches a single character.
+- `detailed` — When `true`, returns full metadata objects keyed by view name instead of bare name strings. Default `false`.
+</parameters>
+
+<examples>
+✓ "What views are in the mydb database?" → listViews(database="mydb")
+✓ "Find the active-users view" → listViews(search="active")
+✓ "What does active_users select?" → listViews(search="active_users", detailed=true)
+✗ "Show me the columns of a view" → use listTables with `detailed: true` instead
+✗ "List materialized views" → MySQL/MariaDB have no materialized-view concept
+</examples>
+
+<what_it_returns>
+Brief mode (default): a sorted JSON array of view-name strings, e.g. `["active_orders", "active_users", "published_posts"]`.
+Detailed mode: a JSON object keyed by bare view name; each value carries `schema`, `definer` (`user@host`), `security` (`INVOKER` or `DEFINER`), `checkOption` (`NONE`, `CASCADED`, or `LOCAL`), `updatable` (boolean), `characterSetClient`, `collationConnection`, and `definition` (the SELECT body verbatim from `information_schema.VIEWS.VIEW_DEFINITION`, with no `CREATE VIEW` wrapper). The view name is the map key only — it is not repeated inside the value.
+
+Versus the Postgres `listViews` detailed payload: `description` is intentionally absent (neither MySQL nor MariaDB exposes a user-comment column for views — `CREATE VIEW` syntax has no `COMMENT` clause), `algorithm` is intentionally absent (MariaDB-only column on `information_schema.VIEWS`), `owner` is renamed to `definer` (more accurate for the MySQL `DEFINER` concept), and the five MySQL/MariaDB-only structured fields (`security`, `checkOption`, `updatable`, `characterSetClient`, `collationConnection`) are added. The `definition` field shape is byte-identical to Postgres — raw SELECT body verbatim, no DDL wrapper. When the connected role lacks the `SHOW VIEW` privilege on a particular view, the engine redacts `VIEW_DEFINITION` to the empty string; the row remains in the response with `definition` reflecting that empty value.
+</what_it_returns>
+
+<pagination>
+Paginated. Pass the prior response's `nextCursor` as `cursor` to fetch the next page. The `search` filter must stay the same across pages for cursor continuity. Brief and detailed modes share the same `TABLE_NAME` row order, so a client can switch `detailed` between pages without losing position.
+</pagination>

--- a/crates/mysql/assets/tools/read_query.md
+++ b/crates/mysql/assets/tools/read_query.md
@@ -1,0 +1,32 @@
+Execute a read-only SQL query. Allowed statements: SELECT, SHOW, DESCRIBE, USE, EXPLAIN.
+
+<usecase>
+Use when:
+- Querying data from tables (SELECT with WHERE, JOIN, GROUP BY, etc.)
+- Aggregations: COUNT, SUM, AVG, GROUP BY, HAVING
+- Listing server variables or status (SHOW)
+- Viewing table structure (DESCRIBE)
+- Switching database context (USE)
+</usecase>
+
+<when_not_to_use>
+- Data changes (INSERT, UPDATE, DELETE) → use writeQuery
+- Query performance analysis → use explainQuery
+- Discovering tables or columns → use listTables (pass detailed=true for column-level metadata)
+</when_not_to_use>
+
+<examples>
+✓ "SELECT * FROM users WHERE status = 'active'"
+✓ "SELECT COUNT(*) FROM orders GROUP BY region"
+✓ "SHOW TABLES" or "DESCRIBE users"
+✗ "INSERT INTO users ..." → use writeQuery
+✗ "EXPLAIN SELECT ..." → use explainQuery for structured analysis
+</examples>
+
+<what_it_returns>
+A JSON array of row objects, each keyed by column name.
+</what_it_returns>
+
+<pagination>
+`SELECT` results are paginated. Pass the prior response's `nextCursor` as `cursor` to fetch the next page. `SHOW`, `DESCRIBE`, `USE`, and `EXPLAIN` return a single page and ignore `cursor`.
+</pagination>

--- a/crates/mysql/assets/tools/write_query.md
+++ b/crates/mysql/assets/tools/write_query.md
@@ -1,0 +1,25 @@
+Execute a write SQL query (INSERT, UPDATE, DELETE, CREATE, ALTER, DROP).
+
+<usecase>
+Use when:
+- Inserting, updating, or deleting rows
+- Creating or altering tables, indexes, views, or other schema objects
+- Any data modification operation
+</usecase>
+
+<when_not_to_use>
+- Read-only queries (SELECT, SHOW) → use readQuery
+- Query performance analysis → use explainQuery
+- Creating/dropping entire databases → use createDatabase or dropDatabase
+</when_not_to_use>
+
+<examples>
+✓ "INSERT INTO users (name, email) VALUES ('Alice', 'alice@example.com')"
+✓ "UPDATE orders SET status = 'shipped' WHERE id = 42"
+✓ "CREATE TABLE logs (id INT PRIMARY KEY, message TEXT)"
+✗ "SELECT * FROM users" → use readQuery
+</examples>
+
+<what_it_returns>
+A JSON array of affected/returning row objects, each keyed by column name.
+</what_it_returns>

--- a/crates/mysql/src/handler.rs
+++ b/crates/mysql/src/handler.rs
@@ -24,8 +24,11 @@ use crate::tools::{
 /// Backend-specific description for MySQL/MariaDB.
 const DESCRIPTION: &str = "Database MCP Server for MySQL and MariaDB";
 
-/// Backend-specific instructions for MySQL/MariaDB.
+/// Backend-specific instructions for MySQL/MariaDB in read-write mode.
 const INSTRUCTIONS: &str = include_str!("../assets/instructions.md");
+
+/// Backend-specific instructions for MySQL/MariaDB in read-only mode.
+const INSTRUCTIONS_READ_ONLY: &str = include_str!("../assets/instructions.readonly.md");
 
 /// MySQL/MariaDB database handler.
 ///
@@ -98,7 +101,11 @@ impl ServerHandler for MysqlHandler {
     fn get_info(&self) -> ServerInfo {
         let mut info = server_info();
         info.server_info.description = Some(DESCRIPTION.into());
-        info.instructions = Some(INSTRUCTIONS.into());
+        info.instructions = Some(if self.config.read_only {
+            INSTRUCTIONS_READ_ONLY.into()
+        } else {
+            INSTRUCTIONS.into()
+        });
         info
     }
 
@@ -192,6 +199,23 @@ mod tests {
         assert!(!router.has_route("createDatabase"));
         assert!(!router.has_route("dropDatabase"));
         assert!(!router.has_route("dropTable"));
+    }
+
+    #[tokio::test]
+    async fn instructions_match_read_only_mode() {
+        let read_write = handler(false).get_info().instructions.expect("instructions present");
+        assert!(
+            read_write.contains("writeQuery"),
+            "read-write instructions mention writeQuery"
+        );
+
+        let read_only = handler(true).get_info().instructions.expect("instructions present");
+        for tool in ["writeQuery", "createDatabase", "dropDatabase", "dropTable"] {
+            assert!(
+                !read_only.contains(tool),
+                "read-only instructions must not mention {tool}"
+            );
+        }
     }
 
     #[tokio::test]

--- a/crates/mysql/src/handler.rs
+++ b/crates/mysql/src/handler.rs
@@ -25,27 +25,7 @@ use crate::tools::{
 const DESCRIPTION: &str = "Database MCP Server for MySQL and MariaDB";
 
 /// Backend-specific instructions for MySQL/MariaDB.
-const INSTRUCTIONS: &str = r"## Workflow
-
-1. Call `listDatabases` to discover available databases.
-2. Call `listTables` to see tables. Pass `search` to filter by name (case-insensitive substring). Pass `detailed: true` to get columns, constraints, indexes, and triggers in the same call — this supersedes the legacy `getTableSchema` workflow.
-3. Call `listViews` to see views.
-4. Call `listTriggers` to see triggers.
-5. Call `listFunctions` to see stored functions.
-6. Call `listProcedures` to see stored procedures.
-7. Use `readQuery` for read-only SQL (SELECT, SHOW, DESCRIBE, USE, EXPLAIN).
-8. Use `writeQuery` for data changes (INSERT, UPDATE, DELETE, CREATE, ALTER, DROP).
-9. Use `explainQuery` to analyze query execution plans and diagnose slow queries.
-10. Use `createDatabase` to create a new database.
-11. Use `dropDatabase` to drop an existing database.
-12. Use `dropTable` to remove a table from a database.
-
-Per-database tools default to the active database; pass `database` to target another.
-
-## Constraints
-
-- The `writeQuery`, `createDatabase`, `dropDatabase`, and `dropTable` tools are hidden when read-only mode is active.
-- Multi-statement queries are not supported. Send one statement per request.";
+const INSTRUCTIONS: &str = include_str!("../assets/instructions.md");
 
 /// MySQL/MariaDB database handler.
 ///

--- a/crates/mysql/src/tools/create_database.rs
+++ b/crates/mysql/src/tools/create_database.rs
@@ -17,27 +17,7 @@ pub(crate) struct CreateDatabaseTool;
 impl CreateDatabaseTool {
     const NAME: &'static str = "createDatabase";
     const TITLE: &'static str = "Create Database";
-    const DESCRIPTION: &'static str = r#"Create a new database on the connected server.
-
-<usecase>
-Use when:
-- Setting up a new database for a project or application
-- The user asks to create a database
-</usecase>
-
-<examples>
-✓ "Create a database called analytics" → createDatabase(database="analytics")
-✗ "Create a table" → use writeQuery with CREATE TABLE
-</examples>
-
-<important>
-Database name must be non-empty; backend reserved-character rules apply.
-If the database already exists, returns a message indicating so without error.
-</important>
-
-<what_it_returns>
-A confirmation message with the created database name.
-</what_it_returns>"#;
+    const DESCRIPTION: &'static str = include_str!("../../assets/tools/create_database.md");
 }
 
 impl ToolBase for CreateDatabaseTool {

--- a/crates/mysql/src/tools/drop_database.rs
+++ b/crates/mysql/src/tools/drop_database.rs
@@ -17,27 +17,7 @@ pub(crate) struct DropDatabaseTool;
 impl DropDatabaseTool {
     const NAME: &'static str = "dropDatabase";
     const TITLE: &'static str = "Drop Database";
-    const DESCRIPTION: &'static str = r#"Drop an existing database from the connected server.
-
-<usecase>
-Use when:
-- Removing a database that is no longer needed
-- Cleaning up test or temporary databases
-</usecase>
-
-<examples>
-✓ "Drop the test_db database" → dropDatabase(database="test_db")
-✗ "Drop a table" → use dropTable instead
-</examples>
-
-<safety>
-IMPORTANT: This permanently deletes the database and ALL its data. This action cannot be undone.
-Cannot drop the database you are currently connected to.
-</safety>
-
-<what_it_returns>
-A confirmation message with the dropped database name.
-</what_it_returns>"#;
+    const DESCRIPTION: &'static str = include_str!("../../assets/tools/drop_database.md");
 }
 
 impl ToolBase for DropDatabaseTool {

--- a/crates/mysql/src/tools/drop_table.rs
+++ b/crates/mysql/src/tools/drop_table.rs
@@ -18,28 +18,7 @@ pub(crate) struct DropTableTool;
 impl DropTableTool {
     const NAME: &'static str = "dropTable";
     const TITLE: &'static str = "Drop Table";
-    const DESCRIPTION: &'static str = r#"Drop a table from a database.
-
-<usecase>
-Use when:
-- Removing a table that is no longer needed
-- Cleaning up test or temporary tables
-</usecase>
-
-<examples>
-✓ "Drop the temp_logs table from mydb" → dropTable(database="mydb", table="temp_logs")
-✗ "Delete rows from a table" → use writeQuery with DELETE
-✗ "Drop a database" → use dropDatabase instead
-</examples>
-
-<safety>
-IMPORTANT: This permanently deletes the table and ALL its data. This action cannot be undone.
-If the table has foreign key dependencies, the drop will fail — resolve dependencies first.
-</safety>
-
-<what_it_returns>
-A confirmation message with the dropped table name.
-</what_it_returns>"#;
+    const DESCRIPTION: &'static str = include_str!("../../assets/tools/drop_table.md");
 }
 
 impl ToolBase for DropTableTool {

--- a/crates/mysql/src/tools/explain_query.rs
+++ b/crates/mysql/src/tools/explain_query.rs
@@ -16,36 +16,7 @@ pub(crate) struct ExplainQueryTool;
 impl ExplainQueryTool {
     const NAME: &'static str = "explainQuery";
     const TITLE: &'static str = "Explain Query";
-    const DESCRIPTION: &'static str = r#"Return the execution plan for a SQL query to diagnose performance. Use this tool instead of running EXPLAIN directly through readQuery — it provides structured output.
-
-<usecase>
-Use when:
-- A query runs slowly and you need to understand why
-- Investigating performance bottlenecks
-- Planning index creation to optimize queries
-- Analyzing join methods, table scan strategies, and sort operations
-</usecase>
-
-<when_not_to_use>
-- Running actual queries → use readQuery or writeQuery
-- Checking table structure → use listTables(detailed=true)
-</when_not_to_use>
-
-<examples>
-✓ "Why is my SELECT on orders slow?" → explainQuery(query="SELECT ...")
-✓ "Should I add an index?" → explainQuery with analyze=true
-✗ "Run this SELECT" → use readQuery
-</examples>
-
-<safety>
-Set `analyze` to true for actual execution statistics (EXPLAIN ANALYZE).
-IMPORTANT: EXPLAIN ANALYZE actually executes the query! In read-only mode, only read-only statements are allowed with analyze.
-When analyze is false, returns EXPLAIN FORMAT=JSON output without executing.
-</safety>
-
-<what_it_returns>
-A JSON array of execution plan rows showing access methods, join types, row estimates, and costs.
-</what_it_returns>"#;
+    const DESCRIPTION: &'static str = include_str!("../../assets/tools/explain_query.md");
 }
 
 impl ToolBase for ExplainQueryTool {

--- a/crates/mysql/src/tools/list_databases.rs
+++ b/crates/mysql/src/tools/list_databases.rs
@@ -16,27 +16,7 @@ pub(crate) struct ListDatabasesTool;
 impl ListDatabasesTool {
     const NAME: &'static str = "listDatabases";
     const TITLE: &'static str = "List Databases";
-    const DESCRIPTION: &'static str = r#"List all accessible databases on the connected server. Use this tool to discover what databases are available before using other tools.
-
-<usecase>
-ALWAYS call this tool FIRST when:
-- You need to explore what databases exist on the server
-- You need a database name for listTables or query tools
-- The user asks what data is available
-</usecase>
-
-<examples>
-✓ "What databases are on this server?"
-✓ "Show me what's available" → call listDatabases first
-</examples>
-
-<what_it_returns>
-A sorted JSON array of database name strings.
-</what_it_returns>
-
-<pagination>
-Paginated. Pass the prior response's `nextCursor` as `cursor` to fetch the next page.
-</pagination>"#;
+    const DESCRIPTION: &'static str = include_str!("../../assets/tools/list_databases.md");
 }
 
 impl ToolBase for ListDatabasesTool {

--- a/crates/mysql/src/tools/list_functions.rs
+++ b/crates/mysql/src/tools/list_functions.rs
@@ -17,38 +17,7 @@ pub(crate) struct ListFunctionsTool;
 impl ListFunctionsTool {
     const NAME: &'static str = "listFunctions";
     const TITLE: &'static str = "List Functions";
-    const DESCRIPTION: &'static str = r#"List user-defined SQL functions in a database, optionally filtered and/or with full metadata. Loadable UDFs (`mysql.func`) and stored procedures are excluded.
-
-<usecase>
-Use when:
-- Auditing stored functions across a database (brief mode, default).
-- Searching for a function by partial name (pass `search`).
-- Inspecting a function's language, signature, return type, determinism, SQL-data-access classification, security mode, definer, comment, session context, and full reconstructed `CREATE FUNCTION` text before reasoning about correctness or invocation safety (pass `detailed: true`). Detailed mode supersedes ad-hoc `readQuery` against `information_schema.ROUTINES` / `information_schema.PARAMETERS`.
-</usecase>
-
-<parameters>
-- `database` — Database to target. Defaults to the active database.
-- `cursor` — Opaque pagination cursor; echo the prior response's `nextCursor`.
-- `search` — Case-insensitive filter on function names via `LIKE`. `%` matches any sequence; `_` matches a single character.
-- `detailed` — When `true`, returns full metadata objects keyed by function name instead of bare name strings. Default `false`.
-</parameters>
-
-<examples>
-✓ "What functions are in the mydb database?" → listFunctions(database="mydb")
-✓ "Find the order-total calculation" → listFunctions(search="order")
-✓ "What does calc_order_total do?" → listFunctions(search="calc_order_total", detailed=true)
-✗ "List stored procedures" → use listProcedures instead
-✗ "List loadable UDFs from mysql.func" → not supported; only routines in information_schema.ROUTINES are returned
-</examples>
-
-<what_it_returns>
-Brief mode (default): a sorted JSON array of function-name strings, e.g. `["calc_order_subtotal", "calc_order_total", "double_it"]`.
-Detailed mode: a JSON object keyed by bare function name (MySQL/MariaDB do not allow function overloading, so no signature suffix is needed); each value carries `schema`, `language` (typically `"SQL"`; MariaDB external-language functions report the external language name), `arguments` (comma-separated `name type` pairs from `information_schema.PARAMETERS`, empty string for zero-parameter functions), `returnType` (full `DTD_IDENTIFIER` including length/precision/unsigned/enum/set members), `deterministic` (boolean), `sqlDataAccess` (one of `CONTAINS_SQL`, `NO_SQL`, `READS_SQL_DATA`, `MODIFIES_SQL_DATA`), `security` (`INVOKER` or `DEFINER`), `definer` (`user@host`), `description` (the `COMMENT` text or `null` when no comment was set — the empty string MySQL stores is coerced to JSON `null`), `definition` (the canonical reconstructed `CREATE FUNCTION` text including `DEFINER=` in `` `user`@`host` `` form), `sqlMode`, `characterSetClient`, `collationConnection`, and `databaseCollation`. Versus the Postgres detailed payload: `volatility`, `parallelSafety`, and `strict` are intentionally absent (no MySQL/MariaDB analogues), `owner` is renamed to `definer` (more accurate for the MySQL `DEFINER` concept), keys are bare names rather than `name(arguments)` (no overloads possible), and the four session-context fields (`sqlMode`, `characterSetClient`, `collationConnection`, `databaseCollation`) are MySQL/MariaDB-only additions.
-</what_it_returns>
-
-<pagination>
-Paginated. Pass the prior response's `nextCursor` as `cursor` to fetch the next page. The `search` filter must stay the same across pages for cursor continuity.
-</pagination>"#;
+    const DESCRIPTION: &'static str = include_str!("../../assets/tools/list_functions.md");
 }
 
 impl ToolBase for ListFunctionsTool {

--- a/crates/mysql/src/tools/list_procedures.rs
+++ b/crates/mysql/src/tools/list_procedures.rs
@@ -16,38 +16,7 @@ pub(crate) struct ListProceduresTool;
 impl ListProceduresTool {
     const NAME: &'static str = "listProcedures";
     const TITLE: &'static str = "List Procedures";
-    const DESCRIPTION: &'static str = r#"List user-defined stored procedures in a database, optionally filtered and/or with full metadata. Stored functions and loadable UDFs (`mysql.func`) are excluded.
-
-<usecase>
-Use when:
-- Auditing stored procedures across a database (brief mode, default).
-- Searching for a procedure by partial name (pass `search`).
-- Inspecting a procedure's language, parameter list (with `IN`/`OUT`/`INOUT` modes), determinism, SQL-data-access classification, security mode, definer, comment, session context, and full reconstructed `CREATE PROCEDURE` text before reasoning about correctness or invocation safety (pass `detailed: true`). Detailed mode supersedes ad-hoc `readQuery` against `information_schema.ROUTINES` / `information_schema.PARAMETERS`.
-</usecase>
-
-<parameters>
-- `database` — Database to target. Defaults to the active database.
-- `cursor` — Opaque pagination cursor; echo the prior response's `nextCursor`.
-- `search` — Case-insensitive filter on procedure names via `LIKE`. `%` matches any sequence; `_` matches a single character.
-- `detailed` — When `true`, returns full metadata objects keyed by procedure name instead of bare name strings. Default `false`.
-</parameters>
-
-<examples>
-✓ "What procedures are in the mydb database?" → listProcedures(database="mydb")
-✓ "Find the order archival routine" → listProcedures(search="archive")
-✓ "What does archive_order do?" → listProcedures(search="archive_order", detailed=true)
-✗ "List functions" → use listFunctions instead
-✗ "List loadable UDFs from mysql.func" → not supported; only routines in information_schema.ROUTINES are returned
-</examples>
-
-<what_it_returns>
-Brief mode (default): a sorted JSON array of procedure-name strings, e.g. `["archive_order", "archive_order_history", "purge_order_archive", "touch_post"]`.
-Detailed mode: a JSON object keyed by bare procedure name (MySQL/MariaDB do not allow procedure overloading, so no signature suffix is needed); each value carries `schema`, `language` (typically `"SQL"`; MariaDB external-language procedures report the external language name), `arguments` (comma-separated `MODE name type` triples from `information_schema.PARAMETERS` — `MODE` is one of `IN`, `OUT`, `INOUT`; empty string for zero-parameter procedures), `deterministic` (boolean), `sqlDataAccess` (one of `CONTAINS_SQL`, `NO_SQL`, `READS_SQL_DATA`, `MODIFIES_SQL_DATA`), `security` (`INVOKER` or `DEFINER`), `definer` (`user@host`), `description` (the `COMMENT` text or `null` when no comment was set — the empty string MySQL stores is coerced to JSON `null`), `definition` (the canonical reconstructed `CREATE PROCEDURE` text including `DEFINER=` in `` `user`@`host` `` form; no `RETURNS` clause — procedures have no return type), `sqlMode`, `characterSetClient`, `collationConnection`, and `databaseCollation`. Versus the Postgres `listProcedures` detailed payload: `volatility`, `parallelSafety`, `strict`, and `returnType` are intentionally absent (no MySQL/MariaDB analogues for the first three; procedures have no return type for the fourth — the Postgres-side payload also omits all four), `owner` is renamed to `definer` (more accurate for the MySQL `DEFINER` concept), keys are bare names rather than `name(arguments)` (no overloads possible), the four session-context fields (`sqlMode`, `characterSetClient`, `collationConnection`, `databaseCollation`) are MySQL/MariaDB-only additions, and `deterministic` plus `sqlDataAccess` are MySQL/MariaDB-only additions versus the Postgres `listProcedures` detailed payload (which omits both because Postgres procedures have no equivalent attributes).
-</what_it_returns>
-
-<pagination>
-Paginated. Pass the prior response's `nextCursor` as `cursor` to fetch the next page. The `search` filter must stay the same across pages for cursor continuity.
-</pagination>"#;
+    const DESCRIPTION: &'static str = include_str!("../../assets/tools/list_procedures.md");
 }
 
 impl ToolBase for ListProceduresTool {

--- a/crates/mysql/src/tools/list_tables.rs
+++ b/crates/mysql/src/tools/list_tables.rs
@@ -295,36 +295,7 @@ pub(crate) struct ListTablesTool;
 impl ListTablesTool {
     const NAME: &'static str = "listTables";
     const TITLE: &'static str = "List Tables";
-    const DESCRIPTION: &'static str = r#"List tables in a database, optionally filtered and/or with full metadata.
-
-<usecase>
-Use when:
-- Exploring a database to find relevant tables (brief mode, default).
-- Searching for a table by partial name (pass `search`).
-- Inspecting a table's columns, constraints, indexes, and triggers before writing a query (pass `detailed: true`). This supersedes the legacy `getTableSchema` tool.
-</usecase>
-
-<parameters>
-- `database` — Database to target. Defaults to the active database.
-- `cursor` — Opaque pagination cursor; echo the prior response's `nextCursor`.
-- `search` — Case-insensitive filter on table names via `LIKE`. `%` matches any sequence; `_` matches a single character.
-- `detailed` — When `true`, returns full metadata objects keyed by table name instead of bare name strings. Default `false`.
-</parameters>
-
-<examples>
-✓ "What tables are in mydb?" → listTables(database="mydb")
-✓ "Find the orders table" → listTables(search="order")
-✓ "What columns does orders have?" → listTables(search="orders", detailed=true)
-</examples>
-
-<what_it_returns>
-Brief mode (default): a sorted JSON array of table-name strings, e.g. `["customers", "orders"]`.
-Detailed mode: a JSON object keyed by table name; each value carries `schema`, `kind`, `owner`, `comment`, `columns`, `constraints`, `indexes`, and `triggers` (the name is the key and is not repeated inside the value). Keys iterate in the same alphabetical order brief mode uses. Example: `{"orders": {"schema": "mydb", "kind": "TABLE", …}}`.
-</what_it_returns>
-
-<pagination>
-Paginated. Pass the prior response's `nextCursor` as `cursor` to fetch the next page. The `search` filter must stay the same across pages for cursor continuity.
-</pagination>"#;
+    const DESCRIPTION: &'static str = include_str!("../../assets/tools/list_tables.md");
 }
 
 impl ToolBase for ListTablesTool {

--- a/crates/mysql/src/tools/list_triggers.rs
+++ b/crates/mysql/src/tools/list_triggers.rs
@@ -16,37 +16,7 @@ pub(crate) struct ListTriggersTool;
 impl ListTriggersTool {
     const NAME: &'static str = "listTriggers";
     const TITLE: &'static str = "List Triggers";
-    const DESCRIPTION: &'static str = r#"List user-defined triggers in a database, optionally filtered and/or with full metadata.
-
-<usecase>
-Use when:
-- Auditing trigger coverage across a database (brief mode, default).
-- Searching for a trigger by partial name (pass `search`).
-- Inspecting a trigger's timing, event, activation level, full `CREATE TRIGGER` text, and the session context active at trigger-creation time before reasoning about side-effects (pass `detailed: true`). Detailed mode supersedes ad-hoc `readQuery` against `information_schema.TRIGGERS`.
-</usecase>
-
-<parameters>
-- `database` — Database to target. Defaults to the active database.
-- `cursor` — Opaque pagination cursor; echo the prior response's `nextCursor`.
-- `search` — Case-insensitive filter on trigger names via `LIKE`. `%` matches any sequence; `_` matches a single character.
-- `detailed` — When `true`, returns full metadata objects keyed by trigger name instead of bare name strings. Default `false`.
-</parameters>
-
-<examples>
-✓ "What triggers are in the mydb database?" → listTriggers(database="mydb")
-✓ "Find the audit triggers" → listTriggers(search="audit")
-✓ "What does orders_audit_after_insert do?" → listTriggers(search="orders_audit_after_insert", detailed=true)
-✗ "Show me a trigger's body" → use detailed mode; the `definition` field carries the full `CREATE TRIGGER` text
-</examples>
-
-<what_it_returns>
-Brief mode (default): a sorted JSON array of trigger-name strings, e.g. `["customers_audit_after_insert", "orders_audit_after_insert"]`.
-Detailed mode: a JSON object keyed by trigger name; each value carries `schema`, `table`, `timing` (BEFORE/AFTER), `events` (single-element array — `INSERT`, `UPDATE`, or `DELETE`), `activationLevel` (always `ROW` on MySQL/MariaDB), `definition` (the canonical `CREATE TRIGGER` text including `DEFINER=` in `` `user`@`host` `` form), `sqlMode`, `characterSetClient`, `collationConnection`, and `databaseCollation`. The Postgres-only `status` and `functionName` fields are intentionally absent (no per-trigger enabled/disabled flag and no separate handler-function reference on MySQL/MariaDB); the four session-context fields are MySQL/MariaDB-only additions versus the Postgres detailed payload.
-</what_it_returns>
-
-<pagination>
-Paginated. Pass the prior response's `nextCursor` as `cursor` to fetch the next page. The `search` filter must stay the same across pages for cursor continuity.
-</pagination>"#;
+    const DESCRIPTION: &'static str = include_str!("../../assets/tools/list_triggers.md");
 }
 
 impl ToolBase for ListTriggersTool {

--- a/crates/mysql/src/tools/list_views.rs
+++ b/crates/mysql/src/tools/list_views.rs
@@ -16,40 +16,7 @@ pub(crate) struct ListViewsTool;
 impl ListViewsTool {
     const NAME: &'static str = "listViews";
     const TITLE: &'static str = "List Views";
-    const DESCRIPTION: &'static str = r#"List user-defined views in a database, optionally filtered and/or with full metadata. Base tables and system-schema views are excluded.
-
-<usecase>
-Use when:
-- Auditing views across a database (brief mode, default).
-- Searching for a view by partial name (pass `search`).
-- Inspecting a view's definer, security mode, check-option level, updatable flag, session character set/collation, and full SELECT body before querying it (pass `detailed: true`). Detailed mode supersedes ad-hoc `readQuery` against `information_schema.VIEWS`.
-</usecase>
-
-<parameters>
-- `database` — Database to target. Defaults to the active database.
-- `cursor` — Opaque pagination cursor; echo the prior response's `nextCursor`.
-- `search` — Case-insensitive filter on view names via `LIKE`. `%` matches any sequence; `_` matches a single character.
-- `detailed` — When `true`, returns full metadata objects keyed by view name instead of bare name strings. Default `false`.
-</parameters>
-
-<examples>
-✓ "What views are in the mydb database?" → listViews(database="mydb")
-✓ "Find the active-users view" → listViews(search="active")
-✓ "What does active_users select?" → listViews(search="active_users", detailed=true)
-✗ "Show me the columns of a view" → use listTables with `detailed: true` instead
-✗ "List materialized views" → MySQL/MariaDB have no materialized-view concept
-</examples>
-
-<what_it_returns>
-Brief mode (default): a sorted JSON array of view-name strings, e.g. `["active_orders", "active_users", "published_posts"]`.
-Detailed mode: a JSON object keyed by bare view name; each value carries `schema`, `definer` (`user@host`), `security` (`INVOKER` or `DEFINER`), `checkOption` (`NONE`, `CASCADED`, or `LOCAL`), `updatable` (boolean), `characterSetClient`, `collationConnection`, and `definition` (the SELECT body verbatim from `information_schema.VIEWS.VIEW_DEFINITION`, with no `CREATE VIEW` wrapper). The view name is the map key only — it is not repeated inside the value.
-
-Versus the Postgres `listViews` detailed payload: `description` is intentionally absent (neither MySQL nor MariaDB exposes a user-comment column for views — `CREATE VIEW` syntax has no `COMMENT` clause), `algorithm` is intentionally absent (MariaDB-only column on `information_schema.VIEWS`), `owner` is renamed to `definer` (more accurate for the MySQL `DEFINER` concept), and the five MySQL/MariaDB-only structured fields (`security`, `checkOption`, `updatable`, `characterSetClient`, `collationConnection`) are added. The `definition` field shape is byte-identical to Postgres — raw SELECT body verbatim, no DDL wrapper. When the connected role lacks the `SHOW VIEW` privilege on a particular view, the engine redacts `VIEW_DEFINITION` to the empty string; the row remains in the response with `definition` reflecting that empty value.
-</what_it_returns>
-
-<pagination>
-Paginated. Pass the prior response's `nextCursor` as `cursor` to fetch the next page. The `search` filter must stay the same across pages for cursor continuity. Brief and detailed modes share the same `TABLE_NAME` row order, so a client can switch `detailed` between pages without losing position.
-</pagination>"#;
+    const DESCRIPTION: &'static str = include_str!("../../assets/tools/list_views.md");
 }
 
 impl ToolBase for ListViewsTool {

--- a/crates/mysql/src/tools/read_query.rs
+++ b/crates/mysql/src/tools/read_query.rs
@@ -19,38 +19,7 @@ pub(crate) struct ReadQueryTool;
 impl ReadQueryTool {
     const NAME: &'static str = "readQuery";
     const TITLE: &'static str = "Read Query";
-    const DESCRIPTION: &'static str = r#"Execute a read-only SQL query. Allowed statements: SELECT, SHOW, DESCRIBE, USE, EXPLAIN.
-
-<usecase>
-Use when:
-- Querying data from tables (SELECT with WHERE, JOIN, GROUP BY, etc.)
-- Aggregations: COUNT, SUM, AVG, GROUP BY, HAVING
-- Listing server variables or status (SHOW)
-- Viewing table structure (DESCRIBE)
-- Switching database context (USE)
-</usecase>
-
-<when_not_to_use>
-- Data changes (INSERT, UPDATE, DELETE) → use writeQuery
-- Query performance analysis → use explainQuery
-- Discovering tables or columns → use listTables (pass detailed=true for column-level metadata)
-</when_not_to_use>
-
-<examples>
-✓ "SELECT * FROM users WHERE status = 'active'"
-✓ "SELECT COUNT(*) FROM orders GROUP BY region"
-✓ "SHOW TABLES" or "DESCRIBE users"
-✗ "INSERT INTO users ..." → use writeQuery
-✗ "EXPLAIN SELECT ..." → use explainQuery for structured analysis
-</examples>
-
-<what_it_returns>
-A JSON array of row objects, each keyed by column name.
-</what_it_returns>
-
-<pagination>
-`SELECT` results are paginated. Pass the prior response's `nextCursor` as `cursor` to fetch the next page. `SHOW`, `DESCRIBE`, `USE`, and `EXPLAIN` return a single page and ignore `cursor`.
-</pagination>"#;
+    const DESCRIPTION: &'static str = include_str!("../../assets/tools/read_query.md");
 }
 
 impl ToolBase for ReadQueryTool {

--- a/crates/mysql/src/tools/write_query.rs
+++ b/crates/mysql/src/tools/write_query.rs
@@ -15,31 +15,7 @@ pub(crate) struct WriteQueryTool;
 impl WriteQueryTool {
     const NAME: &'static str = "writeQuery";
     const TITLE: &'static str = "Write Query";
-    const DESCRIPTION: &'static str = r#"Execute a write SQL query (INSERT, UPDATE, DELETE, CREATE, ALTER, DROP).
-
-<usecase>
-Use when:
-- Inserting, updating, or deleting rows
-- Creating or altering tables, indexes, views, or other schema objects
-- Any data modification operation
-</usecase>
-
-<when_not_to_use>
-- Read-only queries (SELECT, SHOW) → use readQuery
-- Query performance analysis → use explainQuery
-- Creating/dropping entire databases → use createDatabase or dropDatabase
-</when_not_to_use>
-
-<examples>
-✓ "INSERT INTO users (name, email) VALUES ('Alice', 'alice@example.com')"
-✓ "UPDATE orders SET status = 'shipped' WHERE id = 42"
-✓ "CREATE TABLE logs (id INT PRIMARY KEY, message TEXT)"
-✗ "SELECT * FROM users" → use readQuery
-</examples>
-
-<what_it_returns>
-A JSON array of affected/returning row objects, each keyed by column name.
-</what_it_returns>"#;
+    const DESCRIPTION: &'static str = include_str!("../../assets/tools/write_query.md");
 }
 
 impl ToolBase for WriteQueryTool {

--- a/crates/postgres/assets/instructions.md
+++ b/crates/postgres/assets/instructions.md
@@ -1,0 +1,22 @@
+## Workflow
+
+1. Call `listDatabases` to discover available databases.
+2. Call `listTables` to see tables. Pass `search` to filter by name (case-insensitive substring). Pass `detailed: true` to get columns, constraints, indexes, and triggers in the same call — this supersedes the legacy `getTableSchema` workflow.
+3. Call `listViews` to see views in the `public` schema.
+4. Call `listTriggers` to see user-defined triggers in the `public` schema.
+5. Call `listFunctions` to see user-defined functions in the `public` schema.
+6. Call `listProcedures` to see user-defined procedures in the `public` schema.
+7. Call `listMaterializedViews` to see materialized views in the `public` schema.
+8. Use `readQuery` for read-only SQL (SELECT, SHOW, EXPLAIN).
+9. Use `writeQuery` for data changes (INSERT, UPDATE, DELETE, CREATE, ALTER, DROP).
+10. Use `explainQuery` to analyze query execution plans and diagnose slow queries.
+11. Use `createDatabase` to create a new database.
+12. Use `dropDatabase` to drop an existing database.
+13. Use `dropTable` to remove a table from a database (supports `cascade` for foreign key dependencies).
+
+Per-database tools default to the active database; pass `database` to target another.
+
+## Constraints
+
+- The `writeQuery`, `createDatabase`, `dropDatabase`, and `dropTable` tools are hidden when read-only mode is active.
+- Multi-statement queries are not supported. Send one statement per request.

--- a/crates/postgres/assets/instructions.readonly.md
+++ b/crates/postgres/assets/instructions.readonly.md
@@ -1,0 +1,18 @@
+## Workflow
+
+1. Call `listDatabases` to discover available databases.
+2. Call `listTables` to see tables. Pass `search` to filter by name (case-insensitive substring). Pass `detailed: true` to get columns, constraints, indexes, and triggers in the same call — this supersedes the legacy `getTableSchema` workflow.
+3. Call `listViews` to see views in the `public` schema.
+4. Call `listTriggers` to see user-defined triggers in the `public` schema.
+5. Call `listFunctions` to see user-defined functions in the `public` schema.
+6. Call `listProcedures` to see user-defined procedures in the `public` schema.
+7. Call `listMaterializedViews` to see materialized views in the `public` schema.
+8. Use `readQuery` for read-only SQL (SELECT, SHOW, EXPLAIN).
+9. Use `explainQuery` to analyze query execution plans and diagnose slow queries.
+
+Per-database tools default to the active database; pass `database` to target another.
+
+## Constraints
+
+- The server runs in read-only mode. Data and schema changes are not possible.
+- Multi-statement queries are not supported. Send one statement per request.

--- a/crates/postgres/assets/tools/create_database.md
+++ b/crates/postgres/assets/tools/create_database.md
@@ -1,0 +1,20 @@
+Create a new database on the connected server.
+
+<usecase>
+Use when:
+- Setting up a new database for a project or application
+- The user asks to create a database
+</usecase>
+
+<examples>
+✓ "Create a database called analytics" → createDatabase(database="analytics")
+✗ "Create a table" → use writeQuery with CREATE TABLE
+</examples>
+
+<important>
+Database name must be non-empty; backend reserved-character rules apply.
+</important>
+
+<what_it_returns>
+A confirmation message with the created database name.
+</what_it_returns>

--- a/crates/postgres/assets/tools/drop_database.md
+++ b/crates/postgres/assets/tools/drop_database.md
@@ -1,0 +1,21 @@
+Drop an existing database from the connected server.
+
+<usecase>
+Use when:
+- Removing a database that is no longer needed
+- Cleaning up test or temporary databases
+</usecase>
+
+<examples>
+✓ "Drop the test_db database" → dropDatabase(database="test_db")
+✗ "Drop a table" → use dropTable instead
+</examples>
+
+<safety>
+IMPORTANT: This permanently deletes the database and ALL its data. This action cannot be undone.
+Cannot drop the database you are currently connected to.
+</safety>
+
+<what_it_returns>
+A confirmation message with the dropped database name.
+</what_it_returns>

--- a/crates/postgres/assets/tools/drop_table.md
+++ b/crates/postgres/assets/tools/drop_table.md
@@ -1,0 +1,24 @@
+Drop a table from a database. Checks for foreign key dependencies via the database engine.
+
+<usecase>
+Use when:
+- Removing a table that is no longer needed
+- Cleaning up test or temporary tables
+</usecase>
+
+<examples>
+✓ "Drop the temp_logs table" → dropTable(database="mydb", table="temp_logs")
+✓ "Force drop with dependencies" → dropTable(..., cascade=true)
+✗ "Delete rows from a table" → use writeQuery with DELETE
+✗ "Drop a database" → use dropDatabase instead
+</examples>
+
+<safety>
+IMPORTANT: This permanently deletes the table and ALL its data. This action cannot be undone.
+Set `cascade` to true to also drop dependent foreign key constraints.
+Without cascade, the drop will fail if other tables reference this one.
+</safety>
+
+<what_it_returns>
+A confirmation message with the dropped table name.
+</what_it_returns>

--- a/crates/postgres/assets/tools/explain_query.md
+++ b/crates/postgres/assets/tools/explain_query.md
@@ -1,0 +1,30 @@
+Return the execution plan for a SQL query to diagnose performance. Use this tool instead of running EXPLAIN directly through readQuery — it provides structured JSON output.
+
+<usecase>
+Use when:
+- A query runs slowly and you need to understand why
+- Investigating performance bottlenecks
+- Planning index creation to optimize queries
+- Analyzing join methods, table scan strategies, and sort operations
+</usecase>
+
+<when_not_to_use>
+- Running actual queries → use readQuery or writeQuery
+- Checking table structure → use listTables(detailed=true)
+</when_not_to_use>
+
+<examples>
+✓ "Why is my SELECT on orders slow?" → explainQuery(query="SELECT ...")
+✓ "Should I add an index?" → explainQuery with analyze=true
+✗ "Run this SELECT" → use readQuery
+</examples>
+
+<safety>
+Set `analyze` to true for actual execution statistics (EXPLAIN ANALYZE).
+IMPORTANT: EXPLAIN ANALYZE actually executes the query! In read-only mode, only read-only statements are allowed with analyze.
+When analyze is false, returns EXPLAIN (FORMAT JSON) output without executing.
+</safety>
+
+<what_it_returns>
+A JSON array of execution plan rows showing access methods, join types, row estimates, and costs.
+</what_it_returns>

--- a/crates/postgres/assets/tools/list_databases.md
+++ b/crates/postgres/assets/tools/list_databases.md
@@ -1,0 +1,21 @@
+List all accessible databases on the connected server. Use this tool to discover what databases are available before using other tools.
+
+<usecase>
+ALWAYS call this tool FIRST when:
+- You need to explore what databases exist on the server
+- You need a database name for listTables or query tools
+- The user asks what data is available
+</usecase>
+
+<examples>
+✓ "What databases are on this server?"
+✓ "Show me what's available" → call listDatabases first
+</examples>
+
+<what_it_returns>
+A sorted JSON array of database name strings.
+</what_it_returns>
+
+<pagination>
+Paginated. Pass the prior response's `nextCursor` as `cursor` to fetch the next page.
+</pagination>

--- a/crates/postgres/assets/tools/list_functions.md
+++ b/crates/postgres/assets/tools/list_functions.md
@@ -1,0 +1,32 @@
+List user-defined functions in the `public` schema, optionally filtered and/or with full metadata. Aggregates, window functions, and procedures are excluded.
+
+<usecase>
+Use when:
+- Auditing functions across a database (brief mode, default).
+- Searching for a function by partial name (pass `search`).
+- Inspecting a function's language, signature, return type, volatility, strictness, security mode, parallel-safety, owner, comment, and full `CREATE FUNCTION` text before reasoning about correctness or invocation safety (pass `detailed: true`). Detailed mode supersedes ad-hoc `readQuery` against `pg_proc` / `information_schema.routines`.
+</usecase>
+
+<parameters>
+- `database` — Database to target. Defaults to the active database.
+- `cursor` — Opaque pagination cursor; echo the prior response's `nextCursor`.
+- `search` — Case-insensitive filter on function names via `ILIKE`. `%` matches any sequence; `_` matches a single character.
+- `detailed` — When `true`, returns full metadata objects keyed by `name(arguments)` instead of bare name strings. Default `false`.
+</parameters>
+
+<examples>
+✓ "What functions are in mydb?" → listFunctions(database="mydb")
+✓ "Find the order-total calculation" → listFunctions(search="order")
+✓ "What does calc_order_total do?" → listFunctions(search="calc_order_total", detailed=true)
+✗ "List stored procedures" → use listProcedures instead
+✗ "List aggregates" → not supported; aggregates are excluded
+</examples>
+
+<what_it_returns>
+Brief mode (default): a sorted JSON array of function-name strings, e.g. `["audit_user_login", "calc_order_subtotal", "calc_order_total", "calc_order_total"]`. Overloaded functions appear as one entry per overload (duplicate name strings allowed).
+Detailed mode: a JSON object keyed by function signature `name(arguments)`; each value carries `schema`, `name`, `language`, `arguments`, `returnType`, `volatility` (IMMUTABLE/STABLE/VOLATILE), `strict` (boolean), `security` (INVOKER/DEFINER), `parallelSafety` (SAFE/RESTRICTED/UNSAFE), `owner`, `description` (or null when no `COMMENT ON FUNCTION`), and `definition` (the full `CREATE OR REPLACE FUNCTION` text). Overloads occupy distinct keys (e.g. `calc_total(integer)` vs `calc_total(integer, numeric)`).
+</what_it_returns>
+
+<pagination>
+Paginated. Pass the prior response's `nextCursor` as `cursor` to fetch the next page. The `search` filter must stay the same across pages for cursor continuity. Brief and detailed modes share the same `(proname, oid)` row order, so a client can switch `detailed` between pages without losing position.
+</pagination>

--- a/crates/postgres/assets/tools/list_materialized_views.md
+++ b/crates/postgres/assets/tools/list_materialized_views.md
@@ -1,0 +1,41 @@
+List materialized views in the `public` schema, optionally filtered and/or with full metadata. Unlike regular views, materialized views store their results physically and must be refreshed explicitly. Regular views and system-schema matviews are excluded.
+
+<usecase>
+Use when:
+- Auditing materialized views across a database (brief mode, default).
+- Searching for a matview by partial name (pass `search`).
+- Inspecting a matview's owner, comment, full SELECT body, populated state, and index presence before querying or refreshing it (pass `detailed: true`). Detailed mode supersedes ad-hoc `readQuery` against `pg_matviews` / `pg_class`.
+</usecase>
+
+<parameters>
+- `database` — Database to target. Defaults to the active database.
+- `cursor` — Opaque pagination cursor; echo the prior response's `nextCursor`.
+- `search` — Case-insensitive filter on matview names via `ILIKE`. `%` matches any sequence; `_` matches a single character.
+- `detailed` — When `true`, returns full metadata objects keyed by bare matview name instead of bare name strings. Default `false`.
+</parameters>
+
+<examples>
+✓ "What materialized views are in mydb?" → listMaterializedViews(database="mydb")
+✓ "Find the recent-orders matview" → listMaterializedViews(search="orders")
+✓ "What does mv_orders_by_region compute?" → listMaterializedViews(search="mv_orders_by_region", detailed=true)
+✓ "Has the cache matview ever been refreshed?" → listMaterializedViews(search="cache", detailed=true) — read `populated`
+✓ "Which matviews can I refresh concurrently?" → listMaterializedViews(detailed=true) — read `indexed` (CONCURRENTLY additionally needs a unique index)
+✗ "List regular views" → use listViews instead
+</examples>
+
+<what_it_returns>
+Brief mode (default): a sorted JSON array of matview-name strings, e.g. `["mv_archived_orders", "mv_recent_orders"]`. Matview names are unique per schema, so no duplicates appear.
+Detailed mode: a JSON object keyed by bare matview name; each value carries:
+- `schema` — schema name (always `"public"` in this build).
+- `owner` — owning role's name from `pg_matviews.matviewowner`.
+- `description` — `COMMENT ON MATERIALIZED VIEW` text, or `null` when no comment.
+- `definition` — the SELECT body verbatim from `pg_matviews.definition`, with no `CREATE MATERIALIZED VIEW` wrapper.
+- `populated` — `true` once the matview has been refreshed at least once. `false` for matviews created `WITH NO DATA` and never refreshed; querying such a matview returns zero rows until `REFRESH MATERIALIZED VIEW` runs.
+- `indexed` — `true` when at least one index exists on the matview. `REFRESH MATERIALIZED VIEW CONCURRENTLY` additionally requires a unique index; this tool reports the broader has-any-index signal.
+
+The matview name is the map key only — it is not repeated inside the value. Detailed mode deliberately omits column metadata (`columns`), `tablespace`, storage parameters, and unique-index detection. Column shape is recoverable from the `definition` text or via `listTables(detailed=true)` since Postgres exposes matviews in `pg_class`.
+</what_it_returns>
+
+<pagination>
+Paginated. Pass the prior response's `nextCursor` as `cursor` to fetch the next page. The `search` filter must stay the same across pages for cursor continuity. Brief and detailed modes share the same `matviewname` row order, so a client can switch `detailed` between pages without losing position.
+</pagination>

--- a/crates/postgres/assets/tools/list_procedures.md
+++ b/crates/postgres/assets/tools/list_procedures.md
@@ -1,0 +1,34 @@
+List user-defined procedures in the `public` schema, optionally filtered and/or with full metadata. Functions, aggregates, and window functions are excluded.
+
+<usecase>
+Use when:
+- Auditing procedures across a database (brief mode, default).
+- Searching for a procedure by partial name (pass `search`).
+- Inspecting a procedure's language, signature, security mode, owner, comment, and full `CREATE PROCEDURE` text before reasoning about correctness or invocation safety (pass `detailed: true`). Detailed mode supersedes ad-hoc `readQuery` against `pg_proc` / `information_schema.routines`.
+</usecase>
+
+<parameters>
+- `database` — Database to target. Defaults to the active database.
+- `cursor` — Opaque pagination cursor; echo the prior response's `nextCursor`.
+- `search` — Case-insensitive filter on procedure names via `ILIKE`. `%` matches any sequence; `_` matches a single character.
+- `detailed` — When `true`, returns full metadata objects keyed by `name(arguments)` instead of bare name strings. Default `false`.
+</parameters>
+
+<examples>
+✓ "What procedures are in mydb?" → listProcedures(database="mydb")
+✓ "Find the order archival routine" → listProcedures(search="archive")
+✓ "What does archive_order do?" → listProcedures(search="archive_order", detailed=true)
+✗ "List functions" → use listFunctions instead
+✗ "List aggregates" → not supported; aggregates are excluded
+</examples>
+
+<what_it_returns>
+Brief mode (default): a sorted JSON array of procedure-name strings, e.g. `["archive_order", "archive_order_history", "archive_order_history"]`. Overloaded procedures appear as one entry per overload (duplicate name strings allowed).
+Detailed mode: a JSON object keyed by procedure signature `name(arguments)`; each value carries `schema`, `name`, `language`, `arguments`, `security` (INVOKER/DEFINER), `owner`, `description` (or null when no `COMMENT ON PROCEDURE`), and `definition` (the full `CREATE OR REPLACE PROCEDURE` text). Overloads occupy distinct keys (e.g. `archive_order_history(integer)` vs `archive_order_history(integer, boolean)`). Zero-arg procedures key as `name()` — the parens are always present so the key shape stays uniform.
+
+Detailed mode deliberately omits the `listFunctions`-only fields `returnType`, `volatility`, `strict`, and `parallelSafety`: procedures don't return a value, `pg_proc.provolatile` / `proisstrict` are not user-settable for procedures, and `proparallel` carries no procedure-level guarantee in PostgreSQL.
+</what_it_returns>
+
+<pagination>
+Paginated. Pass the prior response's `nextCursor` as `cursor` to fetch the next page. The `search` filter must stay the same across pages for cursor continuity. Brief and detailed modes share the same `(proname, oid)` row order, so a client can switch `detailed` between pages without losing position.
+</pagination>

--- a/crates/postgres/assets/tools/list_tables.md
+++ b/crates/postgres/assets/tools/list_tables.md
@@ -1,0 +1,30 @@
+List tables in a database, optionally filtered and/or with full metadata.
+
+<usecase>
+Use when:
+- Exploring a database to find relevant tables (brief mode, default).
+- Searching for a table by partial name (pass `search`).
+- Inspecting a table's columns, constraints, indexes, and triggers before writing a query (pass `detailed: true`). This supersedes the legacy `getTableSchema` tool.
+</usecase>
+
+<parameters>
+- `database` — Database to target. Defaults to the active database.
+- `cursor` — Opaque pagination cursor; echo the prior response's `nextCursor`.
+- `search` — Case-insensitive filter on table names via `ILIKE`. `%` matches any sequence; `_` matches a single character.
+- `detailed` — When `true`, returns full metadata objects keyed by table name instead of bare name strings. Default `false`.
+</parameters>
+
+<examples>
+✓ "What tables are in mydb?" → listTables(database="mydb")
+✓ "Find the orders table" → listTables(search="order")
+✓ "What columns does orders have?" → listTables(search="orders", detailed=true)
+</examples>
+
+<what_it_returns>
+Brief mode (default): a sorted JSON array of table-name strings, e.g. `["customers", "orders"]`.
+Detailed mode: a JSON object keyed by table name; each value carries `schema`, `kind`, `owner`, `comment`, `columns`, `constraints`, `indexes`, and `triggers` (the name is the key and is not repeated inside the value). Keys iterate in the same alphabetical order brief mode uses. Example: `{"orders": {"schema": "public", "kind": "TABLE", …}}`.
+</what_it_returns>
+
+<pagination>
+Paginated. Pass the prior response's `nextCursor` as `cursor` to fetch the next page. The `search` filter must stay the same across pages for cursor continuity.
+</pagination>

--- a/crates/postgres/assets/tools/list_triggers.md
+++ b/crates/postgres/assets/tools/list_triggers.md
@@ -1,0 +1,31 @@
+List user-defined triggers in the `public` schema, optionally filtered and/or with full metadata.
+
+<usecase>
+Use when:
+- Auditing triggers across a database (brief mode, default).
+- Searching for a trigger by partial name (pass `search`).
+- Inspecting a trigger's timing, events, activation level, handler function, status, and full `CREATE TRIGGER` text before reasoning about side-effects (pass `detailed: true`). Detailed mode supersedes ad-hoc `readQuery` against `pg_trigger` / `information_schema.triggers`.
+</usecase>
+
+<parameters>
+- `database` — Database to target. Defaults to the active database.
+- `cursor` — Opaque pagination cursor; echo the prior response's `nextCursor`.
+- `search` — Case-insensitive filter on trigger names via `ILIKE`. `%` matches any sequence; `_` matches a single character.
+- `detailed` — When `true`, returns full metadata objects keyed by trigger name instead of bare name strings. Default `false`.
+</parameters>
+
+<examples>
+✓ "What triggers are in the mydb database?" → listTriggers(database="mydb")
+✓ "Find the audit triggers" → listTriggers(search="audit")
+✓ "What does orders_audit_after_iu do?" → listTriggers(search="orders_audit_after_iu", detailed=true)
+✗ "Show me a trigger's body" → use detailed mode; the `definition` field carries the full `CREATE TRIGGER` text
+</examples>
+
+<what_it_returns>
+Brief mode (default): a sorted JSON array of trigger-name strings, e.g. `["customers_audit_after_insert", "orders_audit_after_insert"]`.
+Detailed mode: a JSON object keyed by trigger name; each value carries `schema`, `table`, `status` (ENABLED/DISABLED/REPLICA/ALWAYS), `timing` (BEFORE/AFTER/INSTEAD OF), `events` (array of strings drawn from INSERT/UPDATE/DELETE/TRUNCATE in that fixed order), `activationLevel` (ROW/STATEMENT), `functionName`, and `definition` (the full `CREATE TRIGGER` text). Internal triggers (FK enforcement etc.) are excluded.
+</what_it_returns>
+
+<pagination>
+Paginated. Pass the prior response's `nextCursor` as `cursor` to fetch the next page. The `search` filter must stay the same across pages for cursor continuity.
+</pagination>

--- a/crates/postgres/assets/tools/list_views.md
+++ b/crates/postgres/assets/tools/list_views.md
@@ -1,0 +1,34 @@
+List user-defined views in the `public` schema, optionally filtered and/or with full metadata. Materialized views and system-schema views are excluded.
+
+<usecase>
+Use when:
+- Auditing views across a database (brief mode, default).
+- Searching for a view by partial name (pass `search`).
+- Inspecting a view's owner, comment, and full SELECT body before querying it (pass `detailed: true`). Detailed mode supersedes ad-hoc `readQuery` against `pg_views` / `pg_class`.
+</usecase>
+
+<parameters>
+- `database` — Database to target. Defaults to the active database.
+- `cursor` — Opaque pagination cursor; echo the prior response's `nextCursor`.
+- `search` — Case-insensitive filter on view names via `ILIKE`. `%` matches any sequence; `_` matches a single character.
+- `detailed` — When `true`, returns full metadata objects keyed by bare view name instead of bare name strings. Default `false`.
+</parameters>
+
+<examples>
+✓ "What views are in mydb?" → listViews(database="mydb")
+✓ "Find the active-users view" → listViews(search="active")
+✓ "What does active_users select?" → listViews(search="active_users", detailed=true)
+✗ "Show me the columns of a view" → use listTables with `detailed: true` instead
+✗ "List materialized views" → use listMaterializedViews
+</examples>
+
+<what_it_returns>
+Brief mode (default): a sorted JSON array of view-name strings, e.g. `["active_orders", "active_users"]`. View names are unique per schema, so no duplicates appear.
+Detailed mode: a JSON object keyed by bare view name; each value carries `schema`, `owner`, `description` (or null when no `COMMENT ON VIEW`), and `definition` (the SELECT body verbatim from `pg_views.definition`, with no `CREATE VIEW` wrapper). The view name is the map key only — it is not repeated inside the value.
+
+Detailed mode deliberately omits column metadata (`columns`), the `name` field (already the key), and view-level options (`security_barrier`, `security_invoker`, `WITH CHECK OPTION`). Column shape is recoverable from the `definition` text or via `listTables(detailed=true)` since Postgres exposes views in `pg_class`.
+</what_it_returns>
+
+<pagination>
+Paginated. Pass the prior response's `nextCursor` as `cursor` to fetch the next page. The `search` filter must stay the same across pages for cursor continuity. Brief and detailed modes share the same `viewname` row order, so a client can switch `detailed` between pages without losing position.
+</pagination>

--- a/crates/postgres/assets/tools/read_query.md
+++ b/crates/postgres/assets/tools/read_query.md
@@ -1,0 +1,30 @@
+Execute a read-only SQL query. Allowed statements: SELECT, SHOW, EXPLAIN.
+
+<usecase>
+Use when:
+- Querying data from tables (SELECT with WHERE, JOIN, GROUP BY, etc.)
+- Aggregations: COUNT, SUM, AVG, GROUP BY, HAVING
+- Listing server configuration parameters (SHOW)
+</usecase>
+
+<when_not_to_use>
+- Data changes (INSERT, UPDATE, DELETE) → use writeQuery
+- Query performance analysis → use explainQuery
+- Discovering tables or columns → use listTables (pass `detailed: true` to get columns, keys, and indexes)
+</when_not_to_use>
+
+<examples>
+✓ "SELECT * FROM users WHERE status = 'active'"
+✓ "SELECT COUNT(*) FROM orders GROUP BY region"
+✓ "SHOW server_version"
+✗ "INSERT INTO users ..." → use writeQuery
+✗ "EXPLAIN SELECT ..." → use explainQuery for structured analysis
+</examples>
+
+<what_it_returns>
+A JSON array of row objects, each keyed by column name.
+</what_it_returns>
+
+<pagination>
+`SELECT` results are paginated. Pass the prior response's `nextCursor` as `cursor` to fetch the next page. `SHOW` and `EXPLAIN` return a single page and ignore `cursor`.
+</pagination>

--- a/crates/postgres/assets/tools/write_query.md
+++ b/crates/postgres/assets/tools/write_query.md
@@ -1,0 +1,25 @@
+Execute a write SQL query (INSERT, UPDATE, DELETE, CREATE, ALTER, DROP).
+
+<usecase>
+Use when:
+- Inserting, updating, or deleting rows
+- Creating or altering tables, indexes, views, or other schema objects
+- Any data modification operation
+</usecase>
+
+<when_not_to_use>
+- Read-only queries (SELECT, SHOW) → use readQuery
+- Query performance analysis → use explainQuery
+- Creating/dropping entire databases → use createDatabase or dropDatabase
+</when_not_to_use>
+
+<examples>
+✓ "INSERT INTO users (name, email) VALUES ('Alice', 'alice@example.com')"
+✓ "UPDATE orders SET status = 'shipped' WHERE id = 42"
+✓ "CREATE TABLE logs (id SERIAL PRIMARY KEY, message TEXT)"
+✗ "SELECT * FROM users" → use readQuery
+</examples>
+
+<what_it_returns>
+A JSON array of affected/returning row objects, each keyed by column name.
+</what_it_returns>

--- a/crates/postgres/src/handler.rs
+++ b/crates/postgres/src/handler.rs
@@ -26,8 +26,11 @@ use crate::tools::{
 /// Backend-specific description for `PostgreSQL`.
 const DESCRIPTION: &str = "Database MCP Server for PostgreSQL";
 
-/// Backend-specific instructions for `PostgreSQL`.
+/// Backend-specific instructions for `PostgreSQL` in read-write mode.
 const INSTRUCTIONS: &str = include_str!("../assets/instructions.md");
+
+/// Backend-specific instructions for `PostgreSQL` in read-only mode.
+const INSTRUCTIONS_READ_ONLY: &str = include_str!("../assets/instructions.readonly.md");
 
 /// `PostgreSQL` database handler.
 ///
@@ -103,7 +106,11 @@ impl ServerHandler for PostgresHandler {
     fn get_info(&self) -> ServerInfo {
         let mut info = server_info();
         info.server_info.description = Some(DESCRIPTION.into());
-        info.instructions = Some(INSTRUCTIONS.into());
+        info.instructions = Some(if self.config.read_only {
+            INSTRUCTIONS_READ_ONLY.into()
+        } else {
+            INSTRUCTIONS.into()
+        });
         info
     }
 
@@ -209,6 +216,23 @@ mod tests {
         assert!(!router.has_route("createDatabase"));
         assert!(!router.has_route("dropDatabase"));
         assert!(!router.has_route("dropTable"));
+    }
+
+    #[tokio::test]
+    async fn instructions_match_read_only_mode() {
+        let read_write = handler(false).get_info().instructions.expect("instructions present");
+        assert!(
+            read_write.contains("writeQuery"),
+            "read-write instructions mention writeQuery"
+        );
+
+        let read_only = handler(true).get_info().instructions.expect("instructions present");
+        for tool in ["writeQuery", "createDatabase", "dropDatabase", "dropTable"] {
+            assert!(
+                !read_only.contains(tool),
+                "read-only instructions must not mention {tool}"
+            );
+        }
     }
 
     #[tokio::test]

--- a/crates/postgres/src/handler.rs
+++ b/crates/postgres/src/handler.rs
@@ -27,28 +27,7 @@ use crate::tools::{
 const DESCRIPTION: &str = "Database MCP Server for PostgreSQL";
 
 /// Backend-specific instructions for `PostgreSQL`.
-const INSTRUCTIONS: &str = r"## Workflow
-
-1. Call `listDatabases` to discover available databases.
-2. Call `listTables` to see tables. Pass `search` to filter by name (case-insensitive substring). Pass `detailed: true` to get columns, constraints, indexes, and triggers in the same call — this supersedes the legacy `getTableSchema` workflow.
-3. Call `listViews` to see views in the `public` schema.
-4. Call `listTriggers` to see user-defined triggers in the `public` schema.
-5. Call `listFunctions` to see user-defined functions in the `public` schema.
-6. Call `listProcedures` to see user-defined procedures in the `public` schema.
-7. Call `listMaterializedViews` to see materialized views in the `public` schema.
-8. Use `readQuery` for read-only SQL (SELECT, SHOW, EXPLAIN).
-9. Use `writeQuery` for data changes (INSERT, UPDATE, DELETE, CREATE, ALTER, DROP).
-10. Use `explainQuery` to analyze query execution plans and diagnose slow queries.
-11. Use `createDatabase` to create a new database.
-12. Use `dropDatabase` to drop an existing database.
-13. Use `dropTable` to remove a table from a database (supports `cascade` for foreign key dependencies).
-
-Per-database tools default to the active database; pass `database` to target another.
-
-## Constraints
-
-- The `writeQuery`, `createDatabase`, `dropDatabase`, and `dropTable` tools are hidden when read-only mode is active.
-- Multi-statement queries are not supported. Send one statement per request.";
+const INSTRUCTIONS: &str = include_str!("../assets/instructions.md");
 
 /// `PostgreSQL` database handler.
 ///

--- a/crates/postgres/src/tools/create_database.rs
+++ b/crates/postgres/src/tools/create_database.rs
@@ -17,26 +17,7 @@ pub(crate) struct CreateDatabaseTool;
 impl CreateDatabaseTool {
     const NAME: &'static str = "createDatabase";
     const TITLE: &'static str = "Create Database";
-    const DESCRIPTION: &'static str = r#"Create a new database on the connected server.
-
-<usecase>
-Use when:
-- Setting up a new database for a project or application
-- The user asks to create a database
-</usecase>
-
-<examples>
-✓ "Create a database called analytics" → createDatabase(database="analytics")
-✗ "Create a table" → use writeQuery with CREATE TABLE
-</examples>
-
-<important>
-Database name must be non-empty; backend reserved-character rules apply.
-</important>
-
-<what_it_returns>
-A confirmation message with the created database name.
-</what_it_returns>"#;
+    const DESCRIPTION: &'static str = include_str!("../../assets/tools/create_database.md");
 }
 
 impl ToolBase for CreateDatabaseTool {

--- a/crates/postgres/src/tools/drop_database.rs
+++ b/crates/postgres/src/tools/drop_database.rs
@@ -17,27 +17,7 @@ pub(crate) struct DropDatabaseTool;
 impl DropDatabaseTool {
     const NAME: &'static str = "dropDatabase";
     const TITLE: &'static str = "Drop Database";
-    const DESCRIPTION: &'static str = r#"Drop an existing database from the connected server.
-
-<usecase>
-Use when:
-- Removing a database that is no longer needed
-- Cleaning up test or temporary databases
-</usecase>
-
-<examples>
-✓ "Drop the test_db database" → dropDatabase(database="test_db")
-✗ "Drop a table" → use dropTable instead
-</examples>
-
-<safety>
-IMPORTANT: This permanently deletes the database and ALL its data. This action cannot be undone.
-Cannot drop the database you are currently connected to.
-</safety>
-
-<what_it_returns>
-A confirmation message with the dropped database name.
-</what_it_returns>"#;
+    const DESCRIPTION: &'static str = include_str!("../../assets/tools/drop_database.md");
 }
 
 impl ToolBase for DropDatabaseTool {

--- a/crates/postgres/src/tools/drop_table.rs
+++ b/crates/postgres/src/tools/drop_table.rs
@@ -18,30 +18,7 @@ pub(crate) struct DropTableTool;
 impl DropTableTool {
     const NAME: &'static str = "dropTable";
     const TITLE: &'static str = "Drop Table";
-    const DESCRIPTION: &'static str = r#"Drop a table from a database. Checks for foreign key dependencies via the database engine.
-
-<usecase>
-Use when:
-- Removing a table that is no longer needed
-- Cleaning up test or temporary tables
-</usecase>
-
-<examples>
-✓ "Drop the temp_logs table" → dropTable(database="mydb", table="temp_logs")
-✓ "Force drop with dependencies" → dropTable(..., cascade=true)
-✗ "Delete rows from a table" → use writeQuery with DELETE
-✗ "Drop a database" → use dropDatabase instead
-</examples>
-
-<safety>
-IMPORTANT: This permanently deletes the table and ALL its data. This action cannot be undone.
-Set `cascade` to true to also drop dependent foreign key constraints.
-Without cascade, the drop will fail if other tables reference this one.
-</safety>
-
-<what_it_returns>
-A confirmation message with the dropped table name.
-</what_it_returns>"#;
+    const DESCRIPTION: &'static str = include_str!("../../assets/tools/drop_table.md");
 }
 
 impl ToolBase for DropTableTool {

--- a/crates/postgres/src/tools/explain_query.rs
+++ b/crates/postgres/src/tools/explain_query.rs
@@ -16,36 +16,7 @@ pub(crate) struct ExplainQueryTool;
 impl ExplainQueryTool {
     const NAME: &'static str = "explainQuery";
     const TITLE: &'static str = "Explain Query";
-    const DESCRIPTION: &'static str = r#"Return the execution plan for a SQL query to diagnose performance. Use this tool instead of running EXPLAIN directly through readQuery — it provides structured JSON output.
-
-<usecase>
-Use when:
-- A query runs slowly and you need to understand why
-- Investigating performance bottlenecks
-- Planning index creation to optimize queries
-- Analyzing join methods, table scan strategies, and sort operations
-</usecase>
-
-<when_not_to_use>
-- Running actual queries → use readQuery or writeQuery
-- Checking table structure → use listTables(detailed=true)
-</when_not_to_use>
-
-<examples>
-✓ "Why is my SELECT on orders slow?" → explainQuery(query="SELECT ...")
-✓ "Should I add an index?" → explainQuery with analyze=true
-✗ "Run this SELECT" → use readQuery
-</examples>
-
-<safety>
-Set `analyze` to true for actual execution statistics (EXPLAIN ANALYZE).
-IMPORTANT: EXPLAIN ANALYZE actually executes the query! In read-only mode, only read-only statements are allowed with analyze.
-When analyze is false, returns EXPLAIN (FORMAT JSON) output without executing.
-</safety>
-
-<what_it_returns>
-A JSON array of execution plan rows showing access methods, join types, row estimates, and costs.
-</what_it_returns>"#;
+    const DESCRIPTION: &'static str = include_str!("../../assets/tools/explain_query.md");
 }
 
 impl ToolBase for ExplainQueryTool {

--- a/crates/postgres/src/tools/list_databases.rs
+++ b/crates/postgres/src/tools/list_databases.rs
@@ -16,27 +16,7 @@ pub(crate) struct ListDatabasesTool;
 impl ListDatabasesTool {
     const NAME: &'static str = "listDatabases";
     const TITLE: &'static str = "List Databases";
-    const DESCRIPTION: &'static str = r#"List all accessible databases on the connected server. Use this tool to discover what databases are available before using other tools.
-
-<usecase>
-ALWAYS call this tool FIRST when:
-- You need to explore what databases exist on the server
-- You need a database name for listTables or query tools
-- The user asks what data is available
-</usecase>
-
-<examples>
-✓ "What databases are on this server?"
-✓ "Show me what's available" → call listDatabases first
-</examples>
-
-<what_it_returns>
-A sorted JSON array of database name strings.
-</what_it_returns>
-
-<pagination>
-Paginated. Pass the prior response's `nextCursor` as `cursor` to fetch the next page.
-</pagination>"#;
+    const DESCRIPTION: &'static str = include_str!("../../assets/tools/list_databases.md");
 }
 
 impl ToolBase for ListDatabasesTool {

--- a/crates/postgres/src/tools/list_functions.rs
+++ b/crates/postgres/src/tools/list_functions.rs
@@ -16,38 +16,7 @@ pub(crate) struct ListFunctionsTool;
 impl ListFunctionsTool {
     const NAME: &'static str = "listFunctions";
     const TITLE: &'static str = "List Functions";
-    const DESCRIPTION: &'static str = r#"List user-defined functions in the `public` schema, optionally filtered and/or with full metadata. Aggregates, window functions, and procedures are excluded.
-
-<usecase>
-Use when:
-- Auditing functions across a database (brief mode, default).
-- Searching for a function by partial name (pass `search`).
-- Inspecting a function's language, signature, return type, volatility, strictness, security mode, parallel-safety, owner, comment, and full `CREATE FUNCTION` text before reasoning about correctness or invocation safety (pass `detailed: true`). Detailed mode supersedes ad-hoc `readQuery` against `pg_proc` / `information_schema.routines`.
-</usecase>
-
-<parameters>
-- `database` — Database to target. Defaults to the active database.
-- `cursor` — Opaque pagination cursor; echo the prior response's `nextCursor`.
-- `search` — Case-insensitive filter on function names via `ILIKE`. `%` matches any sequence; `_` matches a single character.
-- `detailed` — When `true`, returns full metadata objects keyed by `name(arguments)` instead of bare name strings. Default `false`.
-</parameters>
-
-<examples>
-✓ "What functions are in mydb?" → listFunctions(database="mydb")
-✓ "Find the order-total calculation" → listFunctions(search="order")
-✓ "What does calc_order_total do?" → listFunctions(search="calc_order_total", detailed=true)
-✗ "List stored procedures" → use listProcedures instead
-✗ "List aggregates" → not supported; aggregates are excluded
-</examples>
-
-<what_it_returns>
-Brief mode (default): a sorted JSON array of function-name strings, e.g. `["audit_user_login", "calc_order_subtotal", "calc_order_total", "calc_order_total"]`. Overloaded functions appear as one entry per overload (duplicate name strings allowed).
-Detailed mode: a JSON object keyed by function signature `name(arguments)`; each value carries `schema`, `name`, `language`, `arguments`, `returnType`, `volatility` (IMMUTABLE/STABLE/VOLATILE), `strict` (boolean), `security` (INVOKER/DEFINER), `parallelSafety` (SAFE/RESTRICTED/UNSAFE), `owner`, `description` (or null when no `COMMENT ON FUNCTION`), and `definition` (the full `CREATE OR REPLACE FUNCTION` text). Overloads occupy distinct keys (e.g. `calc_total(integer)` vs `calc_total(integer, numeric)`).
-</what_it_returns>
-
-<pagination>
-Paginated. Pass the prior response's `nextCursor` as `cursor` to fetch the next page. The `search` filter must stay the same across pages for cursor continuity. Brief and detailed modes share the same `(proname, oid)` row order, so a client can switch `detailed` between pages without losing position.
-</pagination>"#;
+    const DESCRIPTION: &'static str = include_str!("../../assets/tools/list_functions.md");
 }
 
 impl ToolBase for ListFunctionsTool {

--- a/crates/postgres/src/tools/list_materialized_views.rs
+++ b/crates/postgres/src/tools/list_materialized_views.rs
@@ -16,47 +16,7 @@ pub(crate) struct ListMaterializedViewsTool;
 impl ListMaterializedViewsTool {
     const NAME: &'static str = "listMaterializedViews";
     const TITLE: &'static str = "List Materialized Views";
-    const DESCRIPTION: &'static str = r#"List materialized views in the `public` schema, optionally filtered and/or with full metadata. Unlike regular views, materialized views store their results physically and must be refreshed explicitly. Regular views and system-schema matviews are excluded.
-
-<usecase>
-Use when:
-- Auditing materialized views across a database (brief mode, default).
-- Searching for a matview by partial name (pass `search`).
-- Inspecting a matview's owner, comment, full SELECT body, populated state, and index presence before querying or refreshing it (pass `detailed: true`). Detailed mode supersedes ad-hoc `readQuery` against `pg_matviews` / `pg_class`.
-</usecase>
-
-<parameters>
-- `database` — Database to target. Defaults to the active database.
-- `cursor` — Opaque pagination cursor; echo the prior response's `nextCursor`.
-- `search` — Case-insensitive filter on matview names via `ILIKE`. `%` matches any sequence; `_` matches a single character.
-- `detailed` — When `true`, returns full metadata objects keyed by bare matview name instead of bare name strings. Default `false`.
-</parameters>
-
-<examples>
-✓ "What materialized views are in mydb?" → listMaterializedViews(database="mydb")
-✓ "Find the recent-orders matview" → listMaterializedViews(search="orders")
-✓ "What does mv_orders_by_region compute?" → listMaterializedViews(search="mv_orders_by_region", detailed=true)
-✓ "Has the cache matview ever been refreshed?" → listMaterializedViews(search="cache", detailed=true) — read `populated`
-✓ "Which matviews can I refresh concurrently?" → listMaterializedViews(detailed=true) — read `indexed` (CONCURRENTLY additionally needs a unique index)
-✗ "List regular views" → use listViews instead
-</examples>
-
-<what_it_returns>
-Brief mode (default): a sorted JSON array of matview-name strings, e.g. `["mv_archived_orders", "mv_recent_orders"]`. Matview names are unique per schema, so no duplicates appear.
-Detailed mode: a JSON object keyed by bare matview name; each value carries:
-- `schema` — schema name (always `"public"` in this build).
-- `owner` — owning role's name from `pg_matviews.matviewowner`.
-- `description` — `COMMENT ON MATERIALIZED VIEW` text, or `null` when no comment.
-- `definition` — the SELECT body verbatim from `pg_matviews.definition`, with no `CREATE MATERIALIZED VIEW` wrapper.
-- `populated` — `true` once the matview has been refreshed at least once. `false` for matviews created `WITH NO DATA` and never refreshed; querying such a matview returns zero rows until `REFRESH MATERIALIZED VIEW` runs.
-- `indexed` — `true` when at least one index exists on the matview. `REFRESH MATERIALIZED VIEW CONCURRENTLY` additionally requires a unique index; this tool reports the broader has-any-index signal.
-
-The matview name is the map key only — it is not repeated inside the value. Detailed mode deliberately omits column metadata (`columns`), `tablespace`, storage parameters, and unique-index detection. Column shape is recoverable from the `definition` text or via `listTables(detailed=true)` since Postgres exposes matviews in `pg_class`.
-</what_it_returns>
-
-<pagination>
-Paginated. Pass the prior response's `nextCursor` as `cursor` to fetch the next page. The `search` filter must stay the same across pages for cursor continuity. Brief and detailed modes share the same `matviewname` row order, so a client can switch `detailed` between pages without losing position.
-</pagination>"#;
+    const DESCRIPTION: &'static str = include_str!("../../assets/tools/list_materialized_views.md");
 }
 
 impl ToolBase for ListMaterializedViewsTool {

--- a/crates/postgres/src/tools/list_procedures.rs
+++ b/crates/postgres/src/tools/list_procedures.rs
@@ -16,40 +16,7 @@ pub(crate) struct ListProceduresTool;
 impl ListProceduresTool {
     const NAME: &'static str = "listProcedures";
     const TITLE: &'static str = "List Procedures";
-    const DESCRIPTION: &'static str = r#"List user-defined procedures in the `public` schema, optionally filtered and/or with full metadata. Functions, aggregates, and window functions are excluded.
-
-<usecase>
-Use when:
-- Auditing procedures across a database (brief mode, default).
-- Searching for a procedure by partial name (pass `search`).
-- Inspecting a procedure's language, signature, security mode, owner, comment, and full `CREATE PROCEDURE` text before reasoning about correctness or invocation safety (pass `detailed: true`). Detailed mode supersedes ad-hoc `readQuery` against `pg_proc` / `information_schema.routines`.
-</usecase>
-
-<parameters>
-- `database` — Database to target. Defaults to the active database.
-- `cursor` — Opaque pagination cursor; echo the prior response's `nextCursor`.
-- `search` — Case-insensitive filter on procedure names via `ILIKE`. `%` matches any sequence; `_` matches a single character.
-- `detailed` — When `true`, returns full metadata objects keyed by `name(arguments)` instead of bare name strings. Default `false`.
-</parameters>
-
-<examples>
-✓ "What procedures are in mydb?" → listProcedures(database="mydb")
-✓ "Find the order archival routine" → listProcedures(search="archive")
-✓ "What does archive_order do?" → listProcedures(search="archive_order", detailed=true)
-✗ "List functions" → use listFunctions instead
-✗ "List aggregates" → not supported; aggregates are excluded
-</examples>
-
-<what_it_returns>
-Brief mode (default): a sorted JSON array of procedure-name strings, e.g. `["archive_order", "archive_order_history", "archive_order_history"]`. Overloaded procedures appear as one entry per overload (duplicate name strings allowed).
-Detailed mode: a JSON object keyed by procedure signature `name(arguments)`; each value carries `schema`, `name`, `language`, `arguments`, `security` (INVOKER/DEFINER), `owner`, `description` (or null when no `COMMENT ON PROCEDURE`), and `definition` (the full `CREATE OR REPLACE PROCEDURE` text). Overloads occupy distinct keys (e.g. `archive_order_history(integer)` vs `archive_order_history(integer, boolean)`). Zero-arg procedures key as `name()` — the parens are always present so the key shape stays uniform.
-
-Detailed mode deliberately omits the `listFunctions`-only fields `returnType`, `volatility`, `strict`, and `parallelSafety`: procedures don't return a value, `pg_proc.provolatile` / `proisstrict` are not user-settable for procedures, and `proparallel` carries no procedure-level guarantee in PostgreSQL.
-</what_it_returns>
-
-<pagination>
-Paginated. Pass the prior response's `nextCursor` as `cursor` to fetch the next page. The `search` filter must stay the same across pages for cursor continuity. Brief and detailed modes share the same `(proname, oid)` row order, so a client can switch `detailed` between pages without losing position.
-</pagination>"#;
+    const DESCRIPTION: &'static str = include_str!("../../assets/tools/list_procedures.md");
 }
 
 impl ToolBase for ListProceduresTool {

--- a/crates/postgres/src/tools/list_tables.rs
+++ b/crates/postgres/src/tools/list_tables.rs
@@ -17,36 +17,7 @@ pub(crate) struct ListTablesTool;
 impl ListTablesTool {
     const NAME: &'static str = "listTables";
     const TITLE: &'static str = "List Tables";
-    const DESCRIPTION: &'static str = r#"List tables in a database, optionally filtered and/or with full metadata.
-
-<usecase>
-Use when:
-- Exploring a database to find relevant tables (brief mode, default).
-- Searching for a table by partial name (pass `search`).
-- Inspecting a table's columns, constraints, indexes, and triggers before writing a query (pass `detailed: true`). This supersedes the legacy `getTableSchema` tool.
-</usecase>
-
-<parameters>
-- `database` — Database to target. Defaults to the active database.
-- `cursor` — Opaque pagination cursor; echo the prior response's `nextCursor`.
-- `search` — Case-insensitive filter on table names via `ILIKE`. `%` matches any sequence; `_` matches a single character.
-- `detailed` — When `true`, returns full metadata objects keyed by table name instead of bare name strings. Default `false`.
-</parameters>
-
-<examples>
-✓ "What tables are in mydb?" → listTables(database="mydb")
-✓ "Find the orders table" → listTables(search="order")
-✓ "What columns does orders have?" → listTables(search="orders", detailed=true)
-</examples>
-
-<what_it_returns>
-Brief mode (default): a sorted JSON array of table-name strings, e.g. `["customers", "orders"]`.
-Detailed mode: a JSON object keyed by table name; each value carries `schema`, `kind`, `owner`, `comment`, `columns`, `constraints`, `indexes`, and `triggers` (the name is the key and is not repeated inside the value). Keys iterate in the same alphabetical order brief mode uses. Example: `{"orders": {"schema": "public", "kind": "TABLE", …}}`.
-</what_it_returns>
-
-<pagination>
-Paginated. Pass the prior response's `nextCursor` as `cursor` to fetch the next page. The `search` filter must stay the same across pages for cursor continuity.
-</pagination>"#;
+    const DESCRIPTION: &'static str = include_str!("../../assets/tools/list_tables.md");
 }
 
 impl ToolBase for ListTablesTool {

--- a/crates/postgres/src/tools/list_triggers.rs
+++ b/crates/postgres/src/tools/list_triggers.rs
@@ -16,37 +16,7 @@ pub(crate) struct ListTriggersTool;
 impl ListTriggersTool {
     const NAME: &'static str = "listTriggers";
     const TITLE: &'static str = "List Triggers";
-    const DESCRIPTION: &'static str = r#"List user-defined triggers in the `public` schema, optionally filtered and/or with full metadata.
-
-<usecase>
-Use when:
-- Auditing triggers across a database (brief mode, default).
-- Searching for a trigger by partial name (pass `search`).
-- Inspecting a trigger's timing, events, activation level, handler function, status, and full `CREATE TRIGGER` text before reasoning about side-effects (pass `detailed: true`). Detailed mode supersedes ad-hoc `readQuery` against `pg_trigger` / `information_schema.triggers`.
-</usecase>
-
-<parameters>
-- `database` — Database to target. Defaults to the active database.
-- `cursor` — Opaque pagination cursor; echo the prior response's `nextCursor`.
-- `search` — Case-insensitive filter on trigger names via `ILIKE`. `%` matches any sequence; `_` matches a single character.
-- `detailed` — When `true`, returns full metadata objects keyed by trigger name instead of bare name strings. Default `false`.
-</parameters>
-
-<examples>
-✓ "What triggers are in the mydb database?" → listTriggers(database="mydb")
-✓ "Find the audit triggers" → listTriggers(search="audit")
-✓ "What does orders_audit_after_iu do?" → listTriggers(search="orders_audit_after_iu", detailed=true)
-✗ "Show me a trigger's body" → use detailed mode; the `definition` field carries the full `CREATE TRIGGER` text
-</examples>
-
-<what_it_returns>
-Brief mode (default): a sorted JSON array of trigger-name strings, e.g. `["customers_audit_after_insert", "orders_audit_after_insert"]`.
-Detailed mode: a JSON object keyed by trigger name; each value carries `schema`, `table`, `status` (ENABLED/DISABLED/REPLICA/ALWAYS), `timing` (BEFORE/AFTER/INSTEAD OF), `events` (array of strings drawn from INSERT/UPDATE/DELETE/TRUNCATE in that fixed order), `activationLevel` (ROW/STATEMENT), `functionName`, and `definition` (the full `CREATE TRIGGER` text). Internal triggers (FK enforcement etc.) are excluded.
-</what_it_returns>
-
-<pagination>
-Paginated. Pass the prior response's `nextCursor` as `cursor` to fetch the next page. The `search` filter must stay the same across pages for cursor continuity.
-</pagination>"#;
+    const DESCRIPTION: &'static str = include_str!("../../assets/tools/list_triggers.md");
 }
 
 impl ToolBase for ListTriggersTool {

--- a/crates/postgres/src/tools/list_views.rs
+++ b/crates/postgres/src/tools/list_views.rs
@@ -16,40 +16,7 @@ pub(crate) struct ListViewsTool;
 impl ListViewsTool {
     const NAME: &'static str = "listViews";
     const TITLE: &'static str = "List Views";
-    const DESCRIPTION: &'static str = r#"List user-defined views in the `public` schema, optionally filtered and/or with full metadata. Materialized views and system-schema views are excluded.
-
-<usecase>
-Use when:
-- Auditing views across a database (brief mode, default).
-- Searching for a view by partial name (pass `search`).
-- Inspecting a view's owner, comment, and full SELECT body before querying it (pass `detailed: true`). Detailed mode supersedes ad-hoc `readQuery` against `pg_views` / `pg_class`.
-</usecase>
-
-<parameters>
-- `database` — Database to target. Defaults to the active database.
-- `cursor` — Opaque pagination cursor; echo the prior response's `nextCursor`.
-- `search` — Case-insensitive filter on view names via `ILIKE`. `%` matches any sequence; `_` matches a single character.
-- `detailed` — When `true`, returns full metadata objects keyed by bare view name instead of bare name strings. Default `false`.
-</parameters>
-
-<examples>
-✓ "What views are in mydb?" → listViews(database="mydb")
-✓ "Find the active-users view" → listViews(search="active")
-✓ "What does active_users select?" → listViews(search="active_users", detailed=true)
-✗ "Show me the columns of a view" → use listTables with `detailed: true` instead
-✗ "List materialized views" → use listMaterializedViews
-</examples>
-
-<what_it_returns>
-Brief mode (default): a sorted JSON array of view-name strings, e.g. `["active_orders", "active_users"]`. View names are unique per schema, so no duplicates appear.
-Detailed mode: a JSON object keyed by bare view name; each value carries `schema`, `owner`, `description` (or null when no `COMMENT ON VIEW`), and `definition` (the SELECT body verbatim from `pg_views.definition`, with no `CREATE VIEW` wrapper). The view name is the map key only — it is not repeated inside the value.
-
-Detailed mode deliberately omits column metadata (`columns`), the `name` field (already the key), and view-level options (`security_barrier`, `security_invoker`, `WITH CHECK OPTION`). Column shape is recoverable from the `definition` text or via `listTables(detailed=true)` since Postgres exposes views in `pg_class`.
-</what_it_returns>
-
-<pagination>
-Paginated. Pass the prior response's `nextCursor` as `cursor` to fetch the next page. The `search` filter must stay the same across pages for cursor continuity. Brief and detailed modes share the same `viewname` row order, so a client can switch `detailed` between pages without losing position.
-</pagination>"#;
+    const DESCRIPTION: &'static str = include_str!("../../assets/tools/list_views.md");
 }
 
 impl ToolBase for ListViewsTool {

--- a/crates/postgres/src/tools/read_query.rs
+++ b/crates/postgres/src/tools/read_query.rs
@@ -19,36 +19,7 @@ pub(crate) struct ReadQueryTool;
 impl ReadQueryTool {
     const NAME: &'static str = "readQuery";
     const TITLE: &'static str = "Read Query";
-    const DESCRIPTION: &'static str = r#"Execute a read-only SQL query. Allowed statements: SELECT, SHOW, EXPLAIN.
-
-<usecase>
-Use when:
-- Querying data from tables (SELECT with WHERE, JOIN, GROUP BY, etc.)
-- Aggregations: COUNT, SUM, AVG, GROUP BY, HAVING
-- Listing server configuration parameters (SHOW)
-</usecase>
-
-<when_not_to_use>
-- Data changes (INSERT, UPDATE, DELETE) → use writeQuery
-- Query performance analysis → use explainQuery
-- Discovering tables or columns → use listTables (pass `detailed: true` to get columns, keys, and indexes)
-</when_not_to_use>
-
-<examples>
-✓ "SELECT * FROM users WHERE status = 'active'"
-✓ "SELECT COUNT(*) FROM orders GROUP BY region"
-✓ "SHOW server_version"
-✗ "INSERT INTO users ..." → use writeQuery
-✗ "EXPLAIN SELECT ..." → use explainQuery for structured analysis
-</examples>
-
-<what_it_returns>
-A JSON array of row objects, each keyed by column name.
-</what_it_returns>
-
-<pagination>
-`SELECT` results are paginated. Pass the prior response's `nextCursor` as `cursor` to fetch the next page. `SHOW` and `EXPLAIN` return a single page and ignore `cursor`.
-</pagination>"#;
+    const DESCRIPTION: &'static str = include_str!("../../assets/tools/read_query.md");
 }
 
 impl ToolBase for ReadQueryTool {

--- a/crates/postgres/src/tools/write_query.rs
+++ b/crates/postgres/src/tools/write_query.rs
@@ -15,31 +15,7 @@ pub(crate) struct WriteQueryTool;
 impl WriteQueryTool {
     const NAME: &'static str = "writeQuery";
     const TITLE: &'static str = "Write Query";
-    const DESCRIPTION: &'static str = r#"Execute a write SQL query (INSERT, UPDATE, DELETE, CREATE, ALTER, DROP).
-
-<usecase>
-Use when:
-- Inserting, updating, or deleting rows
-- Creating or altering tables, indexes, views, or other schema objects
-- Any data modification operation
-</usecase>
-
-<when_not_to_use>
-- Read-only queries (SELECT, SHOW) → use readQuery
-- Query performance analysis → use explainQuery
-- Creating/dropping entire databases → use createDatabase or dropDatabase
-</when_not_to_use>
-
-<examples>
-✓ "INSERT INTO users (name, email) VALUES ('Alice', 'alice@example.com')"
-✓ "UPDATE orders SET status = 'shipped' WHERE id = 42"
-✓ "CREATE TABLE logs (id SERIAL PRIMARY KEY, message TEXT)"
-✗ "SELECT * FROM users" → use readQuery
-</examples>
-
-<what_it_returns>
-A JSON array of affected/returning row objects, each keyed by column name.
-</what_it_returns>"#;
+    const DESCRIPTION: &'static str = include_str!("../../assets/tools/write_query.md");
 }
 
 impl ToolBase for WriteQueryTool {

--- a/crates/sqlite/assets/instructions.md
+++ b/crates/sqlite/assets/instructions.md
@@ -1,0 +1,14 @@
+## Workflow
+
+1. Call `listTables` to discover tables in the connected database. Pass `search` to filter by name (case-insensitive substring). Pass `detailed: true` to get columns, constraints, indexes, and triggers in the same call — this supersedes the legacy `getTableSchema` workflow.
+2. Call `listViews` to discover views in the connected database.
+3. Call `listTriggers` to discover triggers in the connected database.
+4. Use `readQuery` for read-only SQL (SELECT).
+5. Use `writeQuery` for data changes (INSERT, UPDATE, DELETE, CREATE, ALTER, DROP).
+6. Use `explainQuery` to analyze query execution plans and diagnose slow queries.
+7. Use `dropTable` to remove a table from the database.
+
+## Constraints
+
+- The `writeQuery` and `dropTable` tools are hidden when read-only mode is active.
+- Multi-statement queries are not supported. Send one statement per request.

--- a/crates/sqlite/assets/instructions.readonly.md
+++ b/crates/sqlite/assets/instructions.readonly.md
@@ -1,0 +1,12 @@
+## Workflow
+
+1. Call `listTables` to discover tables in the connected database. Pass `search` to filter by name (case-insensitive substring). Pass `detailed: true` to get columns, constraints, indexes, and triggers in the same call — this supersedes the legacy `getTableSchema` workflow.
+2. Call `listViews` to discover views in the connected database.
+3. Call `listTriggers` to discover triggers in the connected database.
+4. Use `readQuery` for read-only SQL (SELECT).
+5. Use `explainQuery` to analyze query execution plans and diagnose slow queries.
+
+## Constraints
+
+- The server runs in read-only mode. Data and schema changes are not possible.
+- Multi-statement queries are not supported. Send one statement per request.

--- a/crates/sqlite/assets/tools/drop_table.md
+++ b/crates/sqlite/assets/tools/drop_table.md
@@ -1,0 +1,20 @@
+Drop a table from the database.
+
+<usecase>
+Use when:
+- Removing a table that is no longer needed
+- Cleaning up test or temporary tables
+</usecase>
+
+<examples>
+✓ "Drop the temp_logs table" → dropTable(table="temp_logs")
+✗ "Delete rows from a table" → use writeQuery with DELETE
+</examples>
+
+<safety>
+IMPORTANT: This permanently deletes the table and ALL its data. This action cannot be undone.
+</safety>
+
+<what_it_returns>
+A confirmation message with the dropped table name.
+</what_it_returns>

--- a/crates/sqlite/assets/tools/explain_query.md
+++ b/crates/sqlite/assets/tools/explain_query.md
@@ -1,0 +1,23 @@
+Return the execution plan for a SQL query to diagnose performance. Use this tool instead of running EXPLAIN directly through readQuery — it provides structured output via EXPLAIN QUERY PLAN.
+
+<usecase>
+Use when:
+- A query runs slowly and you need to understand why
+- Understanding how SQLite will scan tables and use indexes
+- Deciding whether to add an index
+</usecase>
+
+<when_not_to_use>
+- Running actual queries → use readQuery or writeQuery
+- Checking table structure → use listTables with `detailed: true`
+</when_not_to_use>
+
+<examples>
+✓ "Why is my SELECT on orders slow?" → explainQuery(query="SELECT ...")
+✓ "How will SQLite execute this join?" → explainQuery
+✗ "Run this SELECT" → use readQuery
+</examples>
+
+<what_it_returns>
+A JSON array of EXPLAIN QUERY PLAN rows showing how SQLite will scan tables, use indexes, and order operations.
+</what_it_returns>

--- a/crates/sqlite/assets/tools/list_tables.md
+++ b/crates/sqlite/assets/tools/list_tables.md
@@ -1,0 +1,29 @@
+List tables in the connected database, optionally filtered and/or with full metadata.
+
+<usecase>
+Use when:
+- Exploring a database to find relevant tables (brief mode, default).
+- Searching for a table by partial name (pass `search`).
+- Inspecting a table's columns, constraints, indexes, and triggers before writing a query (pass `detailed: true`). This supersedes the legacy `getTableSchema` workflow.
+</usecase>
+
+<parameters>
+- `cursor` — Opaque pagination cursor; echo the prior response's `nextCursor`.
+- `search` — Case-insensitive filter on table names via `LIKE`. `%` matches any sequence; `_` matches a single character.
+- `detailed` — When `true`, returns full metadata objects keyed by table name instead of bare name strings. Default `false`.
+</parameters>
+
+<examples>
+✓ "What tables are in this database?" → listTables()
+✓ "Find the orders table" → listTables(search="order")
+✓ "What columns does orders have?" → listTables(search="orders", detailed=true)
+</examples>
+
+<what_it_returns>
+Brief mode (default): a sorted JSON array of table-name strings, e.g. `["customers", "orders"]`.
+Detailed mode: a JSON object keyed by table name; each value carries `schema`, `kind`, `owner`, `comment`, `columns`, `constraints`, `indexes`, and `triggers` (the name is the key and is not repeated inside the value). Keys iterate in the same alphabetical order brief mode uses. Example: `{"orders": {"schema": "main", "kind": "TABLE", ...}}`.
+</what_it_returns>
+
+<pagination>
+Paginated. Pass the prior response's `nextCursor` as `cursor` to fetch the next page. The `search` filter must stay the same across pages for cursor continuity.
+</pagination>

--- a/crates/sqlite/assets/tools/list_triggers.md
+++ b/crates/sqlite/assets/tools/list_triggers.md
@@ -1,0 +1,32 @@
+List triggers in the connected SQLite database, optionally filtered and/or with full metadata.
+
+<usecase>
+Use when:
+- Auditing trigger coverage across a database (brief mode, default).
+- Searching for a trigger by partial name (pass `search`).
+- Inspecting a trigger's table and full `CREATE TRIGGER` text before reasoning about side-effects (pass `detailed: true`). Detailed mode supersedes ad-hoc `readQuery` against `sqlite_schema`.
+</usecase>
+
+<parameters>
+- `cursor` — Opaque pagination cursor; echo the prior response's `nextCursor`.
+- `search` — Case-insensitive filter on trigger names via `LIKE` (SQLite's `LIKE` is ASCII-case-insensitive by default). `%` matches any sequence; `_` matches a single character.
+- `detailed` — When `true`, returns full metadata objects keyed by trigger name instead of bare name strings. Default `false`.
+</parameters>
+
+<examples>
+✓ "What triggers are in this database?" → listTriggers()
+✓ "Find the audit triggers" → listTriggers(search="audit")
+✓ "What does orders_audit_after_insert do?" → listTriggers(search="orders_audit_after_insert", detailed=true)
+✗ "Show me a trigger's body" → use detailed mode; the `definition` field carries the full `CREATE TRIGGER` text
+</examples>
+
+<what_it_returns>
+Brief mode (default): a sorted JSON array of trigger-name strings, e.g. `["customers_audit_after_insert", "orders_audit_after_insert"]`.
+Detailed mode: a JSON object keyed by trigger name; each value carries exactly three fields — `schema` (always `"main"`), `table` (`sqlite_schema.tbl_name` — may be a view name for `INSTEAD OF` triggers), and `definition` (the original `CREATE TRIGGER` text from `sqlite_schema.sql`, byte-for-byte). Internal `sqlite_*` triggers are excluded.
+The detailed payload deliberately diverges from the Postgres and MySQL/MariaDB `listTriggers` detailed payloads — `timing`, `events`, `activationLevel`, `status`, `functionName`, `sqlMode`, `characterSetClient`, `collationConnection`, `databaseCollation`, and `created` are absent. SQLite's catalogue does not expose those concepts as columns, and this tool deliberately avoids parsing the stored DDL to derive them; clients that need the timing or event keyword can read it off the prefix of `definition`.
+Triggers whose stored `sqlite_schema.sql` is `NULL` (rare; produced by extension-generated rows or hand-edited catalogues) are silently omitted from detailed mode but still listed by name in brief mode.
+</what_it_returns>
+
+<pagination>
+Paginated. Pass the prior response's `nextCursor` as `cursor` to fetch the next page. The `search` filter must stay the same across pages for cursor continuity.
+</pagination>

--- a/crates/sqlite/assets/tools/list_views.md
+++ b/crates/sqlite/assets/tools/list_views.md
@@ -1,0 +1,22 @@
+List all views in the connected SQLite database.
+
+<usecase>
+Use when:
+- Exploring what views exist in the database alongside tables
+- Verifying a view exists before querying it
+- The user asks what views are available
+</usecase>
+
+<examples>
+✓ "What views are in this database?"
+✓ "Does an active_users view exist?" → listViews to check
+✗ "Show me the columns of a view" → use listTables with `detailed: true` instead
+</examples>
+
+<what_it_returns>
+A sorted JSON array of view name strings.
+</what_it_returns>
+
+<pagination>
+Paginated. Pass the prior response's `nextCursor` as `cursor` to fetch the next page.
+</pagination>

--- a/crates/sqlite/assets/tools/read_query.md
+++ b/crates/sqlite/assets/tools/read_query.md
@@ -1,0 +1,29 @@
+Execute a read-only SQL query. Allowed statements: SELECT, EXPLAIN.
+
+<usecase>
+Use when:
+- Querying data from tables (SELECT with WHERE, JOIN, GROUP BY, etc.)
+- Aggregations: COUNT, SUM, AVG, GROUP BY, HAVING
+- Checking data existence or counts
+</usecase>
+
+<when_not_to_use>
+- Data changes (INSERT, UPDATE, DELETE) → use writeQuery
+- Query performance analysis → use explainQuery
+- Discovering tables or columns → use listTables (pass `detailed: true` for columns)
+</when_not_to_use>
+
+<examples>
+✓ "SELECT * FROM users WHERE status = 'active'"
+✓ "SELECT COUNT(*) FROM orders GROUP BY region"
+✗ "INSERT INTO users ..." → use writeQuery
+✗ "EXPLAIN SELECT ..." → use explainQuery for structured analysis
+</examples>
+
+<what_it_returns>
+A JSON array of row objects, each keyed by column name.
+</what_it_returns>
+
+<pagination>
+`SELECT` results are paginated. Pass the prior response's `nextCursor` as `cursor` to fetch the next page. `EXPLAIN` returns a single page and ignores `cursor`.
+</pagination>

--- a/crates/sqlite/assets/tools/write_query.md
+++ b/crates/sqlite/assets/tools/write_query.md
@@ -1,0 +1,24 @@
+Execute a write SQL query (INSERT, UPDATE, DELETE, CREATE, ALTER, DROP).
+
+<usecase>
+Use when:
+- Inserting, updating, or deleting rows
+- Creating or altering tables, indexes, views, or other schema objects
+- Any data modification operation
+</usecase>
+
+<when_not_to_use>
+- Read-only queries (SELECT) → use readQuery
+- Query performance analysis → use explainQuery
+</when_not_to_use>
+
+<examples>
+✓ "INSERT INTO users (name, email) VALUES ('Alice', 'alice@example.com')"
+✓ "UPDATE orders SET status = 'shipped' WHERE id = 42"
+✓ "CREATE TABLE logs (id INTEGER PRIMARY KEY, message TEXT)"
+✗ "SELECT * FROM users" → use readQuery
+</examples>
+
+<what_it_returns>
+A JSON array of affected/returning row objects, each keyed by column name.
+</what_it_returns>

--- a/crates/sqlite/src/handler.rs
+++ b/crates/sqlite/src/handler.rs
@@ -24,20 +24,7 @@ use crate::tools::{
 const DESCRIPTION: &str = "Database MCP Server for SQLite";
 
 /// Backend-specific instructions for `SQLite`.
-const INSTRUCTIONS: &str = r"## Workflow
-
-1. Call `listTables` to discover tables in the connected database. Pass `search` to filter by name (case-insensitive substring). Pass `detailed: true` to get columns, constraints, indexes, and triggers in the same call — this supersedes the legacy `getTableSchema` workflow.
-2. Call `listViews` to discover views in the connected database.
-3. Call `listTriggers` to discover triggers in the connected database.
-4. Use `readQuery` for read-only SQL (SELECT).
-5. Use `writeQuery` for data changes (INSERT, UPDATE, DELETE, CREATE, ALTER, DROP).
-6. Use `explainQuery` to analyze query execution plans and diagnose slow queries.
-7. Use `dropTable` to remove a table from the database.
-
-## Constraints
-
-- The `writeQuery` and `dropTable` tools are hidden when read-only mode is active.
-- Multi-statement queries are not supported. Send one statement per request.";
+const INSTRUCTIONS: &str = include_str!("../assets/instructions.md");
 
 /// `SQLite` file-based database handler.
 ///

--- a/crates/sqlite/src/handler.rs
+++ b/crates/sqlite/src/handler.rs
@@ -23,8 +23,11 @@ use crate::tools::{
 /// Backend-specific description for `SQLite`.
 const DESCRIPTION: &str = "Database MCP Server for SQLite";
 
-/// Backend-specific instructions for `SQLite`.
+/// Backend-specific instructions for `SQLite` in read-write mode.
 const INSTRUCTIONS: &str = include_str!("../assets/instructions.md");
+
+/// Backend-specific instructions for `SQLite` in read-only mode.
+const INSTRUCTIONS_READ_ONLY: &str = include_str!("../assets/instructions.readonly.md");
 
 /// `SQLite` file-based database handler.
 ///
@@ -92,7 +95,11 @@ impl ServerHandler for SqliteHandler {
     fn get_info(&self) -> ServerInfo {
         let mut info = server_info();
         info.server_info.description = Some(DESCRIPTION.into());
-        info.instructions = Some(INSTRUCTIONS.into());
+        info.instructions = Some(if self.config.read_only {
+            INSTRUCTIONS_READ_ONLY.into()
+        } else {
+            INSTRUCTIONS.into()
+        });
         info
     }
 
@@ -194,6 +201,23 @@ mod tests {
         assert!(router.has_route("explainQuery"));
         assert!(!router.has_route("writeQuery"));
         assert!(!router.has_route("dropTable"));
+    }
+
+    #[tokio::test]
+    async fn instructions_match_read_only_mode() {
+        let read_write = handler(false).get_info().instructions.expect("instructions present");
+        assert!(
+            read_write.contains("writeQuery"),
+            "read-write instructions mention writeQuery"
+        );
+
+        let read_only = handler(true).get_info().instructions.expect("instructions present");
+        for tool in ["writeQuery", "dropTable"] {
+            assert!(
+                !read_only.contains(tool),
+                "read-only instructions must not mention {tool}"
+            );
+        }
     }
 
     #[tokio::test]

--- a/crates/sqlite/src/tools/drop_table.rs
+++ b/crates/sqlite/src/tools/drop_table.rs
@@ -19,26 +19,7 @@ pub(crate) struct DropTableTool;
 impl DropTableTool {
     const NAME: &'static str = "dropTable";
     const TITLE: &'static str = "Drop Table";
-    const DESCRIPTION: &'static str = r#"Drop a table from the database.
-
-<usecase>
-Use when:
-- Removing a table that is no longer needed
-- Cleaning up test or temporary tables
-</usecase>
-
-<examples>
-✓ "Drop the temp_logs table" → dropTable(table="temp_logs")
-✗ "Delete rows from a table" → use writeQuery with DELETE
-</examples>
-
-<safety>
-IMPORTANT: This permanently deletes the table and ALL its data. This action cannot be undone.
-</safety>
-
-<what_it_returns>
-A confirmation message with the dropped table name.
-</what_it_returns>"#;
+    const DESCRIPTION: &'static str = include_str!("../../assets/tools/drop_table.md");
 }
 
 impl ToolBase for DropTableTool {

--- a/crates/sqlite/src/tools/explain_query.rs
+++ b/crates/sqlite/src/tools/explain_query.rs
@@ -17,29 +17,7 @@ pub(crate) struct ExplainQueryTool;
 impl ExplainQueryTool {
     const NAME: &'static str = "explainQuery";
     const TITLE: &'static str = "Explain Query";
-    const DESCRIPTION: &'static str = r#"Return the execution plan for a SQL query to diagnose performance. Use this tool instead of running EXPLAIN directly through readQuery — it provides structured output via EXPLAIN QUERY PLAN.
-
-<usecase>
-Use when:
-- A query runs slowly and you need to understand why
-- Understanding how SQLite will scan tables and use indexes
-- Deciding whether to add an index
-</usecase>
-
-<when_not_to_use>
-- Running actual queries → use readQuery or writeQuery
-- Checking table structure → use listTables with `detailed: true`
-</when_not_to_use>
-
-<examples>
-✓ "Why is my SELECT on orders slow?" → explainQuery(query="SELECT ...")
-✓ "How will SQLite execute this join?" → explainQuery
-✗ "Run this SELECT" → use readQuery
-</examples>
-
-<what_it_returns>
-A JSON array of EXPLAIN QUERY PLAN rows showing how SQLite will scan tables, use indexes, and order operations.
-</what_it_returns>"#;
+    const DESCRIPTION: &'static str = include_str!("../../assets/tools/explain_query.md");
 }
 
 impl ToolBase for ExplainQueryTool {

--- a/crates/sqlite/src/tools/list_tables.rs
+++ b/crates/sqlite/src/tools/list_tables.rs
@@ -16,35 +16,7 @@ pub(crate) struct ListTablesTool;
 impl ListTablesTool {
     const NAME: &'static str = "listTables";
     const TITLE: &'static str = "List Tables";
-    const DESCRIPTION: &'static str = r#"List tables in the connected database, optionally filtered and/or with full metadata.
-
-<usecase>
-Use when:
-- Exploring a database to find relevant tables (brief mode, default).
-- Searching for a table by partial name (pass `search`).
-- Inspecting a table's columns, constraints, indexes, and triggers before writing a query (pass `detailed: true`). This supersedes the legacy `getTableSchema` workflow.
-</usecase>
-
-<parameters>
-- `cursor` — Opaque pagination cursor; echo the prior response's `nextCursor`.
-- `search` — Case-insensitive filter on table names via `LIKE`. `%` matches any sequence; `_` matches a single character.
-- `detailed` — When `true`, returns full metadata objects keyed by table name instead of bare name strings. Default `false`.
-</parameters>
-
-<examples>
-✓ "What tables are in this database?" → listTables()
-✓ "Find the orders table" → listTables(search="order")
-✓ "What columns does orders have?" → listTables(search="orders", detailed=true)
-</examples>
-
-<what_it_returns>
-Brief mode (default): a sorted JSON array of table-name strings, e.g. `["customers", "orders"]`.
-Detailed mode: a JSON object keyed by table name; each value carries `schema`, `kind`, `owner`, `comment`, `columns`, `constraints`, `indexes`, and `triggers` (the name is the key and is not repeated inside the value). Keys iterate in the same alphabetical order brief mode uses. Example: `{"orders": {"schema": "main", "kind": "TABLE", ...}}`.
-</what_it_returns>
-
-<pagination>
-Paginated. Pass the prior response's `nextCursor` as `cursor` to fetch the next page. The `search` filter must stay the same across pages for cursor continuity.
-</pagination>"#;
+    const DESCRIPTION: &'static str = include_str!("../../assets/tools/list_tables.md");
 }
 
 impl ToolBase for ListTablesTool {

--- a/crates/sqlite/src/tools/list_triggers.rs
+++ b/crates/sqlite/src/tools/list_triggers.rs
@@ -18,38 +18,7 @@ pub(crate) struct ListTriggersTool;
 impl ListTriggersTool {
     const NAME: &'static str = "listTriggers";
     const TITLE: &'static str = "List Triggers";
-    const DESCRIPTION: &'static str = r#"List triggers in the connected SQLite database, optionally filtered and/or with full metadata.
-
-<usecase>
-Use when:
-- Auditing trigger coverage across a database (brief mode, default).
-- Searching for a trigger by partial name (pass `search`).
-- Inspecting a trigger's table and full `CREATE TRIGGER` text before reasoning about side-effects (pass `detailed: true`). Detailed mode supersedes ad-hoc `readQuery` against `sqlite_schema`.
-</usecase>
-
-<parameters>
-- `cursor` — Opaque pagination cursor; echo the prior response's `nextCursor`.
-- `search` — Case-insensitive filter on trigger names via `LIKE` (SQLite's `LIKE` is ASCII-case-insensitive by default). `%` matches any sequence; `_` matches a single character.
-- `detailed` — When `true`, returns full metadata objects keyed by trigger name instead of bare name strings. Default `false`.
-</parameters>
-
-<examples>
-✓ "What triggers are in this database?" → listTriggers()
-✓ "Find the audit triggers" → listTriggers(search="audit")
-✓ "What does orders_audit_after_insert do?" → listTriggers(search="orders_audit_after_insert", detailed=true)
-✗ "Show me a trigger's body" → use detailed mode; the `definition` field carries the full `CREATE TRIGGER` text
-</examples>
-
-<what_it_returns>
-Brief mode (default): a sorted JSON array of trigger-name strings, e.g. `["customers_audit_after_insert", "orders_audit_after_insert"]`.
-Detailed mode: a JSON object keyed by trigger name; each value carries exactly three fields — `schema` (always `"main"`), `table` (`sqlite_schema.tbl_name` — may be a view name for `INSTEAD OF` triggers), and `definition` (the original `CREATE TRIGGER` text from `sqlite_schema.sql`, byte-for-byte). Internal `sqlite_*` triggers are excluded.
-The detailed payload deliberately diverges from the Postgres and MySQL/MariaDB `listTriggers` detailed payloads — `timing`, `events`, `activationLevel`, `status`, `functionName`, `sqlMode`, `characterSetClient`, `collationConnection`, `databaseCollation`, and `created` are absent. SQLite's catalogue does not expose those concepts as columns, and this tool deliberately avoids parsing the stored DDL to derive them; clients that need the timing or event keyword can read it off the prefix of `definition`.
-Triggers whose stored `sqlite_schema.sql` is `NULL` (rare; produced by extension-generated rows or hand-edited catalogues) are silently omitted from detailed mode but still listed by name in brief mode.
-</what_it_returns>
-
-<pagination>
-Paginated. Pass the prior response's `nextCursor` as `cursor` to fetch the next page. The `search` filter must stay the same across pages for cursor continuity.
-</pagination>"#;
+    const DESCRIPTION: &'static str = include_str!("../../assets/tools/list_triggers.md");
 }
 
 impl ToolBase for ListTriggersTool {

--- a/crates/sqlite/src/tools/list_views.rs
+++ b/crates/sqlite/src/tools/list_views.rs
@@ -19,28 +19,7 @@ pub(crate) struct ListViewsTool;
 impl ListViewsTool {
     const NAME: &'static str = "listViews";
     const TITLE: &'static str = "List Views";
-    const DESCRIPTION: &'static str = r#"List all views in the connected SQLite database.
-
-<usecase>
-Use when:
-- Exploring what views exist in the database alongside tables
-- Verifying a view exists before querying it
-- The user asks what views are available
-</usecase>
-
-<examples>
-✓ "What views are in this database?"
-✓ "Does an active_users view exist?" → listViews to check
-✗ "Show me the columns of a view" → use listTables with `detailed: true` instead
-</examples>
-
-<what_it_returns>
-A sorted JSON array of view name strings.
-</what_it_returns>
-
-<pagination>
-Paginated. Pass the prior response's `nextCursor` as `cursor` to fetch the next page.
-</pagination>"#;
+    const DESCRIPTION: &'static str = include_str!("../../assets/tools/list_views.md");
 }
 
 impl ToolBase for ListViewsTool {

--- a/crates/sqlite/src/tools/read_query.rs
+++ b/crates/sqlite/src/tools/read_query.rs
@@ -21,35 +21,7 @@ pub(crate) struct ReadQueryTool;
 impl ReadQueryTool {
     const NAME: &'static str = "readQuery";
     const TITLE: &'static str = "Read Query";
-    const DESCRIPTION: &'static str = r#"Execute a read-only SQL query. Allowed statements: SELECT, EXPLAIN.
-
-<usecase>
-Use when:
-- Querying data from tables (SELECT with WHERE, JOIN, GROUP BY, etc.)
-- Aggregations: COUNT, SUM, AVG, GROUP BY, HAVING
-- Checking data existence or counts
-</usecase>
-
-<when_not_to_use>
-- Data changes (INSERT, UPDATE, DELETE) → use writeQuery
-- Query performance analysis → use explainQuery
-- Discovering tables or columns → use listTables (pass `detailed: true` for columns)
-</when_not_to_use>
-
-<examples>
-✓ "SELECT * FROM users WHERE status = 'active'"
-✓ "SELECT COUNT(*) FROM orders GROUP BY region"
-✗ "INSERT INTO users ..." → use writeQuery
-✗ "EXPLAIN SELECT ..." → use explainQuery for structured analysis
-</examples>
-
-<what_it_returns>
-A JSON array of row objects, each keyed by column name.
-</what_it_returns>
-
-<pagination>
-`SELECT` results are paginated. Pass the prior response's `nextCursor` as `cursor` to fetch the next page. `EXPLAIN` returns a single page and ignores `cursor`.
-</pagination>"#;
+    const DESCRIPTION: &'static str = include_str!("../../assets/tools/read_query.md");
 }
 
 impl ToolBase for ReadQueryTool {

--- a/crates/sqlite/src/tools/write_query.rs
+++ b/crates/sqlite/src/tools/write_query.rs
@@ -17,30 +17,7 @@ pub(crate) struct WriteQueryTool;
 impl WriteQueryTool {
     const NAME: &'static str = "writeQuery";
     const TITLE: &'static str = "Write Query";
-    const DESCRIPTION: &'static str = r#"Execute a write SQL query (INSERT, UPDATE, DELETE, CREATE, ALTER, DROP).
-
-<usecase>
-Use when:
-- Inserting, updating, or deleting rows
-- Creating or altering tables, indexes, views, or other schema objects
-- Any data modification operation
-</usecase>
-
-<when_not_to_use>
-- Read-only queries (SELECT) → use readQuery
-- Query performance analysis → use explainQuery
-</when_not_to_use>
-
-<examples>
-✓ "INSERT INTO users (name, email) VALUES ('Alice', 'alice@example.com')"
-✓ "UPDATE orders SET status = 'shipped' WHERE id = 42"
-✓ "CREATE TABLE logs (id INTEGER PRIMARY KEY, message TEXT)"
-✗ "SELECT * FROM users" → use readQuery
-</examples>
-
-<what_it_returns>
-A JSON array of affected/returning row objects, each keyed by column name.
-</what_it_returns>"#;
+    const DESCRIPTION: &'static str = include_str!("../../assets/tools/write_query.md");
 }
 
 impl ToolBase for WriteQueryTool {

--- a/tests/approval/mysql.rs
+++ b/tests/approval/mysql.rs
@@ -40,6 +40,17 @@ async fn test_server_info() {
 }
 
 #[tokio::test]
+async fn test_server_info_read_only() {
+    common::run_with_client(server(true), |peer| async move {
+        let info = peer.peer_info().expect("missing peer_info");
+        insta::assert_json_snapshot!("server_info_read_only", info, {
+            ".serverInfo.version" => "[version]"
+        });
+    })
+    .await;
+}
+
+#[tokio::test]
 async fn test_list_tools() {
     common::run_with_client(server(false), |peer| async move {
         let tools = peer.list_all_tools().await.expect("list_all_tools failed");

--- a/tests/approval/postgres.rs
+++ b/tests/approval/postgres.rs
@@ -41,6 +41,17 @@ async fn test_server_info() {
 }
 
 #[tokio::test]
+async fn test_server_info_read_only() {
+    common::run_with_client(server(true), |peer| async move {
+        let info = peer.peer_info().expect("missing peer_info");
+        insta::assert_json_snapshot!("server_info_read_only", info, {
+            ".serverInfo.version" => "[version]"
+        });
+    })
+    .await;
+}
+
+#[tokio::test]
 async fn test_list_tools() {
     common::run_with_client(server(false), |peer| async move {
         let tools = peer.list_all_tools().await.expect("list_all_tools failed");

--- a/tests/approval/snapshots/approval_mysql__server_info_read_only.snap
+++ b/tests/approval/snapshots/approval_mysql__server_info_read_only.snap
@@ -1,0 +1,18 @@
+---
+source: tests/approval/mysql.rs
+expression: info
+---
+{
+  "protocolVersion": "2025-11-25",
+  "capabilities": {
+    "tools": {}
+  },
+  "serverInfo": {
+    "name": "dbmcp",
+    "title": "Database MCP Server",
+    "version": "[version]",
+    "description": "Database MCP Server for MySQL and MariaDB",
+    "websiteUrl": "https://dbmcp.haymon.ai"
+  },
+  "instructions": "## Workflow\n\n1. Call `listDatabases` to discover available databases.\n2. Call `listTables` to see tables. Pass `search` to filter by name (case-insensitive substring). Pass `detailed: true` to get columns, constraints, indexes, and triggers in the same call — this supersedes the legacy `getTableSchema` workflow.\n3. Call `listViews` to see views.\n4. Call `listTriggers` to see triggers.\n5. Call `listFunctions` to see stored functions.\n6. Call `listProcedures` to see stored procedures.\n7. Use `readQuery` for read-only SQL (SELECT, SHOW, DESCRIBE, USE, EXPLAIN).\n8. Use `explainQuery` to analyze query execution plans and diagnose slow queries.\n\nPer-database tools default to the active database; pass `database` to target another.\n\n## Constraints\n\n- The server runs in read-only mode. Data and schema changes are not possible.\n- Multi-statement queries are not supported. Send one statement per request.\n"
+}

--- a/tests/approval/snapshots/approval_postgres__server_info_read_only.snap
+++ b/tests/approval/snapshots/approval_postgres__server_info_read_only.snap
@@ -1,0 +1,18 @@
+---
+source: tests/approval/postgres.rs
+expression: info
+---
+{
+  "protocolVersion": "2025-11-25",
+  "capabilities": {
+    "tools": {}
+  },
+  "serverInfo": {
+    "name": "dbmcp",
+    "title": "Database MCP Server",
+    "version": "[version]",
+    "description": "Database MCP Server for PostgreSQL",
+    "websiteUrl": "https://dbmcp.haymon.ai"
+  },
+  "instructions": "## Workflow\n\n1. Call `listDatabases` to discover available databases.\n2. Call `listTables` to see tables. Pass `search` to filter by name (case-insensitive substring). Pass `detailed: true` to get columns, constraints, indexes, and triggers in the same call — this supersedes the legacy `getTableSchema` workflow.\n3. Call `listViews` to see views in the `public` schema.\n4. Call `listTriggers` to see user-defined triggers in the `public` schema.\n5. Call `listFunctions` to see user-defined functions in the `public` schema.\n6. Call `listProcedures` to see user-defined procedures in the `public` schema.\n7. Call `listMaterializedViews` to see materialized views in the `public` schema.\n8. Use `readQuery` for read-only SQL (SELECT, SHOW, EXPLAIN).\n9. Use `explainQuery` to analyze query execution plans and diagnose slow queries.\n\nPer-database tools default to the active database; pass `database` to target another.\n\n## Constraints\n\n- The server runs in read-only mode. Data and schema changes are not possible.\n- Multi-statement queries are not supported. Send one statement per request.\n"
+}

--- a/tests/approval/snapshots/approval_sqlite__server_info_read_only.snap
+++ b/tests/approval/snapshots/approval_sqlite__server_info_read_only.snap
@@ -1,0 +1,18 @@
+---
+source: tests/approval/sqlite.rs
+expression: info
+---
+{
+  "protocolVersion": "2025-11-25",
+  "capabilities": {
+    "tools": {}
+  },
+  "serverInfo": {
+    "name": "dbmcp",
+    "title": "Database MCP Server",
+    "version": "[version]",
+    "description": "Database MCP Server for SQLite",
+    "websiteUrl": "https://dbmcp.haymon.ai"
+  },
+  "instructions": "## Workflow\n\n1. Call `listTables` to discover tables in the connected database. Pass `search` to filter by name (case-insensitive substring). Pass `detailed: true` to get columns, constraints, indexes, and triggers in the same call — this supersedes the legacy `getTableSchema` workflow.\n2. Call `listViews` to discover views in the connected database.\n3. Call `listTriggers` to discover triggers in the connected database.\n4. Use `readQuery` for read-only SQL (SELECT).\n5. Use `explainQuery` to analyze query execution plans and diagnose slow queries.\n\n## Constraints\n\n- The server runs in read-only mode. Data and schema changes are not possible.\n- Multi-statement queries are not supported. Send one statement per request.\n"
+}

--- a/tests/approval/sqlite.rs
+++ b/tests/approval/sqlite.rs
@@ -35,6 +35,17 @@ async fn test_server_info() {
 }
 
 #[tokio::test]
+async fn test_server_info_read_only() {
+    common::run_with_client(server(true), |peer| async move {
+        let info = peer.peer_info().expect("missing peer_info");
+        insta::assert_json_snapshot!("server_info_read_only", info, {
+            ".serverInfo.version" => "[version]"
+        });
+    })
+    .await;
+}
+
+#[tokio::test]
 async fn test_list_tools() {
     common::run_with_client(server(false), |peer| async move {
         let tools = peer.list_all_tools().await.expect("list_all_tools failed");


### PR DESCRIPTION
## Summary

Two related changes to the MCP-facing prose surface:

1. **Externalize tool descriptions** (`10b7d33`) — move inlined tool-description and handler-instruction raw strings into per-crate `assets/` markdown loaded with `include_str!`. Slims the `.rs` files; keeps MCP prose editable without code churn. Content moved verbatim.

2. **Read-only-aware instructions** (`62bede9`) — handler `INSTRUCTIONS` leaked write-tool details (`writeQuery`, `createDatabase`, `dropDatabase`, `dropTable`) and a "hidden when read-only" note even when the server ran read-only, where those tools are absent from the router. Ship a second per-crate asset `assets/instructions.readonly.md` with write-tool workflow steps removed and the constraint reworded; `get_info` picks the variant via `config.read_only`.

## Test plan

- `cargo fmt` / `cargo clippy --workspace --tests -- -D warnings` — clean
- `cargo test --workspace --lib --bins` — pass (new `instructions_match_read_only_mode` per handler)
- `./tests/run.sh` — 722 tests, 4/4 services PASS (new `server_info_read_only` approval snapshots)