### PR TITLE
fix(pii): redact German postcodes in English-named columns

### DIFF
--- a/crates/pii/src/recognizers/deu/postcode.rs
+++ b/crates/pii/src/recognizers/deu/postcode.rs
@@ -24,6 +24,15 @@ const CONTEXT: &[&str] = &[
     "gemeinde",
     "stadt",
     "dorf",
+    "zip",
+    "postcode",
+    "postal",
+    "address",
+    "city",
+    "delivery",
+    "mailing",
+    "shipping",
+    "correspondence",
 ];
 
 /// Build the `POSTCODE_DE` recognizer.

--- a/crates/pii/src/redact.rs
+++ b/crates/pii/src/redact.rs
@@ -657,6 +657,24 @@ mod tests {
     }
 
     #[test]
+    fn zip_code_column_redacts_de_postcode_via_zip_keyword() {
+        let r = Redactor::with_defaults();
+        let mut rows = vec![json!({"zip_code": "41100"})];
+        let stats = r.apply(&mut rows).expect("apply ok");
+        assert_eq!(rows[0]["zip_code"], "<POSTCODE_DE>");
+        assert_eq!(stats.by_entity.get(&Entity::PostcodeDe).copied(), Some(1));
+    }
+
+    #[test]
+    fn de_postcode_value_untouched_without_address_context() {
+        let r = Redactor::with_defaults();
+        let mut rows = vec![json!({"reference": "41100"})];
+        let stats = r.apply(&mut rows).expect("apply ok");
+        assert_eq!(rows[0]["reference"], "41100");
+        assert!(!stats.by_entity.contains_key(&Entity::PostcodeDe));
+    }
+
+    #[test]
     fn numeric_reference_untouched() {
         let r = Redactor::with_defaults();
         let mut rows = vec![json!({"reference": "900000000"})];


### PR DESCRIPTION
## Problem

`POSTCODE_DE` (weak 0.05 base score, context-gated) only carried **German-language** context keywords (`plz`, `postleitzahl`, `adresse`, `stadt`, …). The redactor feeds the column name as context, so an English-named column like `zip_code` splits to `["zip", "code"]` — matching none of them. The 5-digit DE postcode stayed at 0.05, below the 0.4 floor, and **leaked**.

`POSTCODE_UK` already carries the English/generic terms; DE did not.

## Change

Add English/generic single-word address terms to `POSTCODE_DE` context: `zip`, `postcode`, `postal`, `address`, `city`, `delivery`, `mailing`, `shipping`, `correspondence` (mirrors `POSTCODE_UK`). German keywords unchanged.

Stays consistent with the weak-base + context-boost pattern: a bare 5-digit value in a column with no telling name still does **not** redact — no false-positive regression.

## Tests

- `zip_code_column_redacts_de_postcode_via_zip_keyword` — `{"zip_code": "41100"}` → `<POSTCODE_DE>`.
- `de_postcode_value_untouched_without_address_context` — same value in a `reference` column stays clear.

`cargo fmt` / `cargo clippy --workspace --tests -- -D warnings` / `cargo test --workspace --lib --bins` all green.