### PR TITLE
docs(pii): add local NER model setup guide

### DIFF
--- a/crates/pii/README.md
+++ b/crates/pii/README.md
@@ -5,15 +5,16 @@
 [![CI](https://github.com/haymon-ai/dbmcp/actions/workflows/ci.yml/badge.svg)](https://github.com/haymon-ai/dbmcp/actions/workflows/ci.yml)
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](https://github.com/haymon-ai/dbmcp/blob/master/LICENSE)
 
-Fast, zero-dependency PII detection and anonymisation for Rust. No NLP. No LLM. No network calls. Built for [dbmcp](https://dbmcp.haymon.ai) — the single-binary MCP server for MySQL, MariaDB, PostgreSQL, and SQLite.
+Fast PII detection and anonymisation for Rust. A zero-dependency regex/checksum core, plus an **optional** local ONNX NER pass for free-form names, places, and organizations. No network calls. Built for [dbmcp](https://dbmcp.haymon.ai) — the single-binary MCP server for MySQL, MariaDB, PostgreSQL, and SQLite.
 
 ## What you get
 
-- 32 built-in entity types across 7 categories (`Personal`, `Financial`, `Government`, `Contact`, `Network`, `DigitalIdentity`, `Crypto`)
+- 46 built-in entity types across 7 categories (`Personal`, `Financial`, `Government`, `Contact`, `Network`, `DigitalIdentity`, `Crypto`)
 - Checksum-validated matches where it matters (Luhn, mod-97 IBAN, NHS mod-11, bech32, base58-check, German Steuer-ID, US SSN rules)
 - Four anonymisation operators — `replace`, `mask`, `redact`, `hash` (SHA-256, optional HMAC key)
 - Category-scoped analyser builder for tailored recogniser subsets
 - JSON-safe: walks every string leaf at any depth, object keys preserved
-- Pure Rust regex + checksums — zero runtime dependencies, fully auditable
+- Pure-Rust regex + checksum core — zero runtime dependencies, fully auditable
+- **Optional** ML/NER pass — detects free-form `PERSON`, `LOCATION`, and `ORGANIZATION` spans that regex can't; off by default, local ONNX inference, no network
 
 See the main crate: **[dbmcp](https://dbmcp.haymon.ai)** · [Website](https://dbmcp.haymon.ai) · [Docs](https://dbmcp.haymon.ai/docs/)

--- a/crates/pii/src/lib.rs
+++ b/crates/pii/src/lib.rs
@@ -2,9 +2,11 @@
 //!
 //! Library-only crate. Regex/pattern recognition with optional checksum
 //! validation, plus four built-in operators (`Replace`, `Mask`, `Redact`,
-//! `Hash`). An ML/NER pass (person & location) is always compiled and
-//! enabled at runtime via `PiiConfig`; inference is pure-Rust with no
-//! network. Wired into the MCP server's query tool output via [`Redactor`].
+//! `Hash`). An optional ML/NER pass detects person, location, organization,
+//! NRP, and facility spans (which entities depend on the model's labels); it
+//! is always compiled and enabled at runtime via `PiiConfig`. Inference runs
+//! locally via ONNX Runtime with no network. Wired into the MCP server's
+//! query tool output via [`Redactor`].
 //!
 //! # Quickstart
 //!

--- a/crates/pii/tests/ner.rs
+++ b/crates/pii/tests/ner.rs
@@ -3,14 +3,25 @@
 //! Skips unless `PII_NER_TEST_MODEL` points at a model directory
 //! (`tokenizer.json`, `config.json`, `model.onnx`). Inference uses a
 //! statically-linked ONNX Runtime; no external library to install.
+//!
+//! The NRP and facility tests additionally skip when the model's labels do
+//! not expose them, so a `CoNLL` model (person/location/organization, e.g.
+//! `optimum/bert-base-NER`) leaves the suite green; an `OntoNotes`-class model
+//! exercises all five entities.
 
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 
 use dbmcp_pii::{Entity, NerEngine, Score};
 
 /// Returns the configured model directory, or `None` to skip the test.
 fn model_dir() -> Option<PathBuf> {
     std::env::var_os("PII_NER_TEST_MODEL").map(PathBuf::from)
+}
+
+/// Returns `true` when `config.json` declares a label containing any needle.
+fn model_exposes_label(dir: &Path, needles: &[&str]) -> bool {
+    let config = std::fs::read_to_string(dir.join("config.json")).unwrap_or_default();
+    needles.iter().any(|needle| config.contains(needle))
 }
 
 #[test]
@@ -66,6 +77,10 @@ fn detects_nrp_span() {
         return;
     };
     // Requires an OntoNotes-class model exposing the NORP label.
+    if !model_exposes_label(&dir, &["NORP", "NRP"]) {
+        eprintln!("model exposes no NORP/NRP label; skipping NRP NER test");
+        return;
+    }
     let engine = NerEngine::load(&dir, Score::from_static(0.5)).expect("model loads");
     let out = engine
         .analyze("The committee was mostly French and Catholic")
@@ -83,6 +98,10 @@ fn detects_facility_span() {
         return;
     };
     // Requires an OntoNotes-class model exposing the FAC label.
+    if !model_exposes_label(&dir, &["FAC"]) {
+        eprintln!("model exposes no FAC label; skipping facility NER test");
+        return;
+    }
     let engine = NerEngine::load(&dir, Score::from_static(0.5)).expect("model loads");
     let out = engine
         .analyze("They landed at Heathrow Airport at noon")

--- a/docs/content/docs/configuration.mdx
+++ b/docs/content/docs/configuration.mdx
@@ -126,18 +126,48 @@ The regex/checksum recognisers cannot catch free-form **person names**, **place 
 
 It is **opt-in at runtime**: the ML/NER code is always built into the binary, but stays inactive until both `--pii` and `--pii-ner` are enabled and a model directory is supplied.
 
+Inference uses **ONNX Runtime** — there is **no external runtime library** to install: you need only the `dbmcp` binary and a model directory. The directory must contain:
+
+- `config.json` (with an `id2label` map exposing at least one supported NER label: `PER`/`PERSON`, `LOC`/`GPE`, `ORG`/`ORGANIZATION`, `NORP`/`NRP`, or `FAC`)
+- `tokenizer.json`
+- `model.onnx`
+
+Any other files in the directory are ignored — `dbmcp` reads only these three.
+
+#### Set up a model locally
+
+The quickest path is to download a model that has already been exported to ONNX. The steps below use the recommended English model, [`optimum/bert-base-NER`](https://huggingface.co/optimum/bert-base-NER) — an ONNX export of `dslim/bert-base-NER` (MIT licensed). It uses CoNLL labels, so it detects `PERSON`, `LOCATION`, and `ORGANIZATION`; [`protectai/bert-base-NER-onnx`](https://huggingface.co/protectai/bert-base-NER-onnx) is an equivalent alternative. NRP and facility detection require an OntoNotes-class model. v1 is English-only, but the pipeline is model-agnostic — any directory with the three files above works.
+
+> **Note:** These pre-exported models are full-precision (fp32, ~430 MB). They need no Python toolchain to obtain, but an int8-quantized export is smaller and faster at inference if you can produce one.
+
+**1. Download the model into a local directory** — either with the Hugging Face CLI (`pip install huggingface_hub`):
+
+```bash
+hf download optimum/bert-base-NER --local-dir ./models/bert-ner
+```
+
+or with `git` + Git LFS (the `model.onnx` weights are LFS-tracked):
+
+```bash
+git lfs install
+git clone https://huggingface.co/optimum/bert-base-NER ./models/bert-ner
+```
+
+**2. Confirm the required files are present:**
+
+```bash
+ls ./models/bert-ner
+# config.json  model.onnx  tokenizer.json  (plus vocab.txt, tokenizer_config.json, … — ignored)
+```
+
+**3. Start `dbmcp` with the NER pass enabled, pointing at the directory:**
+
 ```bash
 dbmcp stdio --db-backend sqlite --db-name app.db \
   --pii true --pii-ner true --pii-ner-model ./models/bert-ner
 ```
 
-Inference uses **ONNX Runtime** — there is **no external runtime library** to install: the customer needs only the binary and a model directory. The directory must contain:
-
-- `config.json` (with an `id2label` map exposing at least one supported NER label: `PER`/`PERSON`, `LOC`/`GPE`, `ORG`/`ORGANIZATION`, `NORP`/`NRP`, or `FAC`)
-- `tokenizer.json`
-- `model.onnx` (an int8-quantized export keeps inference fast)
-
-The recommended English model is [`dslim/bert-base-NER`](https://huggingface.co/dslim/bert-base-NER) (MIT licensed; `dslim/distilbert-NER` is a smaller/faster variant), exported to ONNX. v1 is English-only; the pipeline is model-agnostic, so a different-language model can be supplied.
+**4. Verify it loaded.** Loading is **fail-closed**: a missing file or an unusable model makes the server refuse to start, so a clean startup means the model loaded. To confirm the pass is rewriting output, run a `readQuery` over a column holding a person or place name and check the value comes back as `<PERSON>` / `<LOCATION>` (with the default `replace` operator).
 
 Behaviour notes:
 


### PR DESCRIPTION
## What

Adds a step-by-step guide for getting the optional ML/NER PII pass running locally, and fixes doc claims that predated the NER feature.

### Docs
- **`docs/content/docs/configuration.mdx`** — expands the `### ML/NER pass` section with a `#### Set up a model locally` walkthrough: pick a pre-exported ONNX model (`optimum/bert-base-NER`, MIT, CoNLL → person/location/organization), download it (`hf download` or git-lfs clone), confirm the dir holds `config.json` / `tokenizer.json` / `model.onnx`, run `dbmcp`, verify.
- **`crates/pii/README.md`** — drops the now-false `No NLP. No LLM.` tagline, `32` → `46` entity types, adds an optional-ONNX-NER bullet.
- **`crates/pii/src/lib.rs`** — module doc: `person & location` → full entity set; `pure-Rust` → local ONNX Runtime inference.

### Test fix
- **`crates/pii/tests/ner.rs`** — gates the NRP and facility integration tests to skip when the model's labels don't expose them. The documented CoNLL model now leaves the suite green; an OntoNotes-class model still exercises all five entities.

## Verification
- `cargo fmt --check`, `cargo clippy -p dbmcp-pii --tests -- -D warnings` — clean.
- End-to-end: downloaded `optimum/bert-base-NER`, ran `cargo test -p dbmcp-pii --test ner` — person/location/organization detected at 0.998; NRP/facility skip as designed for a CoNLL model.
- Skip gates verified green against a CoNLL `config.json`.

Pre-existing untracked `FINDINGS.md` left out of scope.