### PR TITLE
test(pii): seed PII/NER fixtures in users tables

### DIFF
--- a/tests/seed/mysql.sql
+++ b/tests/seed/mysql.sql
@@ -17,6 +17,17 @@ CREATE TABLE `app`.`users` (
     `name` VARCHAR(100) NOT NULL COMMENT 'Display name; trimmed by trigger on insert.',
     `email` VARCHAR(255) NOT NULL UNIQUE,
     `display_name` VARCHAR(400) GENERATED ALWAYS AS (CONCAT(`name`, ' <', `email`, '>')) STORED,
+    `phone` VARCHAR(40),
+    `ssn` VARCHAR(20),
+    `tax_id` VARCHAR(20),
+    `credit_card` VARCHAR(25),
+    `iban` VARCHAR(40),
+    `city` VARCHAR(80),
+    `employer` VARCHAR(120),
+    `nationality` VARCHAR(60),
+    `bio` TEXT,
+    `notes` TEXT,
+    `metadata` JSON,
     `created_at` TIMESTAMP DEFAULT CURRENT_TIMESTAMP
 ) ENGINE=InnoDB;
 
@@ -48,10 +59,19 @@ CREATE TABLE `app`.`post_tags` (
 
 -- App sample data
 
-INSERT INTO `app`.`users` (`name`, `email`) VALUES
-    ('Alice Johnson', 'alice@example.com'),
-    ('Bob Smith', 'bob@example.com'),
-    ('Charlie Brown', 'charlie@example.com');
+INSERT INTO `app`.`users` (`name`, `email`, `phone`, `ssn`, `tax_id`, `credit_card`, `iban`, `city`, `employer`, `nationality`, `bio`, `notes`, `metadata`) VALUES
+    ('Alice Johnson', 'alice@example.com', '+14155552671', '078-05-1123', NULL, '4111111111111111', 'GB82WEST12345698765432', 'San Francisco', 'Acme Corporation', 'American',
+     'Alice Johnson is a software engineer from San Francisco who works at Acme Corporation. An American citizen, she frequently visits the Golden Gate Bridge. Call her at +14155552671 or email alice@example.com.',
+     'Customer Alice paid with card 4111111111111111. SSN on file 078-05-1123. Refund IBAN GB82WEST12345698765432. Callback phone +14155552671.',
+     '{"contact":{"name":"Alice Johnson","email":"alice@example.com","phone":"+14155552671"},"address":{"city":"San Francisco","country":"USA"}}'),
+    ('Bob Smith', 'bob@example.com', '+44 20 7946 0958', NULL, NULL, '5555555555554444', 'BE62510007547061', 'London', 'Siemens', 'British',
+     'Bob Smith, a British national, lives in London and is employed at Siemens. He often meets clients at the British Museum. Reach Bob at bob@example.com; phone +44 20 7946 0958.',
+     'Bob Smith called from phone +44 20 7946 0958 about a refund. Card 5555555555554444. No SSN on file.',
+     '{"contact":{"name":"Bob Smith","email":"bob@example.com","phone":"+44 20 7946 0958"},"address":{"city":"London","country":"United Kingdom"}}'),
+    ('Charlie Brown', 'charlie@example.com', '+49 30 12345678', NULL, '12345678903', '371449635398431', 'DE89370400440532013000', 'Berlin', 'Deutsche Bank', 'German',
+     'Charlie Brown grew up in Berlin and works as an analyst at Deutsche Bank. A German citizen, Charlie volunteers at the Red Cross and often walks past the Brandenburg Gate. Email charlie@example.com or call +49 30 12345678.',
+     'Charlie Brown German tax ID 12345678903. Paid via Amex card 371449635398431. IBAN DE89370400440532013000.',
+     '{"contact":{"name":"Charlie Brown","email":"charlie@example.com","phone":"+49 30 12345678"},"address":{"city":"Berlin","country":"Germany"},"taxId":"12345678903"}');
 
 INSERT INTO `app`.`posts` (`user_id`, `title`, `body`, `published`) VALUES
     (1, 'Getting Started with SQL', 'An introduction to SQL databases.', 1),

--- a/tests/seed/postgres.sql
+++ b/tests/seed/postgres.sql
@@ -11,6 +11,17 @@ CREATE TABLE users (
     id SERIAL PRIMARY KEY,
     name VARCHAR(100) NOT NULL,
     email VARCHAR(255) NOT NULL UNIQUE,
+    phone VARCHAR(40),
+    ssn VARCHAR(20),
+    tax_id VARCHAR(20),
+    credit_card VARCHAR(25),
+    iban VARCHAR(40),
+    city VARCHAR(80),
+    employer VARCHAR(120),
+    nationality VARCHAR(60),
+    bio TEXT,
+    notes TEXT,
+    metadata JSONB,
     created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
 );
 
@@ -37,10 +48,19 @@ CREATE TABLE post_tags (
 );
 
 -- Sample data: 3 users
-INSERT INTO users (name, email) VALUES
-    ('Alice Johnson', 'alice@example.com'),
-    ('Bob Smith', 'bob@example.com'),
-    ('Charlie Brown', 'charlie@example.com');
+INSERT INTO users (name, email, phone, ssn, tax_id, credit_card, iban, city, employer, nationality, bio, notes, metadata) VALUES
+    ('Alice Johnson', 'alice@example.com', '+14155552671', '078-05-1123', NULL, '4111111111111111', 'GB82WEST12345698765432', 'San Francisco', 'Acme Corporation', 'American',
+     'Alice Johnson is a software engineer from San Francisco who works at Acme Corporation. An American citizen, she frequently visits the Golden Gate Bridge. Call her at +14155552671 or email alice@example.com.',
+     'Customer Alice paid with card 4111111111111111. SSN on file 078-05-1123. Refund IBAN GB82WEST12345698765432. Callback phone +14155552671.',
+     '{"contact":{"name":"Alice Johnson","email":"alice@example.com","phone":"+14155552671"},"address":{"city":"San Francisco","country":"USA"}}'),
+    ('Bob Smith', 'bob@example.com', '+44 20 7946 0958', NULL, NULL, '5555555555554444', 'BE62510007547061', 'London', 'Siemens', 'British',
+     'Bob Smith, a British national, lives in London and is employed at Siemens. He often meets clients at the British Museum. Reach Bob at bob@example.com; phone +44 20 7946 0958.',
+     'Bob Smith called from phone +44 20 7946 0958 about a refund. Card 5555555555554444. No SSN on file.',
+     '{"contact":{"name":"Bob Smith","email":"bob@example.com","phone":"+44 20 7946 0958"},"address":{"city":"London","country":"United Kingdom"}}'),
+    ('Charlie Brown', 'charlie@example.com', '+49 30 12345678', NULL, '12345678903', '371449635398431', 'DE89370400440532013000', 'Berlin', 'Deutsche Bank', 'German',
+     'Charlie Brown grew up in Berlin and works as an analyst at Deutsche Bank. A German citizen, Charlie volunteers at the Red Cross and often walks past the Brandenburg Gate. Email charlie@example.com or call +49 30 12345678.',
+     'Charlie Brown German tax ID 12345678903. Paid via Amex card 371449635398431. IBAN DE89370400440532013000.',
+     '{"contact":{"name":"Charlie Brown","email":"charlie@example.com","phone":"+49 30 12345678"},"address":{"city":"Berlin","country":"Germany"},"taxId":"12345678903"}');
 
 -- Sample data: 5 posts
 INSERT INTO posts (user_id, title, body, published) VALUES

--- a/tests/seed/sqlite.sql
+++ b/tests/seed/sqlite.sql
@@ -4,6 +4,17 @@ CREATE TABLE IF NOT EXISTS users (
     id INTEGER PRIMARY KEY AUTOINCREMENT,
     name VARCHAR(100) NOT NULL,
     email VARCHAR(255) NOT NULL UNIQUE,
+    phone VARCHAR(40),
+    ssn VARCHAR(20),
+    tax_id VARCHAR(20),
+    credit_card VARCHAR(25),
+    iban VARCHAR(40),
+    city VARCHAR(80),
+    employer VARCHAR(120),
+    nationality VARCHAR(60),
+    bio TEXT,
+    notes TEXT,
+    metadata TEXT,
     created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
 );
 
@@ -43,10 +54,19 @@ CREATE TABLE IF NOT EXISTS lookup_codes (
 CREATE VIRTUAL TABLE IF NOT EXISTS posts_fts USING fts5(title, body);
 
 -- Sample data: 3 users
-INSERT INTO users (name, email) VALUES
-    ('Alice Johnson', 'alice@example.com'),
-    ('Bob Smith', 'bob@example.com'),
-    ('Charlie Brown', 'charlie@example.com');
+INSERT INTO users (name, email, phone, ssn, tax_id, credit_card, iban, city, employer, nationality, bio, notes, metadata) VALUES
+    ('Alice Johnson', 'alice@example.com', '+14155552671', '078-05-1123', NULL, '4111111111111111', 'GB82WEST12345698765432', 'San Francisco', 'Acme Corporation', 'American',
+     'Alice Johnson is a software engineer from San Francisco who works at Acme Corporation. An American citizen, she frequently visits the Golden Gate Bridge. Call her at +14155552671 or email alice@example.com.',
+     'Customer Alice paid with card 4111111111111111. SSN on file 078-05-1123. Refund IBAN GB82WEST12345698765432. Callback phone +14155552671.',
+     '{"contact":{"name":"Alice Johnson","email":"alice@example.com","phone":"+14155552671"},"address":{"city":"San Francisco","country":"USA"}}'),
+    ('Bob Smith', 'bob@example.com', '+44 20 7946 0958', NULL, NULL, '5555555555554444', 'BE62510007547061', 'London', 'Siemens', 'British',
+     'Bob Smith, a British national, lives in London and is employed at Siemens. He often meets clients at the British Museum. Reach Bob at bob@example.com; phone +44 20 7946 0958.',
+     'Bob Smith called from phone +44 20 7946 0958 about a refund. Card 5555555555554444. No SSN on file.',
+     '{"contact":{"name":"Bob Smith","email":"bob@example.com","phone":"+44 20 7946 0958"},"address":{"city":"London","country":"United Kingdom"}}'),
+    ('Charlie Brown', 'charlie@example.com', '+49 30 12345678', NULL, '12345678903', '371449635398431', 'DE89370400440532013000', 'Berlin', 'Deutsche Bank', 'German',
+     'Charlie Brown grew up in Berlin and works as an analyst at Deutsche Bank. A German citizen, Charlie volunteers at the Red Cross and often walks past the Brandenburg Gate. Email charlie@example.com or call +49 30 12345678.',
+     'Charlie Brown German tax ID 12345678903. Paid via Amex card 371449635398431. IBAN DE89370400440532013000.',
+     '{"contact":{"name":"Charlie Brown","email":"charlie@example.com","phone":"+49 30 12345678"},"address":{"city":"Berlin","country":"Germany"},"taxId":"12345678903"}');
 
 -- Sample data: 5 posts
 INSERT INTO posts (user_id, title, body, published) VALUES


### PR DESCRIPTION
## Summary

Adds PII/NER manual-testing fixtures to the `users` table across all three backend seed files (`tests/seed/{mysql,postgres,sqlite}.sql`).

## Changes

- New columns: `phone`, `ssn`, `tax_id`, `credit_card`, `iban`, `city`, `employer`, `nationality`, `bio`, `notes`, `metadata`
- Three fixture rows (Alice/US, Bob/UK, Charlie/DE) with realistic PII spread across regex-recognized fields (card/SSN/IBAN/email/phone) and NER targets (person/location/org) in free-text `bio`/`notes`
- `metadata` is JSON/JSONB on MySQL/PostgreSQL (exercises key-preserving structured walk) and TEXT on SQLite (single-string path)

## Notes

- Test-fixture data only; no production code touched
- NER model (`models/`) is gitignored, not part of this change