### PR TITLE
perf(pii): batch NER inference and unify query redaction offload

### DIFF
--- a/crates/mysql/src/tools/explain_query.rs
+++ b/crates/mysql/src/tools/explain_query.rs
@@ -2,6 +2,7 @@
 
 use std::borrow::Cow;
 
+use dbmcp_pii::MaybeRedact as _;
 use dbmcp_server::types::{PinnedExplainQueryRequest, QueryResponse, UnpinnedExplainQueryRequest};
 use dbmcp_sql::Connection as _;
 use dbmcp_sql::validation::validate_read_only;
@@ -116,10 +117,8 @@ impl MysqlHandler {
             format!("EXPLAIN FORMAT=JSON {query}")
         };
 
-        let mut rows = self.connection.fetch_json(explain_sql.as_str(), database).await?;
-        if let Some(r) = &self.redactor {
-            r.apply(&mut rows)?;
-        }
+        let rows = self.connection.fetch_json(explain_sql.as_str(), database).await?;
+        let rows = self.redactor.redact_rows(rows).await?;
         Ok(QueryResponse { rows })
     }
 }

--- a/crates/mysql/src/tools/read_query.rs
+++ b/crates/mysql/src/tools/read_query.rs
@@ -2,6 +2,7 @@
 
 use std::borrow::Cow;
 
+use dbmcp_pii::MaybeRedact as _;
 use dbmcp_server::pagination::{Cursor, Pager};
 use dbmcp_server::types::{PinnedReadQueryRequest, ReadQueryResponse, UnpinnedReadQueryRequest};
 use dbmcp_sql::Connection as _;
@@ -114,29 +115,19 @@ impl MysqlHandler {
 
         let database = database.as_deref().map(str::trim).filter(|s| !s.is_empty());
 
-        match kind {
+        let (rows, next_cursor) = match kind {
             StatementKind::Select => {
                 let pager = Pager::new(cursor, self.config.page_size);
                 let wrapped = with_limit_offset(&query, pager.limit(), pager.offset());
                 let rows = self.connection.fetch_json(wrapped.as_str(), database).await?;
-                let (rows, next_cursor) = pager.paginate(rows);
-                let rows = match &self.redactor {
-                    Some(r) => r.redact_rows(rows).await?,
-                    None => rows,
-                };
-                Ok(ReadQueryResponse { rows, next_cursor })
+                pager.paginate(rows)
             }
             StatementKind::NonSelect => {
                 let rows = self.connection.fetch_json(query.as_str(), database).await?;
-                let rows = match &self.redactor {
-                    Some(r) => r.redact_rows(rows).await?,
-                    None => rows,
-                };
-                Ok(ReadQueryResponse {
-                    rows,
-                    next_cursor: None,
-                })
+                (rows, None)
             }
-        }
+        };
+        let rows = self.redactor.redact_rows(rows).await?;
+        Ok(ReadQueryResponse { rows, next_cursor })
     }
 }

--- a/crates/mysql/src/tools/write_query.rs
+++ b/crates/mysql/src/tools/write_query.rs
@@ -2,6 +2,7 @@
 
 use std::borrow::Cow;
 
+use dbmcp_pii::MaybeRedact as _;
 use dbmcp_server::types::{PinnedQueryRequest, QueryResponse, UnpinnedQueryRequest};
 use dbmcp_sql::Connection as _;
 use rmcp::handler::server::router::tool::{AsyncTool, ToolBase};
@@ -93,10 +94,8 @@ impl MysqlHandler {
     pub async fn write_query(&self, query: String, database: Option<String>) -> Result<QueryResponse, ErrorData> {
         let database = database.as_deref().map(str::trim).filter(|s| !s.is_empty());
 
-        let mut rows = self.connection.fetch_json(query.as_str(), database).await?;
-        if let Some(r) = &self.redactor {
-            r.apply(&mut rows)?;
-        }
+        let rows = self.connection.fetch_json(query.as_str(), database).await?;
+        let rows = self.redactor.redact_rows(rows).await?;
 
         Ok(QueryResponse { rows })
     }

--- a/crates/pii/src/lib.rs
+++ b/crates/pii/src/lib.rs
@@ -47,7 +47,7 @@ pub use crate::context::ContextSettings;
 pub use crate::entity::{Entity, ParseEntityError};
 pub use crate::ner::{NerEngine, NerError};
 pub use crate::operators::{ChunkCount, HashAlgorithm, Operator};
-pub use crate::redact::{RedactionError, RedactionStats, Redactor, RedactorInitError};
+pub use crate::redact::{MaybeRedact, RedactionError, RedactionStats, Redactor, RedactorInitError};
 pub use crate::result::{AnalysisExplanation, RecognizerResult};
 pub use crate::score::{MAX_SCORE, Score};
 pub use crate::validation::ValidationOutcome;

--- a/crates/pii/src/ner.rs
+++ b/crates/pii/src/ner.rs
@@ -409,8 +409,6 @@ impl NerEngine {
     /// Returns [`NerError::Inference`] on a tokenization or forward-pass
     /// failure. Never panics.
     pub fn analyze(&self, text: &str) -> Result<Vec<RecognizerResult>, NerError> {
-        // `analyze_batch` returns one vec per input, so a one-text batch yields
-        // exactly one; `unwrap_or_default` keeps the impossible empty case panic-free.
         Ok(self.analyze_batch(&[text])?.into_iter().next().unwrap_or_default())
     }
 
@@ -433,23 +431,18 @@ impl NerEngine {
             return Ok(results);
         }
 
-        // Flatten every window across every text into one list tagged by source.
         let mut windows: Vec<Window> = Vec::with_capacity(texts.len());
         for (i, text) in texts.iter().enumerate() {
             if text.is_empty() {
                 continue;
             }
-            let encoding = self
+            let mut encoding = self
                 .tokenizer
                 .encode(*text, true)
                 .map_err(|e| NerError::Inference(format!("tokenize: {e}")))?;
-            // Borrow the overflow windows before moving the main encoding below.
-            for overflow in encoding.get_overflowing() {
+            for overflow in encoding.take_overflowing() {
                 if !overflow.get_ids().is_empty() {
-                    windows.push(Window {
-                        src: i,
-                        enc: overflow.clone(),
-                    });
+                    windows.push(Window { src: i, enc: overflow });
                 }
             }
             if !encoding.get_ids().is_empty() {
@@ -461,7 +454,7 @@ impl NerEngine {
             self.run_chunk(chunk, &mut results)?;
         }
 
-        // Merge overflow-window dupes per text, exactly as the single path did.
+        // Merge overflow-window dupes per text.
         for spans in &mut results {
             if !spans.is_empty() {
                 *spans = crate::overlap::resolve(std::mem::take(spans));
@@ -478,8 +471,7 @@ impl NerEngine {
     fn run_chunk(&self, chunk: &[Window], results: &mut [Vec<RecognizerResult>]) -> Result<(), NerError> {
         let batch = chunk.len();
         let num_labels = self.id2label.len();
-        // Dynamic padding to the longest window in the chunk (clamp is defensive:
-        // the tokenizer already truncates each window to MAX_SEQ_LEN).
+        // Clamp is defensive: the tokenizer already truncates each window to MAX_SEQ_LEN.
         let max_len = chunk
             .iter()
             .map(|w| w.enc.get_ids().len())
@@ -490,7 +482,6 @@ impl NerEngine {
             return Ok(());
         }
 
-        // Right-pad each window into flat row-major `[batch, max_len]` buffers.
         let mut input_ids = vec![self.pad_id; batch * max_len];
         let mut attention = vec![0_i64; batch * max_len];
         let mut type_ids = if self.needs_token_type_ids {
@@ -556,7 +547,6 @@ impl NerEngine {
         for (r, w) in chunk.iter().enumerate() {
             let real = w.enc.get_ids().len().min(max_len);
             let start = r * row_stride;
-            // Decode only the row's real (unpadded) tokens; pad positions are skipped.
             let Some(row_logits) = logits.get(start..start + real * num_labels) else {
                 continue;
             };

--- a/crates/pii/src/ner.rs
+++ b/crates/pii/src/ner.rs
@@ -31,6 +31,13 @@ const MAX_SEQ_LEN: usize = 512;
 /// Token overlap between consecutive windows of an over-long input.
 const STRIDE: usize = 128;
 
+/// Maximum tokenized windows fed to one batched forward pass.
+///
+/// Bounds peak logits memory at `NER_BATCH_SIZE × MAX_SEQ_LEN × num_labels × 4 B`
+/// (≈ 1.2 MB at 16 × 512 × ~37 labels); inputs add three `× 8 B` tensors. Larger
+/// batches mean fewer `session.run` calls (and `Mutex` acquisitions) per request.
+const NER_BATCH_SIZE: usize = 16;
+
 /// Errors raised while loading or running the NER engine.
 ///
 /// All variants are returned, never panicked — the release profile uses
@@ -80,7 +87,8 @@ pub(crate) const NER_ENTITIES: &[Entity] = &[
 /// Reports whether any BIO label maps to a supported NER entity.
 ///
 /// Shares [`parse_bio`] with decoding, so the load gate accepts exactly the
-/// models `run_window` can decode — rejecting one that emits no target label.
+/// models [`NerEngine::decode_row`] can decode — rejecting one that emits no
+/// target label.
 fn has_supported_entity(labels: &[String]) -> bool {
     labels.iter().any(|label| parse_bio(label).0.is_some())
 }
@@ -134,7 +142,7 @@ fn softmax_argmax(logits: &[f32]) -> (usize, f32) {
 }
 
 /// One token's decoded BIO tag with its byte span and confidence.
-#[derive(Debug)]
+#[derive(Debug, Clone, Copy)]
 struct TokenTag {
     entity: Option<Entity>,
     is_begin: bool,
@@ -194,13 +202,7 @@ fn aggregate_words(tags: &[TokenTag], word_ids: &[Option<u32>]) -> Vec<TokenTag>
             }
             Some(id) => {
                 current = Some(id);
-                out.push(TokenTag {
-                    entity: tag.entity,
-                    is_begin: tag.is_begin,
-                    score: tag.score,
-                    start: tag.start,
-                    end: tag.end,
-                });
+                out.push(*tag);
             }
             None => {
                 current = None;
@@ -291,6 +293,16 @@ fn span_to_result(span: Span) -> RecognizerResult {
     }
 }
 
+/// One tokenized window paired with the index of the text it came from.
+///
+/// Over-long inputs yield several windows; batching flattens every window
+/// across every input into one list, so each carries its `src` index to route
+/// decoded spans back to the right text.
+struct Window {
+    src: usize,
+    enc: tokenizers::Encoding,
+}
+
 /// Loaded token-classification session plus its tokenizer and label map.
 ///
 /// Cheap to share behind an `Arc`. `ort` runs inference through `&mut Session`,
@@ -303,6 +315,8 @@ pub struct NerEngine {
     allowed: Vec<Entity>,
     /// Whether the graph declares a `token_type_ids` input (`DistilBERT` omits it).
     needs_token_type_ids: bool,
+    /// Token id used to right-pad batched rows; masked out, so its value is inert.
+    pad_id: i64,
 }
 
 impl std::fmt::Debug for NerEngine {
@@ -342,6 +356,17 @@ impl NerEngine {
             }))
             .map_err(|e| NerError::Load(format!("truncation config: {e}")))?;
 
+        // Pad id for batched rows: honour an embedded padding config, else the
+        // tokenizer's `[PAD]` token, else 0. Padded positions are attention-masked
+        // and never decoded, so this only needs to be a valid vocab index.
+        let pad_id = i64::from(
+            tokenizer
+                .get_padding()
+                .map(|p| p.pad_id)
+                .or_else(|| tokenizer.token_to_id("[PAD]"))
+                .unwrap_or(0),
+        );
+
         let session = Session::builder()
             .map_err(|e| NerError::Load(format!("session builder: {e}")))?
             .commit_from_file(model_dir.join("model.onnx"))
@@ -355,6 +380,7 @@ impl NerEngine {
             threshold,
             allowed: NER_ENTITIES.to_vec(),
             needs_token_type_ids,
+            pad_id,
         })
     }
 
@@ -375,64 +401,139 @@ impl NerEngine {
 
     /// Runs NER over one text, returning its spans as [`RecognizerResult`]s.
     ///
-    /// Byte offsets index into `text`. Over-long inputs are split into
-    /// overlapping windows whose spans merge via `crate::overlap::resolve`.
+    /// Byte offsets index into `text`. A thin wrapper over [`Self::analyze_batch`]
+    /// so single and batched inference share one code path.
     ///
     /// # Errors
     ///
     /// Returns [`NerError::Inference`] on a tokenization or forward-pass
     /// failure. Never panics.
     pub fn analyze(&self, text: &str) -> Result<Vec<RecognizerResult>, NerError> {
-        if text.is_empty() {
-            return Ok(Vec::new());
-        }
-        let encoding = self
-            .tokenizer
-            .encode(text, true)
-            .map_err(|e| NerError::Inference(format!("tokenize: {e}")))?;
-
-        let mut results = Vec::new();
-        self.run_window(&encoding, &mut results)?;
-        for overflow in encoding.get_overflowing() {
-            self.run_window(overflow, &mut results)?;
-        }
-        Ok(crate::overlap::resolve(results))
+        // `analyze_batch` returns one vec per input, so a one-text batch yields
+        // exactly one; `unwrap_or_default` keeps the impossible empty case panic-free.
+        Ok(self.analyze_batch(&[text])?.into_iter().next().unwrap_or_default())
     }
 
-    /// Runs one tokenized window through the model and appends decoded spans.
-    fn run_window(&self, enc: &tokenizers::Encoding, results: &mut Vec<RecognizerResult>) -> Result<(), NerError> {
-        let ids = enc.get_ids();
-        let seq = ids.len();
+    /// Runs NER over many texts in one batched forward pass.
+    ///
+    /// Returns one span vec per input, index-aligned; each span's byte offsets
+    /// index into its own text. Empty inputs yield an empty vec. Every input is
+    /// tokenized independently (so offsets stay per-text); batching happens only
+    /// at the tensor level — windows are padded to a common length and stacked
+    /// into `[batch, seq]`. Over-long inputs split into overlapping windows whose
+    /// spans merge per text via `crate::overlap::resolve`.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`NerError::Inference`] on a tokenization or forward-pass
+    /// failure. Never panics.
+    pub fn analyze_batch(&self, texts: &[&str]) -> Result<Vec<Vec<RecognizerResult>>, NerError> {
+        let mut results: Vec<Vec<RecognizerResult>> = vec![Vec::new(); texts.len()];
+        if self.id2label.is_empty() {
+            return Ok(results);
+        }
+
+        // Flatten every window across every text into one list tagged by source.
+        let mut windows: Vec<Window> = Vec::with_capacity(texts.len());
+        for (i, text) in texts.iter().enumerate() {
+            if text.is_empty() {
+                continue;
+            }
+            let encoding = self
+                .tokenizer
+                .encode(*text, true)
+                .map_err(|e| NerError::Inference(format!("tokenize: {e}")))?;
+            // Borrow the overflow windows before moving the main encoding below.
+            for overflow in encoding.get_overflowing() {
+                if !overflow.get_ids().is_empty() {
+                    windows.push(Window {
+                        src: i,
+                        enc: overflow.clone(),
+                    });
+                }
+            }
+            if !encoding.get_ids().is_empty() {
+                windows.push(Window { src: i, enc: encoding });
+            }
+        }
+
+        for chunk in windows.chunks(NER_BATCH_SIZE) {
+            self.run_chunk(chunk, &mut results)?;
+        }
+
+        // Merge overflow-window dupes per text, exactly as the single path did.
+        for spans in &mut results {
+            if !spans.is_empty() {
+                *spans = crate::overlap::resolve(std::mem::take(spans));
+            }
+        }
+        Ok(results)
+    }
+
+    /// Runs one chunk of windows through the model and routes spans by source.
+    ///
+    /// Builds padded `[batch, max_len]` i64 tensors (right-padding with `pad_id`
+    /// and attention-mask zeros), one `session.run`, then decodes each row using
+    /// its window's own offsets and real token length into `results[src]`.
+    fn run_chunk(&self, chunk: &[Window], results: &mut [Vec<RecognizerResult>]) -> Result<(), NerError> {
+        let batch = chunk.len();
         let num_labels = self.id2label.len();
-        if seq == 0 || num_labels == 0 {
+        // Dynamic padding to the longest window in the chunk (clamp is defensive:
+        // the tokenizer already truncates each window to MAX_SEQ_LEN).
+        let max_len = chunk
+            .iter()
+            .map(|w| w.enc.get_ids().len())
+            .max()
+            .unwrap_or(0)
+            .min(MAX_SEQ_LEN);
+        if batch == 0 || max_len == 0 {
             return Ok(());
         }
 
-        let len = i64::try_from(seq).map_err(|_| NerError::Inference("sequence too long".to_owned()))?;
-        let shape = [1_i64, len];
-        // BERT ONNX exports take int64 inputs; build one `[1, seq]` tensor per field.
-        let tensor = |name: &str, data: &[u32]| -> Result<Tensor<i64>, NerError> {
-            let row: Vec<i64> = data.iter().map(|&v| i64::from(v)).collect();
-            Tensor::from_array((shape, row)).map_err(|e| NerError::Inference(format!("{name}: {e}")))
+        // Right-pad each window into flat row-major `[batch, max_len]` buffers.
+        let mut input_ids = vec![self.pad_id; batch * max_len];
+        let mut attention = vec![0_i64; batch * max_len];
+        let mut type_ids = if self.needs_token_type_ids {
+            vec![0_i64; batch * max_len]
+        } else {
+            Vec::new()
+        };
+        for (r, w) in chunk.iter().enumerate() {
+            let ids = w.enc.get_ids();
+            let mask = w.enc.get_attention_mask();
+            let base = r * max_len;
+            let real = ids.len().min(max_len);
+            for t in 0..real {
+                input_ids[base + t] = i64::from(ids[t]);
+                attention[base + t] = i64::from(mask[t]);
+            }
+            if self.needs_token_type_ids {
+                let tti = w.enc.get_type_ids();
+                for t in 0..real {
+                    type_ids[base + t] = i64::from(tti[t]);
+                }
+            }
+        }
+
+        let bdim = i64::try_from(batch).map_err(|_| NerError::Inference("batch too large".to_owned()))?;
+        let sdim = i64::try_from(max_len).map_err(|_| NerError::Inference("sequence too long".to_owned()))?;
+        let shape = [bdim, sdim];
+        // BERT ONNX exports take int64 inputs; one `[batch, max_len]` tensor per field.
+        let make = |name: &str, data: Vec<i64>| -> Result<Tensor<i64>, NerError> {
+            Tensor::from_array((shape, data)).map_err(|e| NerError::Inference(format!("{name}: {e}")))
         };
         let mut inputs = ort::inputs![
-            "input_ids" => tensor("input_ids", ids)?,
-            "attention_mask" => tensor("attention_mask", enc.get_attention_mask())?,
+            "input_ids" => make("input_ids", input_ids)?,
+            "attention_mask" => make("attention_mask", attention)?,
         ];
         // DistilBERT-style models omit token_type_ids; only send it when declared.
         if self.needs_token_type_ids {
-            inputs.push((
-                "token_type_ids".into(),
-                tensor("token_type_ids", enc.get_type_ids())?.into(),
-            ));
+            inputs.push(("token_type_ids".into(), make("token_type_ids", type_ids)?.into()));
         }
-        let offsets = enc.get_offsets();
-        let word_ids = enc.get_word_ids();
 
-        // Hold the session lock for inference and reading logits only. The guard
-        // (and the `logits` slice borrowed from it) drop at the end of this block,
-        // releasing the Mutex before the pure-CPU aggregation/decoding below.
-        let tags = {
+        // Hold the session lock for inference and reading logits only, then copy
+        // them out so the pure-CPU decode below runs without the Mutex held.
+        let logits: Vec<f32> = {
             let mut session = self
                 .session
                 .lock()
@@ -448,38 +549,61 @@ impl NerEngine {
             let (_logits_shape, logits) = output
                 .try_extract_tensor::<f32>()
                 .map_err(|e| NerError::Inference(format!("extract logits: {e}")))?;
-
-            let mut tags = Vec::with_capacity(seq);
-            for t in 0..seq {
-                // Special tokens ([CLS]/[SEP]) carry no word id; emit a closing "O".
-                // This is the same signal `aggregate_words` folds on, so one lookup
-                // gates both the skip here and the word grouping below.
-                if word_ids.get(t).copied().flatten().is_none() {
-                    tags.push(TokenTag::outside());
-                    continue;
-                }
-                let logit_row = logits.get(t * num_labels..(t + 1) * num_labels).unwrap_or(&[]);
-                let (best, prob) = softmax_argmax(logit_row);
-                let label = self.id2label.get(best).map_or("O", String::as_str);
-                let (mut entity, is_begin) = parse_bio(label);
-                if !self.entity_allowed(entity) {
-                    entity = None;
-                }
-                let (start, end) = offsets.get(t).copied().unwrap_or((0, 0));
-                tags.push(TokenTag {
-                    entity,
-                    is_begin,
-                    score: prob,
-                    start,
-                    end,
-                });
-            }
-            tags
+            logits.to_vec()
         };
 
-        let words = aggregate_words(&tags, word_ids);
-        results.extend(decode_spans(&words, self.threshold).into_iter().map(span_to_result));
+        let row_stride = max_len * num_labels;
+        for (r, w) in chunk.iter().enumerate() {
+            let real = w.enc.get_ids().len().min(max_len);
+            let start = r * row_stride;
+            // Decode only the row's real (unpadded) tokens; pad positions are skipped.
+            let Some(row_logits) = logits.get(start..start + real * num_labels) else {
+                continue;
+            };
+            self.decode_row(row_logits, &w.enc, &mut results[w.src]);
+        }
         Ok(())
+    }
+
+    /// Decodes one row of logits (`real_len × num_labels`, row-major) into spans.
+    ///
+    /// `enc` supplies the per-token byte offsets and word ids; decoded spans are
+    /// appended to `out` with byte offsets into `enc`'s source text. Shared by the
+    /// single and batched paths so both decode bit-for-bit identically.
+    fn decode_row(&self, logit_rows: &[f32], enc: &tokenizers::Encoding, out: &mut Vec<RecognizerResult>) {
+        let seq = enc.get_ids().len();
+        let num_labels = self.id2label.len();
+        let offsets = enc.get_offsets();
+        let word_ids = enc.get_word_ids();
+
+        let mut tags = Vec::with_capacity(seq);
+        for t in 0..seq {
+            // Special tokens ([CLS]/[SEP]) carry no word id; emit a closing "O".
+            // This is the same signal `aggregate_words` folds on, so one lookup
+            // gates both the skip here and the word grouping below.
+            if word_ids.get(t).copied().flatten().is_none() {
+                tags.push(TokenTag::outside());
+                continue;
+            }
+            let logit_row = logit_rows.get(t * num_labels..(t + 1) * num_labels).unwrap_or(&[]);
+            let (best, prob) = softmax_argmax(logit_row);
+            let label = self.id2label.get(best).map_or("O", String::as_str);
+            let (mut entity, is_begin) = parse_bio(label);
+            if !self.entity_allowed(entity) {
+                entity = None;
+            }
+            let (start, end) = offsets.get(t).copied().unwrap_or((0, 0));
+            tags.push(TokenTag {
+                entity,
+                is_begin,
+                score: prob,
+                start,
+                end,
+            });
+        }
+
+        let words = aggregate_words(&tags, word_ids);
+        out.extend(decode_spans(&words, self.threshold).into_iter().map(span_to_result));
     }
 }
 

--- a/crates/pii/src/redact.rs
+++ b/crates/pii/src/redact.rs
@@ -78,6 +78,16 @@ enum Frame<'a> {
     Pop(usize),
 }
 
+/// One string leaf deferred to the batched NER pass.
+///
+/// Holds a write-back handle to the leaf, an owned copy of its text (the batch
+/// input, kept independent of `slot`), and the already-computed regex spans.
+struct LeafSlot<'a> {
+    slot: &'a mut String,
+    text: String,
+    regex: Vec<RecognizerResult>,
+}
+
 /// Redacts PII from query tool response rows.
 ///
 /// Holds an [`Arc<Analyzer>`] so handlers stay cheap to clone.
@@ -181,6 +191,12 @@ impl Redactor {
         let mut stats = RedactionStats::default();
         let mut infer_err: Option<String> = None;
         let result = catch_unwind(AssertUnwindSafe(|| {
+            // When NER is attached, defer inference: collect every leaf during the
+            // walk and run one batched forward pass afterwards, instead of one pass
+            // per leaf. Without NER, anonymize inline (regex-only, no leaf clones).
+            let ner_engine = self.analyzer.ner_engine();
+            let mut slots: Vec<LeafSlot<'_>> = Vec::new();
+
             // Shared key-path stack. Each `Frame::KeyedChild` carries the tokens
             // to push when entered; a `Frame::Pop` queued before its children
             // restores the path after the subtree is done. This keeps path
@@ -206,28 +222,15 @@ impl Redactor {
                 match v {
                     Value::String(s) => {
                         stats.string_leaves_scanned += 1;
-                        let mut results = self.analyzer.analyze_with_context(s, &path, &self.opts);
-                        if let Some(engine) = self.analyzer.ner_engine() {
-                            match engine.analyze(s) {
-                                Ok(ner) => results = merge_spans(results, ner, self.opts.min_score),
-                                Err(e) => {
-                                    infer_err = Some(e.to_string());
-                                    return;
-                                }
-                            }
+                        let regex = self.analyzer.analyze_with_context(s, &path, &self.opts);
+                        if ner_engine.is_some() {
+                            // Clone the leaf as batch input; keep `s` as the
+                            // write-back handle for the merge pass below.
+                            let text = s.clone();
+                            slots.push(LeafSlot { slot: s, text, regex });
+                        } else if !regex.is_empty() {
+                            apply_spans(s, regex, &self.operator, &mut stats);
                         }
-                        if results.is_empty() {
-                            continue;
-                        }
-                        let anon = anonymize(s, results, &self.operator);
-                        if anon.operations.is_empty() {
-                            continue;
-                        }
-                        for op in &anon.operations {
-                            stats.total += 1;
-                            *stats.by_entity.entry(op.entity_type).or_insert(0) += 1;
-                        }
-                        *s = anon.text;
                     }
                     Value::Object(map) => {
                         for (key, child) in map.iter_mut() {
@@ -242,6 +245,28 @@ impl Redactor {
                         }
                     }
                     Value::Number(_) | Value::Bool(_) | Value::Null => {}
+                }
+            }
+
+            // Batched NER pass: one forward pass over every collected leaf, then
+            // merge each leaf's regex + NER spans and rewrite it in place. On
+            // failure, record the error and rewrite nothing — `apply` fails closed
+            // and the caller discards the rows, so partial state never leaks.
+            if let Some(engine) = ner_engine
+                && !slots.is_empty()
+            {
+                let texts: Vec<&str> = slots.iter().map(|l| l.text.as_str()).collect();
+                match engine.analyze_batch(&texts) {
+                    Ok(per_leaf) => {
+                        for (leaf, ner) in slots.into_iter().zip(per_leaf) {
+                            let results = merge_spans(leaf.regex, ner, self.opts.min_score);
+                            if results.is_empty() {
+                                continue;
+                            }
+                            apply_spans(leaf.slot, results, &self.operator, &mut stats);
+                        }
+                    }
+                    Err(e) => infer_err = Some(e.to_string()),
                 }
             }
         }));
@@ -275,6 +300,29 @@ impl Redactor {
         } else {
             self.apply(&mut rows)?;
             Ok(rows)
+        }
+    }
+}
+
+/// Redaction over the `Option<Redactor>` field every query handler holds.
+///
+/// Centralizes the "redact when enabled, pass through when not" branch so
+/// each query tool calls one method instead of matching on the option.
+#[allow(async_fn_in_trait)]
+pub trait MaybeRedact {
+    /// Redacts `rows` when a redactor is present, else returns them unchanged.
+    ///
+    /// # Errors
+    ///
+    /// Propagates [`RedactionError`] from [`Redactor::redact_rows`].
+    async fn redact_rows(&self, rows: Vec<Value>) -> Result<Vec<Value>, RedactionError>;
+}
+
+impl MaybeRedact for Option<Redactor> {
+    async fn redact_rows(&self, rows: Vec<Value>) -> Result<Vec<Value>, RedactionError> {
+        match self {
+            Some(r) => r.redact_rows(rows).await,
+            None => Ok(rows),
         }
     }
 }
@@ -338,6 +386,22 @@ fn allowed_ner_entities(cfg: &dbmcp_config::PiiConfig) -> Vec<Entity> {
             Some(cats) => ner_entity_category(entity).is_some_and(|c| cats.contains(&c)),
         })
         .collect()
+}
+
+/// Anonymizes one leaf string in place, folding its operations into `stats`.
+///
+/// No-op when the resolved spans produce no operations. Shared by the inline
+/// regex-only path and the batched NER merge pass.
+fn apply_spans(s: &mut String, results: Vec<RecognizerResult>, operator: &OperatorConfig, stats: &mut RedactionStats) {
+    let anon = anonymize(s, results, operator);
+    if anon.operations.is_empty() {
+        return;
+    }
+    for op in &anon.operations {
+        stats.total += 1;
+        *stats.by_entity.entry(op.entity_type).or_insert(0) += 1;
+    }
+    *s = anon.text;
 }
 
 /// Merges regex and NER spans for one leaf into a resolved result set.
@@ -945,5 +1009,20 @@ mod tests {
             allowed_ner_entities(&cfg).is_empty(),
             "a non-NER category must allow no NER entities (model not loaded)"
         );
+    }
+
+    #[tokio::test]
+    async fn maybe_redact_none_passes_rows_through_unchanged() {
+        let redactor: Option<Redactor> = None;
+        let rows = vec![email_row()];
+        let out = redactor.redact_rows(rows.clone()).await.expect("none passes through");
+        assert_eq!(out, rows);
+    }
+
+    #[tokio::test]
+    async fn maybe_redact_some_redacts_like_the_inner_redactor() {
+        let redactor = Some(Redactor::with_defaults());
+        let out = redactor.redact_rows(vec![email_row()]).await.expect("some redacts");
+        assert_eq!(out[0]["msg"], "ping me at <EMAIL_ADDRESS>");
     }
 }

--- a/crates/pii/src/redact.rs
+++ b/crates/pii/src/redact.rs
@@ -80,8 +80,9 @@ enum Frame<'a> {
 
 /// One string leaf deferred to the batched NER pass.
 ///
-/// Holds a write-back handle to the leaf, an owned copy of its text (the batch
-/// input, kept independent of `slot`), and the already-computed regex spans.
+/// `slot` is the write-back handle to the (now-empty) leaf; `text` owns the
+/// leaf's original contents, moved out to serve as batch input; `regex` holds
+/// its already-computed regex spans. The merge pass restores `text` into `slot`.
 struct LeafSlot<'a> {
     slot: &'a mut String,
     text: String,
@@ -193,7 +194,7 @@ impl Redactor {
         let result = catch_unwind(AssertUnwindSafe(|| {
             // When NER is attached, defer inference: collect every leaf during the
             // walk and run one batched forward pass afterwards, instead of one pass
-            // per leaf. Without NER, anonymize inline (regex-only, no leaf clones).
+            // per leaf. Without NER, anonymize inline (regex-only).
             let ner_engine = self.analyzer.ner_engine();
             let mut slots: Vec<LeafSlot<'_>> = Vec::new();
 
@@ -224,9 +225,10 @@ impl Redactor {
                         stats.string_leaves_scanned += 1;
                         let regex = self.analyzer.analyze_with_context(s, &path, &self.opts);
                         if ner_engine.is_some() {
-                            // Clone the leaf as batch input; keep `s` as the
-                            // write-back handle for the merge pass below.
-                            let text = s.clone();
+                            // Move the leaf's text out as batch input (no clone),
+                            // leaving the leaf empty; the merge pass restores it
+                            // before rewriting. `s` stays as the write-back handle.
+                            let text = std::mem::take(s);
                             slots.push(LeafSlot { slot: s, text, regex });
                         } else if !regex.is_empty() {
                             apply_spans(s, regex, &self.operator, &mut stats);
@@ -248,10 +250,9 @@ impl Redactor {
                 }
             }
 
-            // Batched NER pass: one forward pass over every collected leaf, then
-            // merge each leaf's regex + NER spans and rewrite it in place. On
-            // failure, record the error and rewrite nothing — `apply` fails closed
-            // and the caller discards the rows, so partial state never leaks.
+            // On failure, record the error and leave the moved-out leaves empty:
+            // `apply` fails closed and the caller discards the rows, so the
+            // emptied (or partial) state never leaks.
             if let Some(engine) = ner_engine
                 && !slots.is_empty()
             {
@@ -259,11 +260,14 @@ impl Redactor {
                 match engine.analyze_batch(&texts) {
                     Ok(per_leaf) => {
                         for (leaf, ner) in slots.into_iter().zip(per_leaf) {
+                            // Restore the moved-out text into the emptied leaf, so a
+                            // no-PII leaf keeps its original value and apply_spans
+                            // rewrites in place.
+                            *leaf.slot = leaf.text;
                             let results = merge_spans(leaf.regex, ner, self.opts.min_score);
-                            if results.is_empty() {
-                                continue;
+                            if !results.is_empty() {
+                                apply_spans(leaf.slot, results, &self.operator, &mut stats);
                             }
-                            apply_spans(leaf.slot, results, &self.operator, &mut stats);
                         }
                     }
                     Err(e) => infer_err = Some(e.to_string()),
@@ -1009,6 +1013,38 @@ mod tests {
             allowed_ner_entities(&cfg).is_empty(),
             "a non-NER category must allow no NER entities (model not loaded)"
         );
+    }
+
+    #[test]
+    fn ner_redactor_preserves_non_pii_leaves() {
+        // Exercises the batched-NER deferral in `apply`: a leaf whose text is
+        // moved out for inference must be restored verbatim when it yields no
+        // spans. Dropping the restore would silently blank every non-PII string
+        // under NER, so this guards that invariant. Skips without a local model.
+        let Some(dir) = std::env::var_os("PII_NER_TEST_MODEL").map(std::path::PathBuf::from) else {
+            eprintln!("PII_NER_TEST_MODEL unset; skipping NER redactor test");
+            return;
+        };
+        let cfg = dbmcp_config::PiiConfig {
+            enabled: true,
+            ner_enabled: true,
+            ner_model: Some(dir),
+            ..dbmcp_config::PiiConfig::default()
+        };
+        let r = Redactor::from_config(&cfg)
+            .expect("config ok")
+            .expect("redactor present");
+        let mut rows = vec![json!({
+            "name": "Alice Johnson",
+            "clean": "status code 200 returned",
+            "n": 42,
+        })];
+        r.apply(&mut rows).expect("apply ok");
+        // Non-PII leaf survives verbatim (the moved-out text was restored).
+        assert_eq!(rows[0]["clean"], "status code 200 returned");
+        assert_eq!(rows[0]["n"], 42);
+        // The person name is redacted (changed from the original).
+        assert_ne!(rows[0]["name"], "Alice Johnson");
     }
 
     #[tokio::test]

--- a/crates/pii/tests/ner.rs
+++ b/crates/pii/tests/ner.rs
@@ -11,11 +11,69 @@
 
 use std::path::{Path, PathBuf};
 
-use dbmcp_pii::{Entity, NerEngine, Score};
+use dbmcp_pii::{Entity, NerEngine, RecognizerResult, Score};
 
 /// Returns the configured model directory, or `None` to skip the test.
 fn model_dir() -> Option<PathBuf> {
     std::env::var_os("PII_NER_TEST_MODEL").map(PathBuf::from)
+}
+
+/// Loads the test engine, or `None` (with a skip note) when no model is set.
+fn engine() -> Option<NerEngine> {
+    let dir = model_dir()?;
+    Some(NerEngine::load(&dir, Score::from_static(0.5)).expect("model loads"))
+}
+
+/// Spans as `(entity, start, end, score)`, sorted by the offset key.
+fn sorted_spans(results: &[RecognizerResult]) -> Vec<(Entity, usize, usize, f32)> {
+    let mut v: Vec<_> = results
+        .iter()
+        .map(|r| (r.entity_type, r.start, r.end, r.score.as_f32()))
+        .collect();
+    v.sort_by_key(|a| (a.0, a.1, a.2));
+    v
+}
+
+/// Maximum tolerated score drift between batched and single inference.
+///
+/// ONNX Runtime does not guarantee bitwise-identical logits across batch shapes
+/// (GEMM tiling and reduction order differ), so softmax probabilities drift. The
+/// drift grows with how different the two batch compositions are: ~1.5e-3 for
+/// simple inputs, but up to ~8e-3 for spans on an overflow-window boundary whose
+/// row sits next to very different neighbours in one run and not the other. `2e-2`
+/// absorbs that with margin while still catching a genuine score regression.
+///
+/// The real equivalence guarantee — and what drives redaction — is the span set
+/// (entity + byte offsets), which must match exactly; an indexing bug would shift
+/// the argmax and so the spans, not merely jitter the scores.
+const SCORE_EPS: f32 = 2e-2;
+
+/// Asserts a batched result equals the single-text result for the same input.
+///
+/// Span sets (entity + byte offsets) must match exactly; scores are compared
+/// within [`SCORE_EPS`].
+fn assert_equivalent(batched: &[RecognizerResult], single: &[RecognizerResult], label: &str) {
+    let b = sorted_spans(batched);
+    let s = sorted_spans(single);
+    let bk: Vec<_> = b.iter().map(|x| (x.0, x.1, x.2)).collect();
+    let sk: Vec<_> = s.iter().map(|x| (x.0, x.1, x.2)).collect();
+    assert_eq!(bk, sk, "span set differs for {label:?}");
+    for (x, y) in b.iter().zip(&s) {
+        assert!(
+            (x.3 - y.3).abs() < SCORE_EPS,
+            "score mismatch for {label:?}: {x:?} vs {y:?}"
+        );
+    }
+}
+
+/// Runs `analyze_batch` and asserts each row matches its single-text result.
+fn assert_batch_matches_single(engine: &NerEngine, texts: &[&str]) {
+    let batched = engine.analyze_batch(texts).expect("batch inference succeeds");
+    assert_eq!(batched.len(), texts.len(), "one result vec per input");
+    for (i, text) in texts.iter().enumerate() {
+        let single = engine.analyze(text).expect("single inference succeeds");
+        assert_equivalent(&batched[i], &single, text);
+    }
 }
 
 /// Returns `true` when `config.json` declares a label containing any needle.
@@ -123,4 +181,79 @@ fn clean_text_yields_no_spans() {
         .analyze("the invoice total was forty two dollars")
         .expect("inference succeeds");
     assert!(out.is_empty(), "no entities expected, got {out:?}");
+}
+
+#[test]
+fn analyze_batch_matches_single() {
+    let Some(engine) = engine() else {
+        eprintln!("PII_NER_TEST_MODEL unset; skipping NER integration test");
+        return;
+    };
+    // Batching several texts together must not change any individual result
+    // versus running each one alone (a batch of one).
+    assert_batch_matches_single(
+        &engine,
+        &[
+            "My name is Alice Johnson",
+            "She flew to Berlin last week",
+            "the invoice total was forty two dollars",
+            "She joined Microsoft Corporation last year",
+        ],
+    );
+}
+
+#[test]
+fn analyze_batch_mixed_lengths() {
+    let Some(engine) = engine() else {
+        eprintln!("PII_NER_TEST_MODEL unset; skipping NER integration test");
+        return;
+    };
+    // Mixed lengths force dynamic right-padding to the longest window; padded
+    // positions are attention-masked and must not perturb the short rows.
+    let medium = "Alice Johnson met Bob Smith in Berlin while at Microsoft Corporation";
+    assert_batch_matches_single(&engine, &["Hi", "She flew to Berlin", medium]);
+}
+
+#[test]
+fn analyze_batch_empty_interspersed() {
+    let Some(engine) = engine() else {
+        eprintln!("PII_NER_TEST_MODEL unset; skipping NER integration test");
+        return;
+    };
+    let texts = ["Alice Johnson", "", "Berlin"];
+    let batched = engine.analyze_batch(&texts).expect("batch inference succeeds");
+    assert_eq!(batched.len(), 3);
+    assert!(batched[1].is_empty(), "empty input yields an empty result vec");
+    assert_batch_matches_single(&engine, &texts);
+}
+
+#[test]
+fn analyze_batch_overflow_with_short() {
+    let Some(engine) = engine() else {
+        eprintln!("PII_NER_TEST_MODEL unset; skipping NER integration test");
+        return;
+    };
+    // A long text exceeds MAX_SEQ_LEN, so it splits into several overlapping
+    // windows. Batched with short texts, those windows must still route back to
+    // the long text and resolve identically to its single-text result.
+    let long = "Alice Johnson flew to Berlin and joined Microsoft Corporation. ".repeat(100);
+    assert_batch_matches_single(&engine, &["Short note about Alice Johnson", long.as_str(), "Berlin"]);
+}
+
+#[test]
+fn analyze_batch_larger_than_batch_size() {
+    let Some(engine) = engine() else {
+        eprintln!("PII_NER_TEST_MODEL unset; skipping NER integration test");
+        return;
+    };
+    // More inputs than NER_BATCH_SIZE (16) so the window list spans several
+    // chunks; per-chunk forward passes must still produce per-text results.
+    let texts: Vec<&str> = (0..40)
+        .map(|i| match i % 3 {
+            0 => "Alice Johnson lives in Berlin",
+            1 => "no personal data in this line",
+            _ => "She joined Microsoft Corporation",
+        })
+        .collect();
+    assert_batch_matches_single(&engine, &texts);
 }

--- a/crates/postgres/src/tools/explain_query.rs
+++ b/crates/postgres/src/tools/explain_query.rs
@@ -2,6 +2,7 @@
 
 use std::borrow::Cow;
 
+use dbmcp_pii::MaybeRedact as _;
 use dbmcp_server::types::{PinnedExplainQueryRequest, QueryResponse, UnpinnedExplainQueryRequest};
 use dbmcp_sql::Connection as _;
 use dbmcp_sql::validation::validate_read_only;
@@ -116,10 +117,8 @@ impl PostgresHandler {
             format!("EXPLAIN (FORMAT JSON) {query}")
         };
 
-        let mut rows = self.connection.fetch_json(explain_sql.as_str(), database).await?;
-        if let Some(r) = &self.redactor {
-            r.apply(&mut rows)?;
-        }
+        let rows = self.connection.fetch_json(explain_sql.as_str(), database).await?;
+        let rows = self.redactor.redact_rows(rows).await?;
 
         Ok(QueryResponse { rows })
     }

--- a/crates/postgres/src/tools/read_query.rs
+++ b/crates/postgres/src/tools/read_query.rs
@@ -2,6 +2,7 @@
 
 use std::borrow::Cow;
 
+use dbmcp_pii::MaybeRedact as _;
 use dbmcp_server::pagination::{Cursor, Pager};
 use dbmcp_server::types::{PinnedReadQueryRequest, ReadQueryResponse, UnpinnedReadQueryRequest};
 use dbmcp_sql::Connection as _;
@@ -113,29 +114,19 @@ impl PostgresHandler {
         let kind = validate_read_only(&query, &sqlparser::dialect::PostgreSqlDialect {})?;
         let database = database.as_deref().map(str::trim).filter(|s| !s.is_empty());
 
-        match kind {
+        let (rows, next_cursor) = match kind {
             StatementKind::Select => {
                 let pager = Pager::new(cursor, self.config.page_size);
                 let wrapped = with_limit_offset(&query, pager.limit(), pager.offset());
                 let rows = self.connection.fetch_json(wrapped.as_str(), database).await?;
-                let (rows, next_cursor) = pager.paginate(rows);
-                let rows = match &self.redactor {
-                    Some(r) => r.redact_rows(rows).await?,
-                    None => rows,
-                };
-                Ok(ReadQueryResponse { rows, next_cursor })
+                pager.paginate(rows)
             }
             StatementKind::NonSelect => {
                 let rows = self.connection.fetch_json(query.as_str(), database).await?;
-                let rows = match &self.redactor {
-                    Some(r) => r.redact_rows(rows).await?,
-                    None => rows,
-                };
-                Ok(ReadQueryResponse {
-                    rows,
-                    next_cursor: None,
-                })
+                (rows, None)
             }
-        }
+        };
+        let rows = self.redactor.redact_rows(rows).await?;
+        Ok(ReadQueryResponse { rows, next_cursor })
     }
 }

--- a/crates/postgres/src/tools/write_query.rs
+++ b/crates/postgres/src/tools/write_query.rs
@@ -2,6 +2,7 @@
 
 use std::borrow::Cow;
 
+use dbmcp_pii::MaybeRedact as _;
 use dbmcp_server::types::{PinnedQueryRequest, QueryResponse, UnpinnedQueryRequest};
 use dbmcp_sql::Connection as _;
 use rmcp::handler::server::router::tool::{AsyncTool, ToolBase};
@@ -92,10 +93,8 @@ impl PostgresHandler {
     /// Returns [`SqlError`] if the query fails.
     pub async fn write_query(&self, query: String, database: Option<String>) -> Result<QueryResponse, ErrorData> {
         let database = database.as_deref().map(str::trim).filter(|s| !s.is_empty());
-        let mut rows = self.connection.fetch_json(query.as_str(), database).await?;
-        if let Some(r) = &self.redactor {
-            r.apply(&mut rows)?;
-        }
+        let rows = self.connection.fetch_json(query.as_str(), database).await?;
+        let rows = self.redactor.redact_rows(rows).await?;
         Ok(QueryResponse { rows })
     }
 }

--- a/crates/sqlite/src/tools/explain_query.rs
+++ b/crates/sqlite/src/tools/explain_query.rs
@@ -2,6 +2,7 @@
 
 use std::borrow::Cow;
 
+use dbmcp_pii::MaybeRedact as _;
 use dbmcp_server::types::QueryResponse;
 
 use dbmcp_sql::Connection as _;
@@ -67,10 +68,8 @@ impl SqliteHandler {
     ) -> Result<QueryResponse, ErrorData> {
         let explain_sql = format!("EXPLAIN QUERY PLAN {query}");
 
-        let mut rows = self.connection.fetch_json(explain_sql.as_str(), None).await?;
-        if let Some(r) = &self.redactor {
-            r.apply(&mut rows)?;
-        }
+        let rows = self.connection.fetch_json(explain_sql.as_str(), None).await?;
+        let rows = self.redactor.redact_rows(rows).await?;
 
         Ok(QueryResponse { rows })
     }

--- a/crates/sqlite/src/tools/read_query.rs
+++ b/crates/sqlite/src/tools/read_query.rs
@@ -2,6 +2,7 @@
 
 use std::borrow::Cow;
 
+use dbmcp_pii::MaybeRedact as _;
 use dbmcp_server::pagination::Pager;
 use dbmcp_server::types::ReadQueryResponse;
 
@@ -76,29 +77,19 @@ impl SqliteHandler {
     ) -> Result<ReadQueryResponse, ErrorData> {
         let kind = validate_read_only(&query, &sqlparser::dialect::SQLiteDialect {})?;
 
-        match kind {
+        let (rows, next_cursor) = match kind {
             StatementKind::Select => {
                 let pager = Pager::new(cursor, self.config.page_size);
                 let wrapped = with_limit_offset(&query, pager.limit(), pager.offset());
                 let rows = self.connection.fetch_json(wrapped.as_str(), None).await?;
-                let (rows, next_cursor) = pager.paginate(rows);
-                let rows = match &self.redactor {
-                    Some(r) => r.redact_rows(rows).await?,
-                    None => rows,
-                };
-                Ok(ReadQueryResponse { rows, next_cursor })
+                pager.paginate(rows)
             }
             StatementKind::NonSelect => {
                 let rows = self.connection.fetch_json(query.as_str(), None).await?;
-                let rows = match &self.redactor {
-                    Some(r) => r.redact_rows(rows).await?,
-                    None => rows,
-                };
-                Ok(ReadQueryResponse {
-                    rows,
-                    next_cursor: None,
-                })
+                (rows, None)
             }
-        }
+        };
+        let rows = self.redactor.redact_rows(rows).await?;
+        Ok(ReadQueryResponse { rows, next_cursor })
     }
 }

--- a/crates/sqlite/src/tools/write_query.rs
+++ b/crates/sqlite/src/tools/write_query.rs
@@ -2,6 +2,7 @@
 
 use std::borrow::Cow;
 
+use dbmcp_pii::MaybeRedact as _;
 use dbmcp_server::types::QueryResponse;
 
 use dbmcp_sql::Connection as _;
@@ -59,10 +60,8 @@ impl SqliteHandler {
     ///
     /// Returns [`SqlError`] if the query fails.
     pub async fn write_query(&self, QueryRequest { query }: QueryRequest) -> Result<QueryResponse, ErrorData> {
-        let mut rows = self.connection.fetch_json(query.as_str(), None).await?;
-        if let Some(r) = &self.redactor {
-            r.apply(&mut rows)?;
-        }
+        let rows = self.connection.fetch_json(query.as_str(), None).await?;
+        let rows = self.redactor.redact_rows(rows).await?;
         Ok(QueryResponse { rows })
     }
 }


### PR DESCRIPTION
## What

Batch the optional NER pass and route every query tool's redaction through one offload path.

### Inference batching
- `NerEngine::analyze_batch` runs many texts in **one padded forward pass** (right-pad to the chunk's longest window, attention-masked), replacing one `session.run` (and `Mutex` acquisition) per leaf. `analyze` is now a thin wrapper over it.
- `Redactor::apply` defers NER: collect every string leaf during the walk, run one batched pass, then merge regex + NER spans per leaf.

### Allocation trimming
- Defer-and-batch previously cloned every string leaf to feed the batch. Swap to `std::mem::take` — a no-PII leaf now costs **zero allocations** (merge pass restores the moved-out text).
- `analyze_batch` cloned each overflow window via `get_overflowing()`; use the consuming `take_overflowing()` to move them instead.

### Redaction offload unified
- `readQuery`, `explainQuery`, `writeQuery` (all 3 backends) now redact via `self.redactor.redact_rows(...).await` behind the `MaybeRedact` trait.
- Fixes a latent issue: `explainQuery`/`writeQuery` called the **synchronous** `Redactor::apply`, so with NER on the BERT forward pass ran on the async runtime thread. `redact_rows` offloads NER to `spawn_blocking`; non-NER behaviour is unchanged (runs inline).

## Tests
- New gated NER integration tests: batched == single equivalence (span set exact, scores within eps), mixed lengths, empty interspersed, overflow windows, > batch size.
- New gated redactor test: non-PII leaves survive the `mem::take`/restore round-trip (mutation-verified).
- `cargo fmt --check`, `cargo clippy --workspace --tests -D warnings`, `cargo test --workspace --lib --bins` all green. NER integration validated against a real bert-base-NER model.

## Notes
- Off by default; only runs when `--pii` / `--pii-ner` enabled. Fail-closed preserved throughout.