### PR TITLE
fix(pii): context-gate weak numeric recognizers

### DIFF
--- a/crates/pii/src/analyzer.rs
+++ b/crates/pii/src/analyzer.rs
@@ -182,7 +182,7 @@ impl Builder {
 #[cfg(test)]
 mod tests {
     use super::{AnalyzeOptions, Analyzer};
-    use crate::context::{ContextMatchingMode, ContextSettings};
+    use crate::context::ContextSettings;
     use crate::pattern::Pattern;
     use crate::recognizers::Recognizer;
     use crate::score::Score;
@@ -195,7 +195,6 @@ mod tests {
             min_score_with_context: Score::from_static(0.4),
             prefix_words: 5,
             suffix_words: 0,
-            matching_mode: ContextMatchingMode::WholeWord,
         }
     }
 

--- a/crates/pii/src/context.rs
+++ b/crates/pii/src/context.rs
@@ -15,21 +15,11 @@ use crate::result::RecognizerResult;
 use crate::score::{MAX_SCORE, Score};
 use crate::words::{first_word, words};
 
-/// Matching mode for context keyword comparison.
-#[derive(Debug, Default, Clone, Copy, PartialEq, Eq)]
-pub enum ContextMatchingMode {
-    /// Window word must equal the keyword (case-insensitive).
-    WholeWord,
-    /// Window word must contain the keyword as a substring (case-insensitive).
-    #[default]
-    Substring,
-}
-
 /// Per-call tuning for the boost pass.
 ///
 /// Constructed via [`Default::default`] — values are not user-tunable today.
 /// `similarity_factor=0.35`, `min_score_with_context=0.4`, `prefix_words=5`,
-/// `suffix_words=0`, `matching_mode=Substring`.
+/// `suffix_words=0`. Keyword comparison is whole-word (case-insensitive).
 #[derive(Debug, Clone)]
 pub struct ContextSettings {
     /// Score increment applied on a successful keyword match.
@@ -40,8 +30,6 @@ pub struct ContextSettings {
     pub prefix_words: u16,
     /// Number of words after the match included in the window.
     pub suffix_words: u16,
-    /// Whole-word vs substring keyword comparison.
-    pub matching_mode: ContextMatchingMode,
 }
 
 impl Default for ContextSettings {
@@ -51,7 +39,6 @@ impl Default for ContextSettings {
             min_score_with_context: Score::from_static(0.4),
             prefix_words: 5,
             suffix_words: 0,
-            matching_mode: ContextMatchingMode::Substring,
         }
     }
 }
@@ -100,7 +87,7 @@ fn boost_one(
         settings.suffix_words,
     );
 
-    let Some(hit) = find_supportive_keyword(&window, external_context, keywords, settings.matching_mode) else {
+    let Some(hit) = find_supportive_keyword(&window, external_context, keywords) else {
         return;
     };
 
@@ -162,16 +149,14 @@ fn find_supportive_keyword(
     window: &[String],
     external_context: &[String],
     keywords: &[&'static str],
-    mode: ContextMatchingMode,
 ) -> Option<&'static str> {
     // Window words and external_context are already lowercased; recognizer
-    // keywords are pre-lowercased (debug_asserted by `with_context`).
-    keywords.iter().copied().find(|&kw| {
-        window.iter().chain(external_context.iter()).any(|w| match mode {
-            ContextMatchingMode::WholeWord => w == kw,
-            ContextMatchingMode::Substring => w.contains(kw),
-        })
-    })
+    // keywords are pre-lowercased (debug_asserted by `with_context`). A
+    // window word must equal a keyword (whole-word, case-insensitive).
+    keywords
+        .iter()
+        .copied()
+        .find(|&kw| window.iter().chain(external_context.iter()).any(|w| w == kw))
 }
 
 fn boost_score(current: Score, factor: Score, floor: Score) -> Score {
@@ -195,7 +180,6 @@ mod tests {
             min_score_with_context: Score::from_static(0.4),
             prefix_words: 5,
             suffix_words: 0,
-            matching_mode: ContextMatchingMode::WholeWord,
         }
     }
 
@@ -230,7 +214,6 @@ mod tests {
         let settings = ContextSettings::default();
         assert_eq!(settings.prefix_words, 5);
         assert_eq!(settings.suffix_words, 0);
-        assert!(matches!(settings.matching_mode, ContextMatchingMode::Substring));
     }
 
     #[test]
@@ -280,26 +263,11 @@ mod tests {
 
     #[test]
     fn whole_word_excludes_substring() {
+        // "discard" must NOT satisfy the "card" keyword — whole-word only.
         let rec = dummy_recognizer("R", &["card"]);
         let text = "discard 4012";
-        let settings = ContextSettings {
-            matching_mode: ContextMatchingMode::WholeWord,
-            ..default_settings()
-        };
-        let out = apply_context_boost(text, vec![result(0.1, "R", 8, 12)], &rec, &[], &settings);
+        let out = apply_context_boost(text, vec![result(0.1, "R", 8, 12)], &rec, &[], &default_settings());
         assert!(out[0].explanation.supportive_keyword.is_none());
-    }
-
-    #[test]
-    fn substring_includes_substring() {
-        let rec = dummy_recognizer("R", &["card"]);
-        let text = "discard 4012";
-        let settings = ContextSettings {
-            matching_mode: ContextMatchingMode::Substring,
-            ..default_settings()
-        };
-        let out = apply_context_boost(text, vec![result(0.1, "R", 8, 12)], &rec, &[], &settings);
-        assert_eq!(out[0].explanation.supportive_keyword.as_deref(), Some("card"));
     }
 
     #[test]

--- a/crates/pii/src/lib.rs
+++ b/crates/pii/src/lib.rs
@@ -39,7 +39,7 @@ mod words;
 pub use crate::analyzer::{AnalyzeOptions, Analyzer};
 pub use crate::anonymizer::{OperatorConfig, anonymize};
 pub use crate::category::{Category, ParseCategoryError};
-pub use crate::context::{ContextMatchingMode, ContextSettings};
+pub use crate::context::ContextSettings;
 pub use crate::entity::{Entity, ParseEntityError};
 pub use crate::operators::{ChunkCount, HashAlgorithm, Operator};
 pub use crate::redact::{RedactionError, RedactionStats, Redactor};

--- a/crates/pii/src/recognizers/gbr/bank_account.rs
+++ b/crates/pii/src/recognizers/gbr/bank_account.rs
@@ -1,9 +1,12 @@
-//! `BANK_ACCOUNT_UK` recognizer (keyword-context required).
+//! `BANK_ACCOUNT_UK` recognizer (weak digit pattern, keyword-context gated).
 
 use super::Recognizer;
 use crate::pattern::Pattern;
 use crate::score::Score;
 use crate::{Category, Entity};
+
+/// Context keywords for UK bank account.
+const CONTEXT: &[&str] = &["account", "acct", "bank", "iban"];
 
 /// Build the `BANK_ACCOUNT_UK` recognizer.
 ///
@@ -15,39 +18,47 @@ pub fn bank_account_gbr() -> Recognizer {
     let pattern = Pattern::new(
         "UK bank account (8-10 digits)",
         r"\b\d{8,10}\b",
-        Score::from_static(0.4),
+        Score::from_static(0.05),
     )
     .expect("static UK bank-account pattern compiles");
     Recognizer::new(Entity::BankAccountUk, vec![pattern])
         .expect("non-empty pattern list")
         .with_name("BankAccountGbrRecognizer")
         .with_category(Category::Financial)
+        .with_context(CONTEXT)
 }
 
 #[cfg(test)]
 mod tests {
-    use super::bank_account_gbr;
+    use super::{CONTEXT, bank_account_gbr};
 
-    fn matches(text: &str) -> Vec<String> {
-        let r = bank_account_gbr();
-        r.analyze(text)
+    #[test]
+    fn carries_context_list() {
+        assert_eq!(bank_account_gbr().context(), CONTEXT);
+    }
+
+    fn results(text: &str) -> Vec<(&str, f32)> {
+        bank_account_gbr()
+            .analyze(text)
             .into_iter()
-            .map(|res| text[res.start..res.end].to_string())
+            .map(|r| (&text[r.start..r.end], r.score.as_f32()))
             .collect()
     }
 
     #[test]
-    fn positive_with_keyword() {
-        assert_eq!(matches("acct 12345678"), vec!["12345678"]);
-    }
-
-    #[test]
-    fn positive_iban_keyword() {
-        assert_eq!(matches("IBAN account 12345678"), vec!["12345678"]);
-    }
-
-    #[test]
-    fn negative_too_short() {
-        assert!(matches("account 1234567").is_empty());
+    fn recognizes_bank_account_gbr() {
+        let cases: &[(&str, &[(&str, f32)])] = &[
+            ("acct 12345678", &[("12345678", 0.05)]),
+            ("IBAN account 12345678", &[("12345678", 0.05)]),
+            ("1234567890", &[("1234567890", 0.05)]),
+            ("900000000", &[("900000000", 0.05)]),
+            ("44455512", &[("44455512", 0.05)]),
+            ("account 1234567", &[]),
+            ("12345678901", &[]),
+            ("123456", &[]),
+        ];
+        for (input, expected) in cases {
+            assert_eq!(results(input), expected.to_vec(), "input {input:?}");
+        }
     }
 }

--- a/crates/pii/src/recognizers/gbr/sort_code.rs
+++ b/crates/pii/src/recognizers/gbr/sort_code.rs
@@ -1,9 +1,12 @@
-//! `SORT_CODE_UK` recognizer (keyword-context required).
+//! `SORT_CODE_UK` recognizer (weak digit pattern, keyword-context gated).
 
 use super::Recognizer;
 use crate::pattern::Pattern;
 use crate::score::Score;
 use crate::{Category, Entity};
+
+/// Context keywords for UK sort code.
+const CONTEXT: &[&str] = &["sort", "sortcode"];
 
 /// Build the `SORT_CODE_UK` recognizer.
 ///
@@ -15,34 +18,47 @@ pub fn sort_code_gbr() -> Recognizer {
     let pattern = Pattern::new(
         "UK sort code",
         r"\b\d{2}[- ]?\d{2}[- ]?\d{2}\b",
-        Score::from_static(0.4),
+        Score::from_static(0.05),
     )
     .expect("static UK sort-code pattern compiles");
     Recognizer::new(Entity::SortCodeUk, vec![pattern])
         .expect("non-empty pattern list")
         .with_name("SortCodeGbrRecognizer")
         .with_category(Category::Financial)
+        .with_context(CONTEXT)
 }
 
 #[cfg(test)]
 mod tests {
-    use super::sort_code_gbr;
+    use super::{CONTEXT, sort_code_gbr};
 
-    fn matches(text: &str) -> Vec<String> {
-        let r = sort_code_gbr();
-        r.analyze(text)
+    #[test]
+    fn carries_context_list() {
+        assert_eq!(sort_code_gbr().context(), CONTEXT);
+    }
+
+    fn results(text: &str) -> Vec<(&str, f32)> {
+        sort_code_gbr()
+            .analyze(text)
             .into_iter()
-            .map(|res| text[res.start..res.end].to_string())
+            .map(|r| (&text[r.start..r.end], r.score.as_f32()))
             .collect()
     }
 
     #[test]
-    fn positive_dashed_with_keyword() {
-        assert_eq!(matches("sort 12-34-56"), vec!["12-34-56"]);
-    }
-
-    #[test]
-    fn positive_spaced_with_keyword() {
-        assert_eq!(matches("sort code 12 34 56"), vec!["12 34 56"]);
+    fn recognizes_sort_code_gbr() {
+        let cases: &[(&str, &[(&str, f32)])] = &[
+            ("sort 12-34-56", &[("12-34-56", 0.05)]),
+            ("sort code 12 34 56", &[("12 34 56", 0.05)]),
+            ("123456", &[("123456", 0.05)]),
+            ("483163", &[("483163", 0.05)]),
+            ("2021-10", &[("2021-10", 0.05)]),
+            ("12345", &[]),
+            ("1234567", &[]),
+            ("1234567890", &[]),
+        ];
+        for (input, expected) in cases {
+            assert_eq!(results(input), expected.to_vec(), "input {input:?}");
+        }
     }
 }

--- a/crates/pii/src/recognizers/generic/phone.rs
+++ b/crates/pii/src/recognizers/generic/phone.rs
@@ -39,7 +39,7 @@ pub fn phone_number() -> Recognizer {
 mod tests {
     use super::{CONTEXT, phone_number};
     use crate::analyzer::{AnalyzeOptions, Analyzer};
-    use crate::context::{ContextMatchingMode, ContextSettings};
+    use crate::context::ContextSettings;
     use crate::score::Score;
 
     fn matches(text: &str) -> Vec<String> {
@@ -71,7 +71,6 @@ mod tests {
                 min_score_with_context: Score::from_static(0.4),
                 prefix_words: 5,
                 suffix_words: 0,
-                matching_mode: ContextMatchingMode::WholeWord,
             }),
         };
         let out = a.analyze("my phone 415 555 0142", &opts);

--- a/crates/pii/src/recognizers/mod.rs
+++ b/crates/pii/src/recognizers/mod.rs
@@ -309,8 +309,6 @@ mod tests {
             "ApiKeyAwsSecretRecognizer",
             "JwtTokenRecognizer",
             "PrivateKeyRecognizer",
-            "BankAccountGbrRecognizer",
-            "SortCodeGbrRecognizer",
         ];
         let mut missing = Vec::new();
         for r in all() {

--- a/crates/pii/src/recognizers/usa/passport.rs
+++ b/crates/pii/src/recognizers/usa/passport.rs
@@ -34,31 +34,37 @@ pub fn passport_usa() -> Recognizer {
 
 #[cfg(test)]
 mod tests {
-    use super::passport_usa;
+    use super::{CONTEXT, passport_usa};
 
-    fn matches(text: &str) -> Vec<(usize, usize)> {
+    #[test]
+    fn carries_context_list() {
+        assert_eq!(passport_usa().context(), CONTEXT);
+    }
+
+    fn results(text: &str) -> Vec<(&str, f32)> {
         passport_usa()
             .analyze(text)
             .into_iter()
-            .map(|r| (r.start, r.end))
+            .map(|r| (&text[r.start..r.end], r.score.as_f32()))
             .collect()
     }
 
     #[test]
     fn recognizes_passport_usa() {
-        let cases: &[(&str, &[(usize, usize)])] = &[
-            ("912803456", &[(0, 9)]),
-            ("Z12803456", &[(0, 9)]),
-            ("A12803456", &[(0, 9)]),
-            ("my travel document is A12803456", &[(22, 31)]),
-            ("my travel passport is A12803456", &[(22, 31)]),
+        let cases: &[(&str, &[(&str, f32)])] = &[
+            ("912803456", &[("912803456", 0.05)]),
+            ("Z12803456", &[("Z12803456", 0.1)]),
+            ("A12803456", &[("A12803456", 0.1)]),
+            ("900000000", &[("900000000", 0.05)]),
+            ("my travel document is A12803456", &[("A12803456", 0.1)]),
+            ("my travel passport is A12803456", &[("A12803456", 0.1)]),
             ("12345678", &[]),
             ("1234567890", &[]),
             ("AB12803456", &[]),
             ("", &[]),
         ];
         for (input, expected) in cases {
-            assert_eq!(matches(input), expected.to_vec(), "input {input:?}: span mismatch");
+            assert_eq!(results(input), expected.to_vec(), "input {input:?}");
         }
     }
 }

--- a/crates/pii/src/redact.rs
+++ b/crates/pii/src/redact.rs
@@ -226,7 +226,7 @@ impl Redactor {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::context::{ContextMatchingMode, ContextSettings};
+    use crate::context::ContextSettings;
     use crate::pattern::Pattern;
     use crate::recognizers::Recognizer;
     use crate::score::Score;
@@ -560,7 +560,6 @@ mod tests {
             min_score_with_context: Score::from_static(0.4),
             prefix_words: 5,
             suffix_words: 0,
-            matching_mode: ContextMatchingMode::WholeWord,
         }
     }
 

--- a/crates/pii/src/words.rs
+++ b/crates/pii/src/words.rs
@@ -5,10 +5,9 @@
 //! * [`push_key_words`] — JSON object keys. Splits on every
 //!   non-alphanumeric ASCII char (`_`, `-`, `.`, whitespace, punctuation,
 //!   any non-ASCII byte) and lowercases the surviving pieces. camelCase /
-//!   `PascalCase` are intentionally left glued: the boost runs under
-//!   [`crate::ContextMatchingMode::Substring`] in production, so `"phone"`
-//!   matches `"customerphone"` via `str::contains`, and acronym
-//!   substrings like `"ipv4"` stay intact against `"ipv4"` keywords.
+//!   `PascalCase` are left glued; the boost matches whole words, so a glued
+//!   key like `"customerphone"` does not satisfy a `"phone"` keyword —
+//!   snake/kebab/dotted keys (the SQL norm) split into matchable tokens.
 //! * [`words`] / [`first_word`] — free-form text inside the boost window.
 //!   Manual `char::is_alphanumeric || '_'` scan that mirrors Unicode
 //!   `\w+` semantics for the inputs the boost actually sees, so
@@ -94,8 +93,7 @@ mod tests {
 
     #[test]
     fn camel_and_pascal_case_stay_glued() {
-        // camelCase / PascalCase do NOT split — substring matching against
-        // recognizer keywords still finds `"phone"` inside `"customerphone"`.
+        // camelCase / PascalCase do NOT split into separate tokens.
         assert_eq!(words("customerPhoneNumber"), vec!["customerphonenumber"]);
         assert_eq!(words("CustomerPhoneNumber"), vec!["customerphonenumber"]);
         assert_eq!(words("APIKey"), vec!["apikey"]);


### PR DESCRIPTION
## Summary

- The UK sort-code (`SORT_CODE_UK`) and bank-account (`BANK_ACCOUNT_UK`) recognizers matched any digit run of the right length at a score equal to the redactor's confidence floor, so they fired on benign numbers, ISO timestamps (the `YYYY-MM` prefix), and `VARCHAR` identifiers regardless of the source column. Re-tiered both to the weak `0.05` base score with keyword context lists, so they surface only when a nearby column/key name supports the match.
- Switched context keyword matching to whole-word only and removed the substring mode. Substring matching spuriously lifted short keywords found inside longer words (e.g. `us` within `customer`), re-introducing false positives. Whole-word matching keeps snake/kebab/dotted column names (the SQL norm) working while eliminating that class of false positive.
- Strong, validator-backed entities (email, IBAN, credit card, IP, URL, VAT, …) are unaffected — they do not rely on context.

## Test plan

- [x] `cargo fmt --check`
- [x] `cargo clippy --workspace --tests -- -D warnings`
- [x] `cargo test --workspace`
- [x] `./tests/run.sh` (mariadb_12, mysql_9, postgres_18, sqlite — 734 tests)