### PR TITLE
chore(deps): upgrade sqlx 0.8 to 0.9

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -222,6 +222,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "base16ct"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fd307490d624467aa6f74b0eabb77633d1f758a7b25f12bceb0b22e08d9726f6"
+
+[[package]]
 name = "base64"
 version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -450,6 +456,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
+name = "cmov"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f88a43d011fc4a6876cb7344703e297c71dda42494fee094d5f7c76bf13f746"
+
+[[package]]
 name = "colorchoice"
 version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -492,12 +504,6 @@ dependencies = [
 
 [[package]]
 name = "const-oid"
-version = "0.9.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c2459377285ad874054d797f3ccebf984978aa39129f6eafde5cdc8315b612f8"
-
-[[package]]
-name = "const-oid"
 version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a6ef517f0926dd24a1582492c791b6a4818a4d94e789a334894aa15b0d12f55c"
@@ -517,6 +523,12 @@ name = "core-foundation-sys"
 version = "0.8.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
+
+[[package]]
+name = "cpubits"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "15b85f9c39137c3a891689859392b1bd49812121d0d61c9caf00d46ed5ce06ae"
 
 [[package]]
 name = "cpufeatures"
@@ -645,6 +657,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "460fbee9c2c2f33933d720630a6a0bac33ba7053db5344fac858d4b8952d77d5"
 
 [[package]]
+name = "crypto-bigint"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42a0d26b245348befa0c121944541476763dcc46ede886c88f9d12e1697d27c3"
+dependencies = [
+ "cpubits",
+ "ctutils",
+ "num-traits",
+ "rand_core 0.10.1",
+ "serdect",
+ "zeroize",
+]
+
+[[package]]
 name = "crypto-common"
 version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -661,6 +687,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77727bb15fa921304124b128af125e7e3b968275d1b108b379190264f4423710"
 dependencies = [
  "hybrid-array",
+]
+
+[[package]]
+name = "crypto-primes"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "21f41f23de7d24cdbda7f0c4d9c0351f99a4ceb258ef30e5c1927af8987ffe5a"
+dependencies = [
+ "crypto-bigint",
+ "libm",
+ "rand_core 0.10.1",
+]
+
+[[package]]
+name = "ctutils"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7d5515a3834141de9eafb9717ad39eea8247b5674e6066c404e8c4b365d2a29e"
+dependencies = [
+ "cmov",
 ]
 
 [[package]]
@@ -886,22 +932,12 @@ dependencies = [
 
 [[package]]
 name = "der"
-version = "0.7.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e7c1832837b905bbfb5101e07cc24c8deddf52f93225eee6ead5f4d63d53ddcb"
-dependencies = [
- "const-oid 0.9.6",
- "pem-rfc7468 0.7.0",
- "zeroize",
-]
-
-[[package]]
-name = "der"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "71fd89660b2dc699704064e59e9dba0147b903e85319429e131620d022be411b"
 dependencies = [
- "pem-rfc7468 1.0.0",
+ "const-oid",
+ "pem-rfc7468",
  "zeroize",
 ]
 
@@ -943,9 +979,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
 dependencies = [
  "block-buffer 0.10.4",
- "const-oid 0.9.6",
  "crypto-common 0.1.7",
- "subtle",
 ]
 
 [[package]]
@@ -955,8 +989,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f1dd6dbb5841937940781866fa1281a1ff7bd3bf827091440879f9994983d5c2"
 dependencies = [
  "block-buffer 0.12.0",
- "const-oid 0.10.2",
+ "const-oid",
  "crypto-common 0.2.1",
+ "ctutils",
 ]
 
 [[package]]
@@ -1021,13 +1056,12 @@ checksum = "d817e038c30374a4bcb22f94d0a8a0e216958d4c3dcde369b1439fec4bdda6e6"
 
 [[package]]
 name = "etcetera"
-version = "0.8.0"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "136d1b5283a1ab77bd9257427ffd09d8667ced0570b6f938942bc7568ed5b943"
+checksum = "de48cc4d1c1d97a20fd819def54b890cadde72ed3ad0c614822a0a433361be96"
 dependencies = [
  "cfg-if",
- "home",
- "windows-sys 0.48.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1107,9 +1141,9 @@ dependencies = [
 
 [[package]]
 name = "flume"
-version = "0.11.1"
+version = "0.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "da0e4dd2a88388a1f4ccc7c9ce104604dab68d9f408dc34cd45823d5a9069095"
+checksum = "5e139bc46ca777eb5efaf62df0ab8cc5fd400866427e56c68b22e414e53bd3be"
 dependencies = [
  "futures-core",
  "futures-sink",
@@ -1127,6 +1161,12 @@ name = "foldhash"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
+
+[[package]]
+name = "foldhash"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77ce24cb58228fbb8aa041425bb1050850ac19177686ea6e0f41a70416f56fdb"
 
 [[package]]
 name = "foreign-types"
@@ -1315,9 +1355,18 @@ version = "0.15.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
 dependencies = [
+ "foldhash 0.1.5",
+]
+
+[[package]]
+name = "hashbrown"
+version = "0.16.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "841d1cc9bed7f9236f321df977030373f4a4163ae1a7dbfe1a51a2c1a51d9100"
+dependencies = [
  "allocator-api2",
  "equivalent",
- "foldhash",
+ "foldhash 0.2.0",
 ]
 
 [[package]]
@@ -1328,11 +1377,11 @@ checksum = "4f467dd6dccf739c208452f8014c75c18bb8301b050ad1cfb27153803edb0f51"
 
 [[package]]
 name = "hashlink"
-version = "0.10.0"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7382cf6263419f2d8df38c55d7da83da5c18aef87fc7a7fc1fb1e344edfe14c1"
+checksum = "ea0b22561a9c04a7cb1a302c013e0259cd3b4bb619f145b32f72b8b4bcbed230"
 dependencies = [
- "hashbrown 0.15.5",
+ "hashbrown 0.16.1",
 ]
 
 [[package]]
@@ -1349,29 +1398,20 @@ checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
 
 [[package]]
 name = "hkdf"
-version = "0.12.4"
+version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7b5f8eb2ad728638ea2c7d47a21db23b7b58a72ed6a38256b8a1849f15fbbdf7"
+checksum = "4aaa26c720c68b866f2c96ef5c1264b3e6f473fe5d4ce61cd44bbe913e553018"
 dependencies = [
  "hmac",
 ]
 
 [[package]]
 name = "hmac"
-version = "0.12.1"
+version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6c49c37c09c17a53d937dfbb742eb3a961d65a994e6bcdcf37e7399d0cc8ab5e"
+checksum = "6303bc9732ae41b04cb554b844a762b4115a61bfaa81e3e83050991eeb56863f"
 dependencies = [
- "digest 0.10.7",
-]
-
-[[package]]
-name = "home"
-version = "0.5.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cc627f471c528ff0c4a49e1d5e60450c8f6461dd6d10ba9dcd3a61d3dff7728d"
-dependencies = [
- "windows-sys 0.61.2",
+ "digest 0.11.3",
 ]
 
 [[package]]
@@ -1674,9 +1714,6 @@ name = "lazy_static"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
-dependencies = [
- "spin",
-]
 
 [[package]]
 name = "leb128fmt"
@@ -1703,18 +1740,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2d1eacfa31c33ec25e873c136ba5669f00f9866d0688bea7be4d3f7e43067df6"
 dependencies = [
  "cc",
-]
-
-[[package]]
-name = "libredox"
-version = "0.1.16"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e02f3bb43d335493c96bf3fd3a321600bf6bd07ed34bc64118e9293bdffea46c"
-dependencies = [
- "bitflags",
- "libc",
- "plain",
- "redox_syscall 0.7.4",
 ]
 
 [[package]]
@@ -1789,12 +1814,12 @@ dependencies = [
 
 [[package]]
 name = "md-5"
-version = "0.10.6"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d89e7ee0cfbedfc4da3340218492196241d89eefb6dab27de5df917a6d2e78cf"
+checksum = "69b6441f590336821bb897fb28fc622898ccceb1d6cea3fde5ea86b090c4de98"
 dependencies = [
  "cfg-if",
- "digest 0.10.7",
+ "digest 0.11.3",
 ]
 
 [[package]]
@@ -1949,22 +1974,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "num-bigint-dig"
-version = "0.8.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e661dda6640fad38e827a6d4a310ff4763082116fe217f279885c97f511bb0b7"
-dependencies = [
- "lazy_static",
- "libm",
- "num-integer",
- "num-iter",
- "num-traits",
- "rand 0.8.6",
- "smallvec 1.15.1",
- "zeroize",
-]
-
-[[package]]
 name = "num-complex"
 version = "0.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1983,24 +1992,12 @@ dependencies = [
 ]
 
 [[package]]
-name = "num-iter"
-version = "0.1.45"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1429034a0490724d0075ebb2bc9e875d6503c3cf69e235a8941aa757d83ef5bf"
-dependencies = [
- "autocfg",
- "num-integer",
- "num-traits",
-]
-
-[[package]]
 name = "num-traits"
 version = "0.2.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
 dependencies = [
  "autocfg",
- "libm",
 ]
 
 [[package]]
@@ -2132,7 +2129,7 @@ checksum = "2621685985a2ebf1c516881c026032ac7deafcda1a2c9b7850dc81e3dfcb64c1"
 dependencies = [
  "cfg-if",
  "libc",
- "redox_syscall 0.5.18",
+ "redox_syscall",
  "smallvec 1.15.1",
  "windows-link",
 ]
@@ -2148,15 +2145,6 @@ name = "pastey"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b867cad97c0791bbd3aaa6472142568c6c9e8f71937e98379f584cfb0cf35bec"
-
-[[package]]
-name = "pem-rfc7468"
-version = "0.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "88b39c9bfcfc231068454382784bb460aae594343fb030d46e9f50a645418412"
-dependencies = [
- "base64ct",
-]
 
 [[package]]
 name = "pem-rfc7468"
@@ -2224,22 +2212,21 @@ checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
 
 [[package]]
 name = "pkcs1"
-version = "0.7.5"
+version = "0.8.0-rc.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c8ffb9f10fa047879315e6625af03c164b16962a5368d724ed16323b68ace47f"
+checksum = "986d2e952779af96ea048f160fd9194e1751b4faea78bcf3ceb456efe008088e"
 dependencies = [
- "der 0.7.10",
- "pkcs8",
+ "der",
  "spki",
 ]
 
 [[package]]
 name = "pkcs8"
-version = "0.10.2"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f950b2377845cebe5cf8b5165cb3cc1a5e0fa5cfa3e1f7f55707d8fd82e0a7b7"
+checksum = "451913da69c775a56034ea8d9003d27ee8948e12443eae7c038ba100a4f21cb7"
 dependencies = [
- "der 0.7.10",
+ "der",
  "spki",
 ]
 
@@ -2248,12 +2235,6 @@ name = "pkg-config"
 version = "0.3.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "19f132c84eca552bf34cab8ec81f1c1dcc229b811638f9d283dceabe58c5569e"
-
-[[package]]
-name = "plain"
-version = "0.2.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b4596b6d070b27117e987119b4dac604f3c58cfb0b191112e24771b2faeac1a6"
 
 [[package]]
 name = "plotters"
@@ -2368,22 +2349,11 @@ checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
 
 [[package]]
 name = "rand"
-version = "0.8.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5ca0ecfa931c29007047d1bc58e623ab12e5590e8c7cc53200d5202b69266d8a"
-dependencies = [
- "libc",
- "rand_chacha 0.3.1",
- "rand_core 0.6.4",
-]
-
-[[package]]
-name = "rand"
 version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "44c5af06bb1b7d3216d91932aed5265164bf384dc89cd6ba05cf59a35f5f76ea"
 dependencies = [
- "rand_chacha 0.9.0",
+ "rand_chacha",
  "rand_core 0.9.5",
 ]
 
@@ -2400,31 +2370,12 @@ dependencies = [
 
 [[package]]
 name = "rand_chacha"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
-dependencies = [
- "ppv-lite86",
- "rand_core 0.6.4",
-]
-
-[[package]]
-name = "rand_chacha"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d3022b5f1df60f26e1ffddd6c66e8aa15de382ae63b3a0c1bfc0e4d3e3f325cb"
 dependencies = [
  "ppv-lite86",
  "rand_core 0.9.5",
-]
-
-[[package]]
-name = "rand_core"
-version = "0.6.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
-dependencies = [
- "getrandom 0.2.17",
 ]
 
 [[package]]
@@ -2504,15 +2455,6 @@ name = "redox_syscall"
 version = "0.5.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed2bf2547551a7053d6fdfafda3f938979645c44812fbfcda098faae3f1a362d"
-dependencies = [
- "bitflags",
-]
-
-[[package]]
-name = "redox_syscall"
-version = "0.7.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f450ad9c3b1da563fb6948a8e0fb0fb9269711c9c73d9ea1de5058c79c8d643a"
 dependencies = [
  "bitflags",
 ]
@@ -2626,21 +2568,19 @@ dependencies = [
 
 [[package]]
 name = "rsa"
-version = "0.9.10"
+version = "0.10.0-rc.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b8573f03f5883dcaebdfcf4725caa1ecb9c15b2ef50c43a07b816e06799bb12d"
+checksum = "30b2aa4ba0d89f73d1e332df05be0eeab8840351c36ca5654341dfdb57bb3caf"
 dependencies = [
- "const-oid 0.9.6",
- "digest 0.10.7",
- "num-bigint-dig",
- "num-integer",
- "num-traits",
+ "const-oid",
+ "crypto-bigint",
+ "crypto-primes",
+ "digest 0.11.3",
  "pkcs1",
  "pkcs8",
- "rand_core 0.6.4",
+ "rand_core 0.10.1",
  "signature",
  "spki",
- "subtle",
  "zeroize",
 ]
 
@@ -2870,14 +2810,24 @@ dependencies = [
 ]
 
 [[package]]
-name = "sha1"
-version = "0.10.6"
+name = "serdect"
+version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e3bf829a2d51ab4a5ddf1352d8470c140cadc8301b2ae1789db023f01cedd6ba"
+checksum = "66cf8fedced2fcf12406bcb34223dffb92eaf34908ede12fed414c82b7f00b3e"
+dependencies = [
+ "base16ct",
+ "serde",
+]
+
+[[package]]
+name = "sha1"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aacc4cc499359472b4abe1bf11d0b12e688af9a805fa5e3016f9a386dc2d0214"
 dependencies = [
  "cfg-if",
- "cpufeatures 0.2.17",
- "digest 0.10.7",
+ "cpufeatures 0.3.0",
+ "digest 0.11.3",
 ]
 
 [[package]]
@@ -2929,12 +2879,12 @@ dependencies = [
 
 [[package]]
 name = "signature"
-version = "2.2.0"
+version = "3.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "77549399552de45a898a580c1b41d445bf730df867cc44e6c0233bbc4b8329de"
+checksum = "28d567dcbaf0049cb8ac2608a76cd95ff9e4412e1899d389ee400918ca7537f5"
 dependencies = [
- "digest 0.10.7",
- "rand_core 0.6.4",
+ "digest 0.11.3",
+ "rand_core 0.10.1",
 ]
 
 [[package]]
@@ -3002,12 +2952,12 @@ dependencies = [
 
 [[package]]
 name = "spki"
-version = "0.7.3"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d91ed6c858b01f942cd56b37a94b3e0a1798290327d1236e4d9cf4eaca44d29d"
+checksum = "1d9efca8738c78ee9484207732f728b1ef517bbb1833d6fc0879ca898a522f6f"
 dependencies = [
  "base64ct",
- "der 0.7.10",
+ "der",
 ]
 
 [[package]]
@@ -3046,9 +2996,9 @@ dependencies = [
 
 [[package]]
 name = "sqlx"
-version = "0.8.6"
+version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1fefb893899429669dcdd979aff487bd78f4064e5e7907e4269081e0ef7d97dc"
+checksum = "378620ccc25c62c89d8be1c819e76a88d59bdcc3304733330788948e619bfd71"
 dependencies = [
  "sqlx-core",
  "sqlx-macros",
@@ -3059,13 +3009,14 @@ dependencies = [
 
 [[package]]
 name = "sqlx-core"
-version = "0.8.6"
+version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ee6798b1838b6a0f69c007c133b8df5866302197e404e8b6ee8ed3e3a5e68dc6"
+checksum = "05b44e85bf579a8eeb4ceaa77a3a523baf2bf0e9bac7e40f405d537b5d2d5ccb"
 dependencies = [
  "base64 0.22.1",
  "bigdecimal",
  "bytes",
+ "cfg-if",
  "chrono",
  "crc",
  "crossbeam-queue",
@@ -3075,12 +3026,11 @@ dependencies = [
  "futures-intrusive",
  "futures-io",
  "futures-util",
- "hashbrown 0.15.5",
+ "hashbrown 0.16.1",
  "hashlink",
  "indexmap",
  "log",
  "memchr",
- "once_cell",
  "percent-encoding",
  "rustls",
  "serde",
@@ -3092,7 +3042,7 @@ dependencies = [
  "tokio-stream",
  "tracing",
  "url",
- "webpki-roots 0.26.11",
+ "webpki-roots",
 ]
 
 [[package]]
@@ -3107,9 +3057,9 @@ dependencies = [
 
 [[package]]
 name = "sqlx-macros"
-version = "0.8.6"
+version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a2d452988ccaacfbf5e0bdbc348fb91d7c8af5bee192173ac3636b5fb6e6715d"
+checksum = "bd2b84f2bc39a5705ef27ec785a11c934a41bbd4a24941e257927cddc26b60bf"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3120,15 +3070,15 @@ dependencies = [
 
 [[package]]
 name = "sqlx-macros-core"
-version = "0.8.6"
+version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "19a9c1841124ac5a61741f96e1d9e2ec77424bf323962dd894bdb93f37d5219b"
+checksum = "fb8d96de5fdc85a5c4ec813432b523ec637e80ba98f046555f75f7908ddac7c3"
 dependencies = [
+ "cfg-if",
  "dotenvy",
  "either",
  "heck",
  "hex",
- "once_cell",
  "proc-macro2",
  "quote",
  "serde",
@@ -3139,59 +3089,46 @@ dependencies = [
  "sqlx-postgres",
  "sqlx-sqlite",
  "syn",
+ "thiserror",
  "tokio",
  "url",
 ]
 
 [[package]]
 name = "sqlx-mysql"
-version = "0.8.6"
+version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aa003f0038df784eb8fecbbac13affe3da23b45194bd57dba231c8f48199c526"
+checksum = "90b8020fe17c5f2c245bfa2505d7ef59c5604839527c740266ad2214acebea27"
 dependencies = [
- "atoi",
- "base64 0.22.1",
  "bigdecimal",
  "bitflags",
  "byteorder",
  "bytes",
  "chrono",
  "crc",
- "digest 0.10.7",
+ "digest 0.11.3",
  "dotenvy",
  "either",
- "futures-channel",
  "futures-core",
- "futures-io",
  "futures-util",
  "generic-array",
- "hex",
- "hkdf",
- "hmac",
- "itoa",
  "log",
- "md-5",
- "memchr",
- "once_cell",
  "percent-encoding",
- "rand 0.8.6",
+ "rand 0.10.1",
  "rsa",
  "serde",
  "sha1",
- "sha2 0.10.9",
- "smallvec 1.15.1",
+ "sha2 0.11.0",
  "sqlx-core",
- "stringprep",
  "thiserror",
  "tracing",
- "whoami",
 ]
 
 [[package]]
 name = "sqlx-postgres"
-version = "0.8.6"
+version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "db58fcd5a53cf07c184b154801ff91347e4c30d17a3562a635ff028ad5deda46"
+checksum = "87a2bdd6e83f6b3ea525ca9fee568030508b58355a43d0b2c1674d5f79dcd65e"
 dependencies = [
  "atoi",
  "base64 0.22.1",
@@ -3208,17 +3145,15 @@ dependencies = [
  "hex",
  "hkdf",
  "hmac",
- "home",
  "itoa",
  "log",
  "md-5",
  "memchr",
  "num-bigint",
- "once_cell",
- "rand 0.8.6",
+ "rand 0.10.1",
  "serde",
  "serde_json",
- "sha2 0.10.9",
+ "sha2 0.11.0",
  "smallvec 1.15.1",
  "sqlx-core",
  "stringprep",
@@ -3229,13 +3164,14 @@ dependencies = [
 
 [[package]]
 name = "sqlx-sqlite"
-version = "0.8.6"
+version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c2d12fe70b2c1b4401038055f90f151b78208de1f9f89a7dbfd41587a10c3eea"
+checksum = "488e99c397a62007e4229aec669a179816339afc6d2620ca6fa420dbee2e982c"
 dependencies = [
  "atoi",
  "chrono",
  "flume",
+ "form_urlencoded",
  "futures-channel",
  "futures-core",
  "futures-executor",
@@ -3245,7 +3181,6 @@ dependencies = [
  "log",
  "percent-encoding",
  "serde",
- "serde_urlencoded",
  "sqlx-core",
  "thiserror",
  "tracing",
@@ -3739,7 +3674,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dea7109cdcd5864d4eeb1b58a1648dc9bf520360d7af16ec26d0a9354bafcfc0"
 dependencies = [
  "base64 0.22.1",
- "der 0.8.0",
+ "der",
  "log",
  "native-tls",
  "percent-encoding",
@@ -3856,12 +3791,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "wasite"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b8dad83b4f25e74f184f64c43b150b91efe7647395b42289f38e50566d82855b"
-
-[[package]]
 name = "wasm-bindgen"
 version = "0.2.118"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3961,15 +3890,6 @@ dependencies = [
 
 [[package]]
 name = "webpki-roots"
-version = "0.26.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "521bc38abb08001b01866da9f51eb7c5d647a19260e00054a8c7fd5f9e57f7a9"
-dependencies = [
- "webpki-roots 1.0.7",
-]
-
-[[package]]
-name = "webpki-roots"
 version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "52f5ee44c96cf55f1b349600768e3ece3a8f26010c05265ab73f945bb1a2eb9d"
@@ -3979,13 +3899,9 @@ dependencies = [
 
 [[package]]
 name = "whoami"
-version = "1.6.1"
+version = "2.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5d4a4db5077702ca3015d3d02d74974948aba2ad9e12ab7df718ee64ccd7e97d"
-dependencies = [
- "libredox",
- "wasite",
-]
+checksum = "998767ef88740d1f5b0682a9c53c24431453923962269c2db68ee43788c5a40d"
 
 [[package]]
 name = "winapi"
@@ -4079,20 +3995,11 @@ dependencies = [
 
 [[package]]
 name = "windows-sys"
-version = "0.48.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "677d2418bec65e3338edb076e806bc1ec15693c5d0104683f2efe857f61056a9"
-dependencies = [
- "windows-targets 0.48.5",
-]
-
-[[package]]
-name = "windows-sys"
 version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
 dependencies = [
- "windows-targets 0.52.6",
+ "windows-targets",
 ]
 
 [[package]]
@@ -4101,7 +4008,7 @@ version = "0.59.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e38bc4d79ed67fd075bcc251a1c39b32a1776bbe92e5bef1f0bf1f8c531853b"
 dependencies = [
- "windows-targets 0.52.6",
+ "windows-targets",
 ]
 
 [[package]]
@@ -4115,40 +4022,19 @@ dependencies = [
 
 [[package]]
 name = "windows-targets"
-version = "0.48.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9a2fa6e2155d7247be68c096456083145c183cbbbc2764150dda45a87197940c"
-dependencies = [
- "windows_aarch64_gnullvm 0.48.5",
- "windows_aarch64_msvc 0.48.5",
- "windows_i686_gnu 0.48.5",
- "windows_i686_msvc 0.48.5",
- "windows_x86_64_gnu 0.48.5",
- "windows_x86_64_gnullvm 0.48.5",
- "windows_x86_64_msvc 0.48.5",
-]
-
-[[package]]
-name = "windows-targets"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b724f72796e036ab90c1021d4780d4d3d648aca59e491e6b98e725b84e99973"
 dependencies = [
- "windows_aarch64_gnullvm 0.52.6",
- "windows_aarch64_msvc 0.52.6",
- "windows_i686_gnu 0.52.6",
+ "windows_aarch64_gnullvm",
+ "windows_aarch64_msvc",
+ "windows_i686_gnu",
  "windows_i686_gnullvm",
- "windows_i686_msvc 0.52.6",
- "windows_x86_64_gnu 0.52.6",
- "windows_x86_64_gnullvm 0.52.6",
- "windows_x86_64_msvc 0.52.6",
+ "windows_i686_msvc",
+ "windows_x86_64_gnu",
+ "windows_x86_64_gnullvm",
+ "windows_x86_64_msvc",
 ]
-
-[[package]]
-name = "windows_aarch64_gnullvm"
-version = "0.48.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2b38e32f0abccf9987a4e3079dfb67dcd799fb61361e53e2882c3cbaf0d905d8"
 
 [[package]]
 name = "windows_aarch64_gnullvm"
@@ -4158,21 +4044,9 @@ checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
 
 [[package]]
 name = "windows_aarch64_msvc"
-version = "0.48.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc35310971f3b2dbbf3f0690a219f40e2d9afcf64f9ab7cc1be722937c26b4bc"
-
-[[package]]
-name = "windows_aarch64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
-
-[[package]]
-name = "windows_i686_gnu"
-version = "0.48.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a75915e7def60c94dcef72200b9a8e58e5091744960da64ec734a6c6e9b3743e"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -4188,21 +4062,9 @@ checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
 
 [[package]]
 name = "windows_i686_msvc"
-version = "0.48.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8f55c233f70c4b27f66c523580f78f1004e8b5a8b659e05a4eb49d4166cca406"
-
-[[package]]
-name = "windows_i686_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
-
-[[package]]
-name = "windows_x86_64_gnu"
-version = "0.48.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "53d40abd2583d23e4718fddf1ebec84dbff8381c07cae67ff7768bbf19c6718e"
 
 [[package]]
 name = "windows_x86_64_gnu"
@@ -4212,21 +4074,9 @@ checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
-version = "0.48.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b7b52767868a23d5bab768e390dc5f5c55825b6d30b86c844ff2dc7414044cc"
-
-[[package]]
-name = "windows_x86_64_gnullvm"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
-
-[[package]]
-name = "windows_x86_64_msvc"
-version = "0.48.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ed94fce61571a4006852b7389a063ab983c02eb1bb37b47f8272ce92d06d9538"
 
 [[package]]
 name = "windows_x86_64_msvc"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -56,7 +56,7 @@ serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 sha2 = "0.11"
 sqlparser = { version = "0.62", features = ["visitor"] }
-sqlx = { version = "0.8", features = ["runtime-tokio-rustls"] }
+sqlx = { version = "0.9", features = ["runtime-tokio", "tls-rustls"] }
 thiserror = "2"
 tokenizers = { version = "0.23", default-features = false, features = ["fancy-regex"] }
 tokio = { version = "1", features = ["full"] }

--- a/crates/mysql/Cargo.toml
+++ b/crates/mysql/Cargo.toml
@@ -18,7 +18,7 @@ schemars = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
 sqlparser = { workspace = true }
-sqlx = { workspace = true, features = ["mysql", "json"] }
+sqlx = { workspace = true, features = ["mysql", "json", "mysql-rsa"] }
 tokio = { workspace = true }
 tracing = { workspace = true }
 

--- a/crates/sql/src/connection.rs
+++ b/crates/sql/src/connection.rs
@@ -19,7 +19,8 @@ use crate::timeout::execute_with_timeout;
 /// wrapper at every call site. Callers remain responsible for ensuring bindless
 /// strings carry no injection (via read-only validation and identifier quoting).
 ///
-/// The returned [`SqlStr`] owns its text, so no input borrow escapes; a `None`
+/// The returned [`SqlStr`] owns its text, so no input borrow escapes. The
+/// `(SqlStr, Option<_>)` pair is itself an [`sqlx::Execute`] value: a `None`
 /// argument set routes through the unprepared text protocol, `Some` through a
 /// prepared statement.
 pub trait IntoSafeQuery<DB: sqlx::Database> {
@@ -72,7 +73,6 @@ where
     usize: sqlx::ColumnIndex<<Self::DB as sqlx::Database>::Row>,
     <Self::DB as sqlx::Database>::Row: RowExt,
     <Self::DB as sqlx::Database>::QueryResult: sqlx_json::QueryResult,
-    <Self::DB as sqlx::Database>::Arguments: sqlx::IntoArguments<Self::DB>,
 {
     /// The sqlx database driver type (e.g. `sqlx::MySql`).
     type DB: sqlx::Database;
@@ -97,14 +97,9 @@ where
         Q: IntoSafeQuery<Self::DB>,
     {
         let (sql, arguments) = query.into_sql_and_args()?;
-        let sql_log = sql.as_str().to_owned();
         let pool = self.pool(database).await?;
-        execute_with_timeout(self.query_timeout(), &sql_log, async move {
-            let result = match arguments {
-                None => pool.execute(sql).await?,
-                Some(args) => pool.execute(sqlx::query_with(sql, args)).await?,
-            };
-            Ok(result.rows_affected())
+        execute_with_timeout(self.query_timeout(), sql, |sql| async move {
+            Ok(pool.execute((sql, arguments)).await?.rows_affected())
         })
         .await
     }
@@ -119,13 +114,9 @@ where
         Q: IntoSafeQuery<Self::DB>,
     {
         let (sql, arguments) = query.into_sql_and_args()?;
-        let sql_log = sql.as_str().to_owned();
         let pool = self.pool(database).await?;
-        execute_with_timeout(self.query_timeout(), &sql_log, async move {
-            let rows = match arguments {
-                None => pool.fetch_all(sql).await?,
-                Some(args) => pool.fetch_all(sqlx::query_with(sql, args)).await?,
-            };
+        execute_with_timeout(self.query_timeout(), sql, |sql| async move {
+            let rows = pool.fetch_all((sql, arguments)).await?;
             Ok(rows.iter().map(RowExt::to_json).collect())
         })
         .await
@@ -145,13 +136,9 @@ where
         T: for<'r> Decode<'r, Self::DB> + Type<Self::DB> + Send + Unpin,
     {
         let (sql, arguments) = query.into_sql_and_args()?;
-        let sql_log = sql.as_str().to_owned();
         let pool = self.pool(database).await?;
-        execute_with_timeout(self.query_timeout(), &sql_log, async move {
-            let row = match arguments {
-                None => pool.fetch_optional(sql).await?,
-                Some(args) => pool.fetch_optional(sqlx::query_with(sql, args)).await?,
-            };
+        execute_with_timeout(self.query_timeout(), sql, |sql| async move {
+            let row = pool.fetch_optional((sql, arguments)).await?;
             Ok(row.and_then(|r| r.try_get(0usize).ok()))
         })
         .await
@@ -168,13 +155,9 @@ where
         T: for<'r> Decode<'r, Self::DB> + Type<Self::DB> + Send + Unpin,
     {
         let (sql, arguments) = query.into_sql_and_args()?;
-        let sql_log = sql.as_str().to_owned();
         let pool = self.pool(database).await?;
-        execute_with_timeout(self.query_timeout(), &sql_log, async move {
-            let rows = match arguments {
-                None => pool.fetch_all(sql).await?,
-                Some(args) => pool.fetch_all(sqlx::query_with(sql, args)).await?,
-            };
+        execute_with_timeout(self.query_timeout(), sql, |sql| async move {
+            let rows = pool.fetch_all((sql, arguments)).await?;
             rows.iter().map(|r| r.try_get(0usize)).collect()
         })
         .await
@@ -193,13 +176,9 @@ where
         T: for<'r> FromRow<'r, <Self::DB as sqlx::Database>::Row> + Send + Unpin,
     {
         let (sql, arguments) = query.into_sql_and_args()?;
-        let sql_log = sql.as_str().to_owned();
         let pool = self.pool(database).await?;
-        execute_with_timeout(self.query_timeout(), &sql_log, async move {
-            let rows = match arguments {
-                None => pool.fetch_all(sql).await?,
-                Some(args) => pool.fetch_all(sqlx::query_with(sql, args)).await?,
-            };
+        execute_with_timeout(self.query_timeout(), sql, |sql| async move {
+            let rows = pool.fetch_all((sql, arguments)).await?;
             rows.iter().map(T::from_row).collect()
         })
         .await

--- a/crates/sql/src/connection.rs
+++ b/crates/sql/src/connection.rs
@@ -6,10 +6,46 @@
 
 use crate::SqlError;
 use serde_json::Value;
-use sqlx::{Decode, Execute, Executor, FromRow, Row, Type};
+use sqlx::{AssertSqlSafe, Decode, Execute, Executor, FromRow, Row, SqlSafeStr, SqlStr, Type};
 use sqlx_json::{QueryResult as _, RowExt};
 
 use crate::timeout::execute_with_timeout;
+
+/// Splits a query into its SQL text and bound arguments for safe execution.
+///
+/// Lets [`Connection`] query methods accept either a bindless `&str` — wrapped
+/// as [`sqlx::AssertSqlSafe`] and run through the unprepared text protocol — or a
+/// parameterized `sqlx::query(..).bind(..)` value, without callers writing the
+/// wrapper at every call site. Callers remain responsible for ensuring bindless
+/// strings carry no injection (via read-only validation and identifier quoting).
+///
+/// The returned [`SqlStr`] owns its text, so no input borrow escapes; a `None`
+/// argument set routes through the unprepared text protocol, `Some` through a
+/// prepared statement.
+pub trait IntoSafeQuery<DB: sqlx::Database> {
+    /// Returns the SQL text and the bound arguments, if any.
+    ///
+    /// # Errors
+    ///
+    /// [`SqlError::Query`] — extracting bound arguments failed.
+    fn into_sql_and_args(self) -> Result<(SqlStr, Option<DB::Arguments>), SqlError>;
+}
+
+impl<DB: sqlx::Database> IntoSafeQuery<DB> for &str {
+    fn into_sql_and_args(self) -> Result<(SqlStr, Option<DB::Arguments>), SqlError> {
+        Ok((AssertSqlSafe(self).into_sql_str(), None))
+    }
+}
+
+impl<DB: sqlx::Database, A> IntoSafeQuery<DB> for sqlx::query::Query<'_, DB, A>
+where
+    A: Send + sqlx::IntoArguments<DB>,
+{
+    fn into_sql_and_args(mut self) -> Result<(SqlStr, Option<DB::Arguments>), SqlError> {
+        let arguments = self.take_arguments().map_err(|e| SqlError::Query(e.to_string()))?;
+        Ok((self.sql(), arguments))
+    }
+}
 
 /// Unified query surface every backend tool handler uses.
 ///
@@ -17,10 +53,10 @@ use crate::timeout::execute_with_timeout;
 /// [`pool`](Connection::pool), and [`query_timeout`](Connection::query_timeout)
 /// — and receive default implementations for query execution.
 ///
-/// Query methods accept any [`sqlx::Execute`] value: a plain `&str` for
-/// bindless statements (which routes through sqlx's unprepared text
-/// protocol, required for statements like `MySQL` `USE`), or an
-/// `sqlx::query(sql).bind(...)` value for parameterized statements.
+/// Query methods accept any [`IntoSafeQuery`] value: a bindless `&str` (run
+/// through the unprepared text protocol, required for statements like `MySQL`
+/// `USE`) or a parameterized `sqlx::query(sql).bind(...)` value (run as a
+/// prepared statement).
 ///
 /// # Errors
 ///
@@ -36,6 +72,7 @@ where
     usize: sqlx::ColumnIndex<<Self::DB as sqlx::Database>::Row>,
     <Self::DB as sqlx::Database>::Row: RowExt,
     <Self::DB as sqlx::Database>::QueryResult: sqlx_json::QueryResult,
+    <Self::DB as sqlx::Database>::Arguments: sqlx::IntoArguments<Self::DB>,
 {
     /// The sqlx database driver type (e.g. `sqlx::MySql`).
     type DB: sqlx::Database;
@@ -55,14 +92,19 @@ where
     /// # Errors
     ///
     /// See trait-level documentation.
-    async fn execute<'q, E>(&self, query: E, database: Option<&str>) -> Result<u64, SqlError>
+    async fn execute<Q>(&self, query: Q, database: Option<&str>) -> Result<u64, SqlError>
     where
-        E: 'q + Execute<'q, Self::DB>,
+        Q: IntoSafeQuery<Self::DB>,
     {
-        let sql = query.sql().to_owned();
+        let (sql, arguments) = query.into_sql_and_args()?;
+        let sql_log = sql.as_str().to_owned();
         let pool = self.pool(database).await?;
-        execute_with_timeout(self.query_timeout(), &sql, async move {
-            Ok(pool.execute(query).await?.rows_affected())
+        execute_with_timeout(self.query_timeout(), &sql_log, async move {
+            let result = match arguments {
+                None => pool.execute(sql).await?,
+                Some(args) => pool.execute(sqlx::query_with(sql, args)).await?,
+            };
+            Ok(result.rows_affected())
         })
         .await
     }
@@ -72,14 +114,19 @@ where
     /// # Errors
     ///
     /// See trait-level documentation.
-    async fn fetch_json<'q, E>(&self, query: E, database: Option<&str>) -> Result<Vec<Value>, SqlError>
+    async fn fetch_json<Q>(&self, query: Q, database: Option<&str>) -> Result<Vec<Value>, SqlError>
     where
-        E: 'q + Execute<'q, Self::DB>,
+        Q: IntoSafeQuery<Self::DB>,
     {
-        let sql = query.sql().to_owned();
+        let (sql, arguments) = query.into_sql_and_args()?;
+        let sql_log = sql.as_str().to_owned();
         let pool = self.pool(database).await?;
-        execute_with_timeout(self.query_timeout(), &sql, async move {
-            Ok(pool.fetch_all(query).await?.iter().map(RowExt::to_json).collect())
+        execute_with_timeout(self.query_timeout(), &sql_log, async move {
+            let rows = match arguments {
+                None => pool.fetch_all(sql).await?,
+                Some(args) => pool.fetch_all(sqlx::query_with(sql, args)).await?,
+            };
+            Ok(rows.iter().map(RowExt::to_json).collect())
         })
         .await
     }
@@ -92,15 +139,20 @@ where
     /// # Errors
     ///
     /// See trait-level documentation.
-    async fn fetch_optional<'q, E, T>(&self, query: E, database: Option<&str>) -> Result<Option<T>, SqlError>
+    async fn fetch_optional<Q, T>(&self, query: Q, database: Option<&str>) -> Result<Option<T>, SqlError>
     where
-        E: 'q + Execute<'q, Self::DB>,
+        Q: IntoSafeQuery<Self::DB>,
         T: for<'r> Decode<'r, Self::DB> + Type<Self::DB> + Send + Unpin,
     {
-        let sql = query.sql().to_owned();
+        let (sql, arguments) = query.into_sql_and_args()?;
+        let sql_log = sql.as_str().to_owned();
         let pool = self.pool(database).await?;
-        execute_with_timeout(self.query_timeout(), &sql, async move {
-            Ok(pool.fetch_optional(query).await?.and_then(|r| r.try_get(0usize).ok()))
+        execute_with_timeout(self.query_timeout(), &sql_log, async move {
+            let row = match arguments {
+                None => pool.fetch_optional(sql).await?,
+                Some(args) => pool.fetch_optional(sqlx::query_with(sql, args)).await?,
+            };
+            Ok(row.and_then(|r| r.try_get(0usize).ok()))
         })
         .await
     }
@@ -110,15 +162,19 @@ where
     /// # Errors
     ///
     /// See trait-level documentation.
-    async fn fetch_scalar<'q, E, T>(&self, query: E, database: Option<&str>) -> Result<Vec<T>, SqlError>
+    async fn fetch_scalar<Q, T>(&self, query: Q, database: Option<&str>) -> Result<Vec<T>, SqlError>
     where
-        E: 'q + Execute<'q, Self::DB>,
+        Q: IntoSafeQuery<Self::DB>,
         T: for<'r> Decode<'r, Self::DB> + Type<Self::DB> + Send + Unpin,
     {
-        let sql = query.sql().to_owned();
+        let (sql, arguments) = query.into_sql_and_args()?;
+        let sql_log = sql.as_str().to_owned();
         let pool = self.pool(database).await?;
-        execute_with_timeout(self.query_timeout(), &sql, async move {
-            let rows = pool.fetch_all(query).await?;
+        execute_with_timeout(self.query_timeout(), &sql_log, async move {
+            let rows = match arguments {
+                None => pool.fetch_all(sql).await?,
+                Some(args) => pool.fetch_all(sqlx::query_with(sql, args)).await?,
+            };
             rows.iter().map(|r| r.try_get(0usize)).collect()
         })
         .await
@@ -131,15 +187,19 @@ where
     /// See trait-level documentation. Row decode failures (column type
     /// mismatch, malformed JSON inside a [`sqlx::types::Json`] column, etc.)
     /// surface as [`SqlError::Query`].
-    async fn fetch<'q, E, T>(&self, query: E, database: Option<&str>) -> Result<Vec<T>, SqlError>
+    async fn fetch<Q, T>(&self, query: Q, database: Option<&str>) -> Result<Vec<T>, SqlError>
     where
-        E: 'q + Execute<'q, Self::DB>,
+        Q: IntoSafeQuery<Self::DB>,
         T: for<'r> FromRow<'r, <Self::DB as sqlx::Database>::Row> + Send + Unpin,
     {
-        let sql = query.sql().to_owned();
+        let (sql, arguments) = query.into_sql_and_args()?;
+        let sql_log = sql.as_str().to_owned();
         let pool = self.pool(database).await?;
-        execute_with_timeout(self.query_timeout(), &sql, async move {
-            let rows = pool.fetch_all(query).await?;
+        execute_with_timeout(self.query_timeout(), &sql_log, async move {
+            let rows = match arguments {
+                None => pool.fetch_all(sql).await?,
+                Some(args) => pool.fetch_all(sqlx::query_with(sql, args)).await?,
+            };
             rows.iter().map(T::from_row).collect()
         })
         .await

--- a/crates/sql/src/timeout.rs
+++ b/crates/sql/src/timeout.rs
@@ -1,22 +1,26 @@
 //! Query-level timeout wrapper for SQL operations.
 //!
-//! Provides [`execute_with_timeout`] which wraps any async query future
-//! with an optional `tokio::time::timeout` guard.  All backend crates
-//! use this single function instead of duplicating timeout logic.
+//! Provides [`execute_with_timeout`] which runs a query operation under
+//! an optional `tokio::time::timeout` guard.  All backend crates use this
+//! single function instead of duplicating timeout logic.
 
 use std::time::{Duration, Instant};
 
+use sqlx::SqlStr;
+
 use crate::SqlError;
 
-/// Executes `fut` with an optional query timeout.
+/// Runs a query operation with an optional query timeout.
 ///
-/// When `timeout_secs` is `Some(n)` where `n > 0`, the future is wrapped
-/// with [`tokio::time::timeout`].  On expiry the future is dropped
-/// (cancelling the in-flight query) and [`SqlError::QueryTimeout`] is
-/// returned with the wall-clock elapsed time and the original SQL text.
+/// `op` is handed the [`SqlStr`] to execute and returns the in-flight
+/// query future. When `timeout_secs` is `Some(n)` with `n > 0`, that
+/// future is wrapped with [`tokio::time::timeout`]; on expiry it is
+/// dropped (cancelling the in-flight query) and [`SqlError::QueryTimeout`]
+/// is returned with the elapsed time and the SQL text. `None` or
+/// `Some(0)` runs without a timeout.
 ///
-/// When `timeout_secs` is `None` or `Some(0)`, the future runs without
-/// any timeout.
+/// The SQL text is only copied into the error on the timeout path, so the
+/// success path adds no allocation.
 ///
 /// # Errors
 ///
@@ -26,22 +30,23 @@ use crate::SqlError;
 ///   non-timeout reason (e.g. syntax error, connection loss).
 pub async fn execute_with_timeout<T>(
     timeout_secs: Option<u64>,
-    sql: &str,
-    fut: impl Future<Output = Result<T, sqlx::Error>>,
+    sql: SqlStr,
+    op: impl AsyncFnOnce(SqlStr) -> Result<T, sqlx::Error>,
 ) -> Result<T, SqlError> {
-    match timeout_secs.filter(|&t| t > 0) {
-        Some(secs) => {
+    let result = match timeout_secs {
+        Some(secs) if secs > 0 => {
             let start = Instant::now();
-            tokio::time::timeout(Duration::from_secs(secs), fut)
+            let err_sql = sql.clone();
+            tokio::time::timeout(Duration::from_secs(secs), op(sql))
                 .await
                 .map_err(|_| SqlError::QueryTimeout {
                     elapsed_secs: start.elapsed().as_secs_f64(),
-                    sql: sql.to_string(),
+                    sql: err_sql.as_str().to_owned(),
                 })?
-                .map_err(|e| SqlError::Query(e.to_string()))
         }
-        None => fut.await.map_err(|e| SqlError::Query(e.to_string())),
-    }
+        _ => op(sql).await,
+    };
+    result.map_err(|e| SqlError::Query(e.to_string()))
 }
 
 #[cfg(test)]
@@ -50,13 +55,13 @@ mod tests {
 
     #[tokio::test]
     async fn fast_query_succeeds_with_timeout() {
-        let result = execute_with_timeout(Some(5), "SELECT 1", async { Ok(42) }).await;
+        let result = execute_with_timeout(Some(5), SqlStr::from_static("SELECT 1"), |_| async { Ok(42) }).await;
         assert_eq!(result.expect("should succeed"), 42);
     }
 
     #[tokio::test]
     async fn query_error_propagates_as_app_error() {
-        let result: Result<i32, SqlError> = execute_with_timeout(Some(5), "BAD SQL", async {
+        let result: Result<i32, SqlError> = execute_with_timeout(Some(5), SqlStr::from_static("BAD SQL"), |_| async {
             Err(sqlx::Error::Configuration("syntax error".into()))
         })
         .await;
@@ -69,11 +74,12 @@ mod tests {
 
     #[tokio::test]
     async fn slow_query_times_out() {
-        let result: Result<i32, SqlError> = execute_with_timeout(Some(1), "SELECT SLEEP(60)", async {
-            tokio::time::sleep(Duration::from_mins(1)).await;
-            Ok(0)
-        })
-        .await;
+        let result: Result<i32, SqlError> =
+            execute_with_timeout(Some(1), SqlStr::from_static("SELECT SLEEP(60)"), |_| async {
+                tokio::time::sleep(Duration::from_mins(1)).await;
+                Ok(0)
+            })
+            .await;
         let err = result.expect_err("should time out");
         match err {
             SqlError::QueryTimeout { elapsed_secs, sql } => {
@@ -86,13 +92,13 @@ mod tests {
 
     #[tokio::test]
     async fn none_timeout_runs_without_limit() {
-        let result = execute_with_timeout(None, "SELECT 1", async { Ok(1) }).await;
+        let result = execute_with_timeout(None, SqlStr::from_static("SELECT 1"), |_| async { Ok(1) }).await;
         assert_eq!(result.expect("should succeed"), 1);
     }
 
     #[tokio::test]
     async fn zero_timeout_disables_limit() {
-        let result = execute_with_timeout(Some(0), "SELECT 1", async { Ok(1) }).await;
+        let result = execute_with_timeout(Some(0), SqlStr::from_static("SELECT 1"), |_| async { Ok(1) }).await;
         assert_eq!(result.expect("should succeed"), 1);
     }
 }


### PR DESCRIPTION
## Summary

Upgrades sqlx `0.8` → `0.9`, then refines the upgrade for simplicity, readability, and performance.

### `chore(deps): upgrade sqlx 0.8 to 0.9`
- `runtime-tokio-rustls` feature split into `runtime-tokio` + `tls-rustls` (ring-backed, matches the old default).
- Adds `mysql-rsa` (0.9 gates RSA behind it; required for MySQL 8 `caching_sha2_password` auth over non-TLS connections).

### `refactor(sql): simplify query dispatch and timeout helper`
- **Query dispatch** — lean on sqlx 0.9's blanket `Execute` impl for `(SqlStr, Option<Arguments>)` instead of the manual `match` / `query_with` dispatch repeated in every `Connection` query method. Drops the now-dead `IntoArguments` trait bound.
- **Timeout helper** — move SQL-string ownership into `execute_with_timeout` via an `AsyncFnOnce(SqlStr)` op, eliminating the per-query `sql_log` allocation. The SQL is cloned (O(1) for our `SqlStr` variants) only when a timeout is configured, and materialized into a `String` only when one actually fires. Collapses the `FnOnce + Future` generics to a single `AsyncFnOnce` bound and de-duplicates the `sqlx::Error -> SqlError::Query` conversion.

Net `-15` lines in `connection.rs`, and no allocation on the query hot path.

## Why this is correct
In sqlx 0.9 `Execute::sql(self)` consumes `self` (was `&self -> &str`), so a query value can't be both logged and executed — the `(SqlStr, Option<Arguments>)` tuple is the minimal carrier, and sqlx's blanket impl does the unprepared (`None`) / prepared (`Some`) protocol dispatch internally. Bindless statements (e.g. MySQL `USE`) still route through the unprepared text protocol.

## Testing
- `cargo fmt --check`, `cargo clippy --workspace --tests -- -D warnings` (also pedantic/nursery/perf clean on the changed files)
- `cargo test --workspace --lib --bins`
- `./tests/run.sh` — 734 integration tests pass across MariaDB 12, MySQL 9, PostgreSQL 18, SQLite
