### PR TITLE
chore(deps): bump tokenizers to 0.23, drop unused deps

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -664,6 +664,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "daachorse"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6f55d7153ba3b507595872a3874803f07a8a81d1e888abed8e5db7da0597d6e2"
+
+[[package]]
 name = "darling"
 version = "0.20.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -749,10 +755,8 @@ dependencies = [
  "clap",
  "dbmcp-config",
  "dbmcp-mysql",
- "dbmcp-pii",
  "dbmcp-postgres",
  "dbmcp-server",
- "dbmcp-sql",
  "dbmcp-sqlite",
  "indexmap",
  "insta",
@@ -1049,9 +1053,9 @@ dependencies = [
 
 [[package]]
 name = "fancy-regex"
-version = "0.14.0"
+version = "0.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6e24cb5a94bcae1e5408b0effca5cd7172ea3c5755049c5f3af4cd283a165298"
+checksum = "72cf461f865c862bb7dc573f643dd6a2b6842f7c30b07882b56bd148cc2761b8"
 dependencies = [
  "bit-set",
  "regex-automata",
@@ -3433,17 +3437,17 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokenizers"
-version = "0.22.2"
+version = "0.23.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b238e22d44a15349529690fb07bd645cf58149a1b1e44d6cb5bd1641ff1a6223"
+checksum = "44e5bea67576e04b6ff8564c5d9e09c2ef0cf476502245f2f120e497769d3112"
 dependencies = [
  "ahash",
- "aho-corasick",
  "compact_str",
+ "daachorse",
  "dary_heap",
  "derive_builder",
  "esaxx-rs",
- "fancy-regex 0.14.0",
+ "fancy-regex 0.17.0",
  "getrandom 0.3.4",
  "itertools 0.14.0",
  "log",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -39,7 +39,6 @@ bigdecimal = "0.4"
 bs58 = { version = "0.5", features = ["check"] }
 clap = { version = "4", features = ["derive", "env"] }
 fancy-regex = "0.18"
-hmac = "0.12"
 indexmap = { version = "2", features = ["serde"] }
 mimalloc = "0.1"
 moka = { version = "0.12", features = ["future"] }
@@ -59,7 +58,7 @@ sha2 = "0.11"
 sqlparser = { version = "0.62", features = ["visitor"] }
 sqlx = { version = "0.8", features = ["runtime-tokio-rustls"] }
 thiserror = "2"
-tokenizers = { version = "0.22", default-features = false, features = ["fancy-regex"] }
+tokenizers = { version = "0.23", default-features = false, features = ["fancy-regex"] }
 tokio = { version = "1", features = ["full"] }
 tokio-util = { version = "0.7", features = ["rt"] }
 toml = "1"
@@ -113,8 +112,6 @@ tracing = { workspace = true }
 tracing-subscriber = { workspace = true }
 
 [dev-dependencies]
-dbmcp-pii = { workspace = true }
-dbmcp-sql = { workspace = true }
 indexmap = { workspace = true }
 insta = { workspace = true }
 rmcp = { workspace = true, features = ["client"] }

--- a/crates/pii/README.md
+++ b/crates/pii/README.md
@@ -5,16 +5,16 @@
 [![CI](https://github.com/haymon-ai/dbmcp/actions/workflows/ci.yml/badge.svg)](https://github.com/haymon-ai/dbmcp/actions/workflows/ci.yml)
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](https://github.com/haymon-ai/dbmcp/blob/master/LICENSE)
 
-Fast PII detection and anonymisation for Rust. A zero-dependency regex/checksum core, plus an **optional** local ONNX NER pass for free-form names, places, and organizations. No network calls. Built for [dbmcp](https://dbmcp.haymon.ai) — the single-binary MCP server for MySQL, MariaDB, PostgreSQL, and SQLite.
+Fast PII detection and anonymisation for Rust. A zero-dependency regex/checksum core, plus an **optional** local ONNX NER pass for free-form names, places, organizations, groups, and facilities. No network calls. Built for [dbmcp](https://dbmcp.haymon.ai) — the single-binary MCP server for MySQL, MariaDB, PostgreSQL, and SQLite.
 
 ## What you get
 
 - 46 built-in entity types across 7 categories (`Personal`, `Financial`, `Government`, `Contact`, `Network`, `DigitalIdentity`, `Crypto`)
 - Checksum-validated matches where it matters (Luhn, mod-97 IBAN, NHS mod-11, bech32, base58-check, German Steuer-ID, US SSN rules)
-- Four anonymisation operators — `replace`, `mask`, `redact`, `hash` (SHA-256, optional HMAC key)
+- Four anonymisation operators — `replace`, `mask`, `redact`, `hash` (SHA-256 / SHA-512)
 - Category-scoped analyser builder for tailored recogniser subsets
 - JSON-safe: walks every string leaf at any depth, object keys preserved
 - Pure-Rust regex + checksum core — zero runtime dependencies, fully auditable
-- **Optional** ML/NER pass — detects free-form `PERSON`, `LOCATION`, and `ORGANIZATION` spans that regex can't; off by default, local ONNX inference, no network
+- **Optional** ML/NER pass — detects free-form `PERSON`, `LOCATION`, `ORGANIZATION`, `NATIONALITY_RELIGION_POLITICS`, and `FACILITY` spans that regex can't; off by default, local ONNX inference, no network
 
 See the main crate: **[dbmcp](https://dbmcp.haymon.ai)** · [Website](https://dbmcp.haymon.ai) · [Docs](https://dbmcp.haymon.ai/docs/)


### PR DESCRIPTION
## Summary

- **Bump `tokenizers` 0.22 → 0.23** (resolves to 0.23.1). Used only by the PII NER pass; the Rust API surface in `crates/pii/src/ner.rs` is unchanged, so no source edits were needed.
- **Drop unused `hmac` workspace dependency** — no workspace crate referenced it and no source used it (only the vendored `references/` repos, which are not workspace members).
- **Drop unused root dev-dependencies `dbmcp-pii` and `dbmcp-sql`** — the root crate's integration tests reference neither.
- **docs(pii):** expand the NER entity list in the README (add `NATIONALITY_RELIGION_POLITICS` and `FACILITY` to match `ner.rs` `NER_ENTITIES`) and fix a stale hash-operator claim (`hash` is a bare SHA-256 / SHA-512 digest — no HMAC support exists).

## Notes

- The tokenizers `fancy-regex` feature is **kept**: with `default-features = false` it is the only enabled regex backend, and dropping it trips the crate's `compile_error!("One of the \`onig\`, or \`fancy-regex\` features must be enabled")` gate. The alternative (`onig`) would pull an oniguruma C dependency.
- The `RUSTSEC-2024-0436` (paste, unmaintained) ignore in `.cargo/audit.toml` is **kept**: tokenizers 0.23 still pulls `paste` via `macro_rules_attribute`, so the path the comment documents still holds.

## Verification

- `cargo build` ✅
- `cargo clippy --workspace --tests -- -D warnings` ✅
- `cargo test --workspace --lib --bins` ✅ (all binaries, 0 failed)
- `cargo fmt --check` ✅
- `cargo audit` ✅ (no new advisories)

Docker integration tests (`./tests/run.sh`) not run — pure dependency/docs change with no SQL-path impact.