### PR TITLE
chore(registry): sync server.json and Dockerfile with current CLI

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,7 +12,7 @@ RUN ARCH=$([ "$TARGETARCH" = "arm64" ] && echo "aarch64-unknown-linux-gnu" || ec
 FROM gcr.io/distroless/cc-debian12
 
 LABEL org.opencontainers.image.title="dbmcp" \
-      org.opencontainers.image.description="Database MCP server for MySQL, MariaDB, PostgreSQL & SQLite" \
+      org.opencontainers.image.description="Database MCP server for MySQL, MariaDB, PostgreSQL & SQLite with PII redaction and write-prevention" \
       org.opencontainers.image.licenses="MIT" \
       org.opencontainers.image.source="https://github.com/haymon-ai/dbmcp" \
       io.modelcontextprotocol.server.name="ai.haymon/dbmcp"

--- a/server.json
+++ b/server.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
   "name": "ai.haymon/dbmcp",
-  "description": "Database MCP server for MySQL, MariaDB, PostgreSQL & SQLite",
+  "description": "Database MCP server for MySQL, MariaDB, PostgreSQL & SQLite with PII redaction and write-prevention",
   "version": "0.12.1",
   "websiteUrl": "https://dbmcp.haymon.ai",
   "repository": {
@@ -149,7 +149,8 @@
     {
       "type": "named",
       "name": "--db-ssl-verify-cert",
-      "description": "Verify server certificate"
+      "description": "Verify server certificate",
+      "default": "true"
     },
     {
       "type": "named",
@@ -173,6 +174,41 @@
       "name": "--db-query-timeout",
       "description": "Query execution timeout in seconds",
       "default": "30"
+    },
+    {
+      "type": "named",
+      "name": "--db-page-size",
+      "description": "Maximum items returned in a single paginated tool response (1-500)",
+      "default": "100"
+    },
+    {
+      "type": "named",
+      "name": "--pii",
+      "description": "Enable PII redaction of query tool output",
+      "default": "false"
+    },
+    {
+      "type": "named",
+      "name": "--pii-operator",
+      "description": "Operator applied to detected PII spans",
+      "default": "replace",
+      "choices": ["replace", "mask", "redact", "hash"]
+    },
+    {
+      "type": "named",
+      "name": "--pii-categories",
+      "description": "Comma-separated PII categories to detect (default: all). Values: personal, financial, government, contact, network, digital-identity, crypto"
+    },
+    {
+      "type": "named",
+      "name": "--pii-ner",
+      "description": "Enable the optional ML/NER pass (person & location detection)",
+      "default": "false"
+    },
+    {
+      "type": "named",
+      "name": "--pii-ner-model",
+      "description": "Path to the NER model directory (required with --pii-ner)"
     },
     {
       "type": "named",
@@ -238,7 +274,7 @@
       "name": "DB_SSL_VERIFY_CERT",
       "description": "Verify server certificate",
       "format": "boolean",
-      "default": "false"
+      "default": "true"
     },
     {
       "name": "DB_READ_ONLY",
@@ -262,6 +298,39 @@
       "description": "Query execution timeout in seconds",
       "format": "number",
       "default": "30"
+    },
+    {
+      "name": "DB_PAGE_SIZE",
+      "description": "Maximum items returned in a single paginated tool response (1-500)",
+      "format": "number",
+      "default": "100"
+    },
+    {
+      "name": "PII_ENABLE",
+      "description": "Enable PII redaction of query tool output",
+      "format": "boolean",
+      "default": "false"
+    },
+    {
+      "name": "PII_OPERATOR",
+      "description": "Operator applied to detected PII spans",
+      "default": "replace",
+      "choices": ["replace", "mask", "redact", "hash"]
+    },
+    {
+      "name": "PII_CATEGORIES",
+      "description": "Comma-separated PII categories to detect (default: all). Values: personal, financial, government, contact, network, digital-identity, crypto"
+    },
+    {
+      "name": "PII_NER_ENABLE",
+      "description": "Enable the optional ML/NER pass (person & location detection)",
+      "format": "boolean",
+      "default": "false"
+    },
+    {
+      "name": "PII_NER_MODEL",
+      "description": "Path to the NER model directory (required with PII_NER_ENABLE=true)",
+      "format": "filepath"
     },
     {
       "name": "LOG_LEVEL",


### PR DESCRIPTION
## Context

`server.json` (MCP registry manifest) and the Dockerfile OCI description label drifted behind recent master work — PII redaction (`crates/pii`), the optional ONNX/NER pass, and the `--db-page-size` pagination flag were not reflected. The manifest also carried a stale value: `DB_SSL_VERIFY_CERT` was documented as defaulting to `false`, but the code default is `true` (`crates/config/src/database.rs` `DEFAULT_SSL_VERIFY_CERT = true`).

## Changes

**`server.json`**
- Tagline → `... with PII redaction and write-prevention`.
- Added `packageArguments` + `environmentVariables`: `--db-page-size`/`DB_PAGE_SIZE`, `--pii`/`PII_ENABLE`, `--pii-operator`/`PII_OPERATOR` (choices replace/mask/redact/hash), `--pii-categories`/`PII_CATEGORIES`, `--pii-ner`/`PII_NER_ENABLE`, `--pii-ner-model`/`PII_NER_MODEL`.
- Fixed `DB_SSL_VERIFY_CERT` default `false` → `true` (env + flag entries).

**`Dockerfile`**
- `org.opencontainers.image.description` label → same new tagline. No runtime change: ONNX Runtime is statically linked via `ort` `download-binaries`, so distroless stays valid.

Version unchanged (`0.12.1`). Manifest/label only — no code changes.

## Verification

- `python3 -m json.tool server.json` — valid JSON.
- Every flag/env/default cross-checked against `src/commands/common.rs` and `crates/config/src/database.rs`.
- `docker build --build-arg VERSION=v0.12.1 .` succeeds; built image label confirmed via `docker inspect`; binary `--help` runs.

> Note: `docker build` requires `--build-arg VERSION=v<x.y.z>` — the default `VERSION=latest` 404s (no `latest` release tag). Pre-existing, out of scope for this PR.