### PR TITLE
chore(audit): ignore RUSTSEC-2024-0436 (paste unmaintained)

### DIFF
--- a/.cargo/audit.toml
+++ b/.cargo/audit.toml
@@ -7,4 +7,9 @@ ignore = [
     # during reseed. Not applicable here; rand 0.8.5 is a transitive dep and
     # we don't ship such a logger.
     "RUSTSEC-2026-0097",
+    # paste: unmaintained (archived), not a vulnerability. Transitive,
+    # compile-time-only dep via candle-transformers -> candle-core -> gemm.
+    # No source uses it; candle 0.10.2 and gemm 0.19.0 are already latest and
+    # still pull paste, so there is no upstream fix to take.
+    "RUSTSEC-2024-0436",
 ]


### PR DESCRIPTION
## What

Suppress **RUSTSEC-2024-0436** in `.cargo/audit.toml`. The `paste` crate (`1.0.15`) is unmaintained/archived.

## Why it's safe to ignore

- **Unmaintained warning, not a vulnerability** — `paste` is a compile-time proc-macro; no exploitable defect.
- **Transitive only** — no workspace crate depends on it directly, and no source uses `paste::` / `paste!`.
  - Chain: `gemm 0.19.0` → `candle-core 0.10.2` → `candle-nn` → `candle-transformers` → `dbmcp-pii`.
- **No upstream fix** — `candle-core 0.10.2` and `gemm 0.19.0` are already the latest published versions and still pull `paste`. A `[patch.crates-io]` redirect to `pastey` is not viable (patch replacement must be a crate literally named `paste`).
- Follows the existing convention for transitive, unfixable advisories already in `.cargo/audit.toml` (rsa `RUSTSEC-2023-0071`, rand `RUSTSEC-2026-0097`).

## Verification

- `cargo audit` runs clean (exit 0, 449 deps scanned, zero findings).
- Config-only change: no `Cargo.lock` churn, no build/test impact.

Closes #175