### PR TITLE
chore(deps): bump rmcp 1.6 → 1.7, drop unused macros feature

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -342,10 +342,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c673075a2e0e5f4a1dde27ce9dee1ea4558c7ffe648f576438a20ca1d2acc4b0"
 dependencies = [
  "iana-time-zone",
- "js-sys",
  "num-traits",
  "serde",
- "wasm-bindgen",
  "windows-link",
 ]
 
@@ -2085,9 +2083,9 @@ dependencies = [
 
 [[package]]
 name = "rmcp"
-version = "1.6.0"
+version = "1.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e12ca9067b5ebfbd5b3fcdc4acfceb81aa7d5ab2a879dff7cb75d22434276aad"
+checksum = "0810a9f717d9828f475fe1f629f4c305c8464b7f496c3a854b58d29e65f4058e"
 dependencies = [
  "async-trait",
  "base64",
@@ -2116,9 +2114,9 @@ dependencies = [
 
 [[package]]
 name = "rmcp-macros"
-version = "1.6.0"
+version = "1.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7caa6743cc0888e433105fe1bc551a7f607940b126a37bc97b478e86064627eb"
+checksum = "6aefac48c364756e97f04c0401ba3231e8607882c7c1d92da0437dc16307904d"
 dependencies = [
  "darling",
  "proc-macro2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -43,8 +43,7 @@ hmac = "0.12"
 indexmap = { version = "2", features = ["serde"] }
 mimalloc = "0.1"
 moka = { version = "0.12", features = ["future"] }
-rmcp = { version = "1.6", features = [
-    "macros",
+rmcp = { version = "1.7", features = [
     "server",
     "transport-io",
     "transport-streamable-http-server",


### PR DESCRIPTION
## Summary

- Bump `rmcp` 1.6 → 1.7 (single workspace dep at `Cargo.toml:46`). No source changes needed; no breaking API.
- Drop the `macros` feature from the workspace dep: no `#[tool]` / `tool_router!` / `tool_handler!` invocations exist anywhere in `src/` or `crates/`, so the feature only pulled the `rmcp-macros` proc-macro crate. `pastey` (its other transitive) is still pulled via the `server` feature. Net: one fewer proc-macro crate compiled.

### What we get from 1.7

- **#833 stdio robustness** — stdio transport now replies JSON-RPC `-32700 Parse error` on a malformed line instead of silently dropping the session, and strips a leading UTF-8 BOM. Hardens the Claude Desktop / Cursor entry path against misbehaving or Windows-emitted clients.
- **#824 quieter HTTP logs** — idle-timeout log verbosity reduced on streamable HTTP.
- **#829 slimmer deps** — `rmcp` drops `chrono` default features (no longer pulls `iana-time-zone*` transitively). Our `sqlx-json` crate uses sqlx's chrono integration independently and is unaffected.
- **#843 spec-compliant prompt wire format** — `PromptMessageContent::Resource` serde fix. We don't expose prompts; no observable effect.

### Why nothing else changed

Audited the codebase for code that overlaps rmcp 1.6/1.7 features:
- Origin / Host validation already delegates to rmcp via `with_allowed_origins` / `with_allowed_hosts` in `src/commands/http.rs`.
- stdio command (`src/commands/stdio.rs`) is already pure-rmcp — BOM strip + parse-error reply happen inside the transport, no wrapper to delete.
- tower-http CORS layer covers browser preflight (OPTIONS), distinct from rmcp's request-time Origin check. Both needed; kept.
- `Server` newtype in `crates/server/src/server.rs` still required to bridge `Arc<dyn DynService<RoleServer>>` → `Service<RoleServer> + Clone` for `StreamableHttpService::new`.
- Declarative `ToolSpec` / `ToolRouterExt::from_specs` gating in `crates/server/src/tool.rs` is build-time filtering over a `const` slice from immutable `Config` flags — cleaner than rmcp 1.6's runtime tool-disabling for our static config. Revisit if config-reload lands.

## Test plan

- [x] `cargo fmt --check`
- [x] `cargo clippy --workspace --all-targets --tests -- -D warnings`
- [x] `cargo test --workspace --lib --bins`
- [x] `./tests/run.sh` — 722 tests PASS across `mariadb_12`, `mysql_9`, `postgres_18`, `sqlite`
- [ ] Manual stdio smoke: `cargo run -- stdio --db-backend sqlite --db-name :memory:`, send `initialize` + a malformed line, verify session stays open with `-32700` reply
- [ ] Manual HTTP smoke: `cargo run -- http --db-backend sqlite --db-name :memory:`, verify allowed vs disallowed `Origin`