### PR TITLE
docs(pii): improve NER model download instructions

### DIFF
--- a/docs/content/docs/configuration.mdx
+++ b/docs/content/docs/configuration.mdx
@@ -157,6 +157,8 @@ git lfs install
 git clone https://huggingface.co/optimum/bert-base-NER ./models/bert-ner
 ```
 
+or manually from the browser — open the model's [**Files and versions**](https://huggingface.co/optimum/bert-base-NER/tree/main) tab on Hugging Face and download `config.json`, `tokenizer.json`, and `model.onnx` with the download icon next to each, saving all three into one directory (e.g. `./models/bert-ner`).
+
 **2. Confirm the required files are present:**
 
 ```bash

--- a/docs/content/docs/configuration.mdx
+++ b/docs/content/docs/configuration.mdx
@@ -143,8 +143,12 @@ The quickest path is to download a model that has already been exported to ONNX.
 **1. Download the model into a local directory** — either with the Hugging Face CLI (`pip install huggingface_hub`):
 
 ```bash
-hf download optimum/bert-base-NER --local-dir ./models/bert-ner
+hf download optimum/bert-base-NER \
+  --include config.json tokenizer.json model.onnx \
+  --local-dir ./models/bert-ner
 ```
+
+`--include` fetches only the three required files and skips the rest.
 
 or with `git` + Git LFS (the `model.onnx` weights are LFS-tracked):
 


### PR DESCRIPTION
Improves the NER model download instructions in the setup guide so users can fetch only what the pipeline needs, with or without a toolchain.

## Changes
`docs/content/docs/configuration.mdx` — step *Download the model into a local directory*:
- The `hf download` example now passes `--include config.json tokenizer.json model.onnx` so only the three files the pipeline reads are downloaded, skipping the unused fp32 extras (`vocab.txt`, `tokenizer_config.json`, …).
- Added a third option: download the three files manually from the model's **Files and versions** tab in the browser — no `huggingface_hub` or `git-lfs` toolchain required.

The guide now covers three paths (HF CLI / git + LFS / browser), all landing the files in one directory.