### PR TITLE
refactor: centralize shared imports into prelude modules

### DIFF
--- a/crates/mysql/src/tools/create_database.rs
+++ b/crates/mysql/src/tools/create_database.rs
@@ -1,14 +1,9 @@
 //! MCP tool: `createDatabase`.
 
-use std::borrow::Cow;
-
 use dbmcp_server::types::{CreateDatabaseRequest, MessageResponse};
-use dbmcp_sql::Connection as _;
 use dbmcp_sql::SqlError;
-use rmcp::handler::server::router::tool::{AsyncTool, ToolBase};
-use rmcp::model::{ErrorData, ToolAnnotations};
 
-use crate::MysqlHandler;
+use super::prelude::*;
 use crate::connection::quote_ident;
 
 const NAME: &str = "createDatabase";

--- a/crates/mysql/src/tools/drop_database.rs
+++ b/crates/mysql/src/tools/drop_database.rs
@@ -1,14 +1,9 @@
 //! MCP tool: `dropDatabase`.
 
-use std::borrow::Cow;
-
 use dbmcp_server::types::{DropDatabaseRequest, MessageResponse};
-use dbmcp_sql::Connection as _;
 use dbmcp_sql::SqlError;
-use rmcp::handler::server::router::tool::{AsyncTool, ToolBase};
-use rmcp::model::{ErrorData, ToolAnnotations};
 
-use crate::MysqlHandler;
+use super::prelude::*;
 use crate::connection::quote_ident;
 
 const NAME: &str = "dropDatabase";

--- a/crates/mysql/src/tools/drop_table.rs
+++ b/crates/mysql/src/tools/drop_table.rs
@@ -1,14 +1,9 @@
 //! MCP tool: `dropTable`.
 
-use std::borrow::Cow;
-
 use dbmcp_server::types::MessageResponse;
-use dbmcp_sql::Connection as _;
 use dbmcp_sql::SqlError;
-use rmcp::handler::server::router::tool::{AsyncTool, ToolBase};
-use rmcp::model::{ErrorData, ToolAnnotations};
 
-use crate::MysqlHandler;
+use super::prelude::*;
 use crate::connection::quote_ident;
 use crate::types::{PinnedDropTableRequest, UnpinnedDropTableRequest};
 

--- a/crates/mysql/src/tools/explain_query.rs
+++ b/crates/mysql/src/tools/explain_query.rs
@@ -1,15 +1,10 @@
 //! MCP tool: `explainQuery`.
 
-use std::borrow::Cow;
-
 use dbmcp_pii::MaybeRedact as _;
 use dbmcp_server::types::{PinnedExplainQueryRequest, QueryResponse, UnpinnedExplainQueryRequest};
-use dbmcp_sql::Connection as _;
 use dbmcp_sql::validation::validate_read_only;
-use rmcp::handler::server::router::tool::{AsyncTool, ToolBase};
-use rmcp::model::{ErrorData, ToolAnnotations};
 
-use crate::MysqlHandler;
+use super::prelude::*;
 
 const NAME: &str = "explainQuery";
 const TITLE: &str = "Explain Query";

--- a/crates/mysql/src/tools/list_databases.rs
+++ b/crates/mysql/src/tools/list_databases.rs
@@ -1,14 +1,9 @@
 //! MCP tool: `listDatabases`.
 
-use std::borrow::Cow;
-
 use dbmcp_server::pagination::Pager;
 use dbmcp_server::types::{ListDatabasesRequest, ListDatabasesResponse};
-use dbmcp_sql::Connection as _;
-use rmcp::handler::server::router::tool::{AsyncTool, ToolBase};
-use rmcp::model::{ErrorData, ToolAnnotations};
 
-use crate::MysqlHandler;
+use super::prelude::*;
 
 const NAME: &str = "listDatabases";
 const TITLE: &str = "List Databases";

--- a/crates/mysql/src/tools/list_functions.rs
+++ b/crates/mysql/src/tools/list_functions.rs
@@ -1,14 +1,9 @@
 //! MCP tool: `listFunctions`.
 
-use std::borrow::Cow;
-
 use dbmcp_server::pagination::{Cursor, Pager};
 use dbmcp_server::types::ListFunctionsResponse;
-use dbmcp_sql::Connection as _;
-use rmcp::handler::server::router::tool::{AsyncTool, ToolBase};
-use rmcp::model::{ErrorData, ToolAnnotations};
 
-use crate::MysqlHandler;
+use super::prelude::*;
 use crate::types::{PinnedListFunctionsRequest, UnpinnedListFunctionsRequest};
 
 const NAME: &str = "listFunctions";

--- a/crates/mysql/src/tools/list_procedures.rs
+++ b/crates/mysql/src/tools/list_procedures.rs
@@ -1,13 +1,8 @@
 //! MCP tool: `listProcedures`.
 
-use std::borrow::Cow;
-
 use dbmcp_server::pagination::{Cursor, Pager};
-use dbmcp_sql::Connection as _;
-use rmcp::handler::server::router::tool::{AsyncTool, ToolBase};
-use rmcp::model::{ErrorData, ToolAnnotations};
 
-use crate::MysqlHandler;
+use super::prelude::*;
 use crate::types::{ListProceduresResponse, PinnedListProceduresRequest, UnpinnedListProceduresRequest};
 
 const NAME: &str = "listProcedures";

--- a/crates/mysql/src/tools/list_tables.rs
+++ b/crates/mysql/src/tools/list_tables.rs
@@ -1,13 +1,8 @@
 //! MCP tool: `listTables`.
 
-use std::borrow::Cow;
-
 use dbmcp_server::pagination::{Cursor, Pager};
-use dbmcp_sql::Connection as _;
-use rmcp::handler::server::router::tool::{AsyncTool, ToolBase};
-use rmcp::model::{ErrorData, ToolAnnotations};
 
-use crate::MysqlHandler;
+use super::prelude::*;
 use crate::types::{ListTablesResponse, PinnedListTablesRequest, UnpinnedListTablesRequest};
 
 /// Brief-mode SQL: `information_schema.TABLES` filtered to `BASE TABLE` rows.

--- a/crates/mysql/src/tools/list_triggers.rs
+++ b/crates/mysql/src/tools/list_triggers.rs
@@ -1,14 +1,9 @@
 //! MCP tool: `listTriggers`.
 
-use std::borrow::Cow;
-
 use dbmcp_server::pagination::{Cursor, Pager};
 use dbmcp_server::types::{ListTriggersResponse, PinnedListTriggersRequest, UnpinnedListTriggersRequest};
-use dbmcp_sql::Connection as _;
-use rmcp::handler::server::router::tool::{AsyncTool, ToolBase};
-use rmcp::model::{ErrorData, ToolAnnotations};
 
-use crate::MysqlHandler;
+use super::prelude::*;
 
 const NAME: &str = "listTriggers";
 const TITLE: &str = "List Triggers";

--- a/crates/mysql/src/tools/list_views.rs
+++ b/crates/mysql/src/tools/list_views.rs
@@ -1,13 +1,8 @@
 //! MCP tool: `listViews`.
 
-use std::borrow::Cow;
-
 use dbmcp_server::pagination::{Cursor, Pager};
-use dbmcp_sql::Connection as _;
-use rmcp::handler::server::router::tool::{AsyncTool, ToolBase};
-use rmcp::model::{ErrorData, ToolAnnotations};
 
-use crate::MysqlHandler;
+use super::prelude::*;
 use crate::types::{ListViewsResponse, PinnedListViewsRequest, UnpinnedListViewsRequest};
 
 const NAME: &str = "listViews";

--- a/crates/mysql/src/tools/mod.rs
+++ b/crates/mysql/src/tools/mod.rs
@@ -15,6 +15,7 @@ mod list_procedures;
 mod list_tables;
 mod list_triggers;
 mod list_views;
+mod prelude;
 mod read_query;
 mod write_query;
 

--- a/crates/mysql/src/tools/prelude.rs
+++ b/crates/mysql/src/tools/prelude.rs
@@ -1,0 +1,9 @@
+//! Shared imports for the `MySQL` tool modules.
+
+pub(crate) use std::borrow::Cow;
+
+pub(crate) use dbmcp_sql::Connection as _;
+pub(crate) use rmcp::handler::server::router::tool::{AsyncTool, ToolBase};
+pub(crate) use rmcp::model::{ErrorData, ToolAnnotations};
+
+pub(crate) use crate::MysqlHandler;

--- a/crates/mysql/src/tools/read_query.rs
+++ b/crates/mysql/src/tools/read_query.rs
@@ -1,18 +1,13 @@
 //! MCP tool: `readQuery`.
 
-use std::borrow::Cow;
-
 use dbmcp_pii::MaybeRedact as _;
 use dbmcp_server::pagination::{Cursor, Pager};
 use dbmcp_server::types::{PinnedReadQueryRequest, ReadQueryResponse, UnpinnedReadQueryRequest};
-use dbmcp_sql::Connection as _;
 use dbmcp_sql::StatementKind;
 use dbmcp_sql::pagination::with_limit_offset;
 use dbmcp_sql::validation::validate_read_only;
-use rmcp::handler::server::router::tool::{AsyncTool, ToolBase};
-use rmcp::model::{ErrorData, ToolAnnotations};
 
-use crate::MysqlHandler;
+use super::prelude::*;
 
 const NAME: &str = "readQuery";
 const TITLE: &str = "Read Query";

--- a/crates/mysql/src/tools/write_query.rs
+++ b/crates/mysql/src/tools/write_query.rs
@@ -1,14 +1,9 @@
 //! MCP tool: `writeQuery`.
 
-use std::borrow::Cow;
-
 use dbmcp_pii::MaybeRedact as _;
 use dbmcp_server::types::{PinnedQueryRequest, QueryResponse, UnpinnedQueryRequest};
-use dbmcp_sql::Connection as _;
-use rmcp::handler::server::router::tool::{AsyncTool, ToolBase};
-use rmcp::model::{ErrorData, ToolAnnotations};
 
-use crate::MysqlHandler;
+use super::prelude::*;
 
 const NAME: &str = "writeQuery";
 const TITLE: &str = "Write Query";

--- a/crates/pii/src/recognizers/can/mod.rs
+++ b/crates/pii/src/recognizers/can/mod.rs
@@ -1,7 +1,5 @@
 //! Canada-specific recognizers (ISO 3166-1 alpha-3 `CAN`).
 
-pub(super) use super::Recognizer;
-
 mod sin;
 
 pub use sin::sin_can;

--- a/crates/pii/src/recognizers/can/sin.rs
+++ b/crates/pii/src/recognizers/can/sin.rs
@@ -1,10 +1,6 @@
 //! `SIN_CA` recognizer (Luhn-validated, keyword-context required).
 
-use super::Recognizer;
-use crate::pattern::Pattern;
-use crate::score::Score;
-use crate::validators::Validator;
-use crate::{Category, Entity};
+use crate::recognizers::prelude::*;
 
 /// Context keywords for Canadian SIN.
 const CONTEXT: &[&str] = &[

--- a/crates/pii/src/recognizers/deu/commercial_register.rs
+++ b/crates/pii/src/recognizers/deu/commercial_register.rs
@@ -1,9 +1,6 @@
 //! `COMMERCIAL_REGISTER_DE` recognizer (Handelsregisternummer, HRA/HRB prefix).
 
-use super::Recognizer;
-use crate::pattern::Pattern;
-use crate::score::Score;
-use crate::{Category, Entity};
+use crate::recognizers::prelude::*;
 
 /// Context keywords for DE Handelsregisternummer.
 const CONTEXT: &[&str] = &[

--- a/crates/pii/src/recognizers/deu/driving_licence.rs
+++ b/crates/pii/src/recognizers/deu/driving_licence.rs
@@ -1,9 +1,6 @@
 //! `DRIVING_LICENCE_DE` recognizer (post-2013 EU-harmonised 11-character Führerschein).
 
-use super::Recognizer;
-use crate::pattern::Pattern;
-use crate::score::Score;
-use crate::{Category, Entity};
+use crate::recognizers::prelude::*;
 
 /// Context keywords for DE Führerschein.
 const CONTEXT: &[&str] = &[

--- a/crates/pii/src/recognizers/deu/health_insurance.rs
+++ b/crates/pii/src/recognizers/deu/health_insurance.rs
@@ -1,10 +1,6 @@
 //! `HEALTH_INSURANCE_DE` recognizer (KVNR, letter + 9 digits, GKV-Spitzenverband checksum).
 
-use super::Recognizer;
-use crate::pattern::Pattern;
-use crate::score::Score;
-use crate::validators::Validator;
-use crate::{Category, Entity};
+use crate::recognizers::prelude::*;
 
 /// Context keywords for DE Krankenversicherungsnummer.
 const CONTEXT: &[&str] = &[

--- a/crates/pii/src/recognizers/deu/id_card.rs
+++ b/crates/pii/src/recognizers/deu/id_card.rs
@@ -1,10 +1,6 @@
 //! `ID_CARD_DE` recognizer (Personalausweisnummer, nPA + legacy T-format).
 
-use super::Recognizer;
-use crate::pattern::Pattern;
-use crate::score::Score;
-use crate::validators::Validator;
-use crate::{Category, Entity};
+use crate::recognizers::prelude::*;
 
 /// Context keywords for DE Personalausweis.
 const CONTEXT: &[&str] = &[

--- a/crates/pii/src/recognizers/deu/license_plate.rs
+++ b/crates/pii/src/recognizers/deu/license_plate.rs
@@ -1,9 +1,6 @@
 //! `LICENSE_PLATE_DE` recognizer (German vehicle registration plate / KFZ-Kennzeichen, FZV § 8).
 
-use super::Recognizer;
-use crate::pattern::Pattern;
-use crate::score::Score;
-use crate::{Category, Entity};
+use crate::recognizers::prelude::*;
 
 /// Context keywords for DE KFZ-Kennzeichen.
 const CONTEXT: &[&str] = &[

--- a/crates/pii/src/recognizers/deu/lifetime_physician_number.rs
+++ b/crates/pii/src/recognizers/deu/lifetime_physician_number.rs
@@ -1,10 +1,6 @@
 //! `LIFETIME_PHYSICIAN_NUMBER_DE` recognizer (Lebenslange Arztnummer / LANR, KBV weighted checksum).
 
-use super::Recognizer;
-use crate::pattern::Pattern;
-use crate::score::Score;
-use crate::validators::Validator;
-use crate::{Category, Entity};
+use crate::recognizers::prelude::*;
 
 /// Context keywords for DE Lebenslange Arztnummer (LANR).
 const CONTEXT: &[&str] = &[

--- a/crates/pii/src/recognizers/deu/medical_practice_id.rs
+++ b/crates/pii/src/recognizers/deu/medical_practice_id.rs
@@ -1,10 +1,6 @@
 //! `MEDICAL_PRACTICE_ID_DE` recognizer (Betriebsstättennummer / BSNR — 9 digits, all-zero rejected).
 
-use super::Recognizer;
-use crate::pattern::Pattern;
-use crate::score::Score;
-use crate::validators::Validator;
-use crate::{Category, Entity};
+use crate::recognizers::prelude::*;
 
 /// Context keywords for DE Betriebsstättennummer (BSNR).
 const CONTEXT: &[&str] = &[

--- a/crates/pii/src/recognizers/deu/mod.rs
+++ b/crates/pii/src/recognizers/deu/mod.rs
@@ -1,7 +1,5 @@
 //! Germany-specific recognizers (ISO 3166-1 alpha-3 `DEU`).
 
-pub(super) use super::Recognizer;
-
 mod commercial_register;
 mod driving_licence;
 mod health_insurance;

--- a/crates/pii/src/recognizers/deu/passport.rs
+++ b/crates/pii/src/recognizers/deu/passport.rs
@@ -1,10 +1,6 @@
 //! `PASSPORT_DE` recognizer (Reisepassnummer, ICAO Doc 9303 9-character format).
 
-use super::Recognizer;
-use crate::pattern::Pattern;
-use crate::score::Score;
-use crate::validators::Validator;
-use crate::{Category, Entity};
+use crate::recognizers::prelude::*;
 
 /// Context keywords for DE Reisepass.
 const CONTEXT: &[&str] = &[

--- a/crates/pii/src/recognizers/deu/postcode.rs
+++ b/crates/pii/src/recognizers/deu/postcode.rs
@@ -1,9 +1,6 @@
 //! `POSTCODE_DE` recognizer (Postleitzahl / PLZ, weak 0.05 base score — requires context).
 
-use super::Recognizer;
-use crate::pattern::Pattern;
-use crate::score::Score;
-use crate::{Category, Entity};
+use crate::recognizers::prelude::*;
 
 /// Context keywords for DE Postleitzahl.
 const CONTEXT: &[&str] = &[

--- a/crates/pii/src/recognizers/deu/social_security.rs
+++ b/crates/pii/src/recognizers/deu/social_security.rs
@@ -1,10 +1,6 @@
 //! `SOCIAL_SECURITY_DE` recognizer (Rentenversicherungsnummer / RVNR).
 
-use super::Recognizer;
-use crate::pattern::Pattern;
-use crate::score::Score;
-use crate::validators::Validator;
-use crate::{Category, Entity};
+use crate::recognizers::prelude::*;
 
 /// Context keywords for DE Rentenversicherungsnummer.
 const CONTEXT: &[&str] = &[

--- a/crates/pii/src/recognizers/deu/tax_id.rs
+++ b/crates/pii/src/recognizers/deu/tax_id.rs
@@ -1,10 +1,6 @@
 //! `TAX_ID_DE` recognizer (Steueridentifikationsnummer, ISO 7064 Mod 11, 10).
 
-use super::Recognizer;
-use crate::pattern::Pattern;
-use crate::score::Score;
-use crate::validators::Validator;
-use crate::{Category, Entity};
+use crate::recognizers::prelude::*;
 
 /// Context keywords for DE Steueridentifikationsnummer.
 const CONTEXT: &[&str] = &[

--- a/crates/pii/src/recognizers/deu/tax_number.rs
+++ b/crates/pii/src/recognizers/deu/tax_number.rs
@@ -1,9 +1,6 @@
 //! `TAX_NUMBER_DE` recognizer (Steuernummer, ELSTER + state-specific slash formats).
 
-use super::Recognizer;
-use crate::pattern::Pattern;
-use crate::score::Score;
-use crate::{Category, Entity};
+use crate::recognizers::prelude::*;
 
 /// Context keywords for DE Steuernummer.
 const CONTEXT: &[&str] = &[

--- a/crates/pii/src/recognizers/eur/mod.rs
+++ b/crates/pii/src/recognizers/eur/mod.rs
@@ -1,7 +1,5 @@
 //! Pan-EU recognizers (custom `EUR` pseudo-code).
 
-pub(super) use super::Recognizer;
-
 mod vat_number;
 
 pub use vat_number::vat_number_eur;

--- a/crates/pii/src/recognizers/eur/vat_number.rs
+++ b/crates/pii/src/recognizers/eur/vat_number.rs
@@ -1,10 +1,6 @@
 //! `VAT_NUMBER` recognizer (EU / UK / Northern Ireland VAT identifier).
 
-use super::Recognizer;
-use crate::pattern::Pattern;
-use crate::score::Score;
-use crate::validators::Validator;
-use crate::{Category, Entity};
+use crate::recognizers::prelude::*;
 
 /// Build the `VAT_NUMBER` recognizer.
 ///

--- a/crates/pii/src/recognizers/gbr/bank_account.rs
+++ b/crates/pii/src/recognizers/gbr/bank_account.rs
@@ -1,9 +1,6 @@
 //! `BANK_ACCOUNT_UK` recognizer (weak digit pattern, keyword-context gated).
 
-use super::Recognizer;
-use crate::pattern::Pattern;
-use crate::score::Score;
-use crate::{Category, Entity};
+use crate::recognizers::prelude::*;
 
 /// Context keywords for UK bank account.
 const CONTEXT: &[&str] = &["account", "acct", "bank", "iban"];

--- a/crates/pii/src/recognizers/gbr/driving_licence.rs
+++ b/crates/pii/src/recognizers/gbr/driving_licence.rs
@@ -1,9 +1,6 @@
 //! `DRIVING_LICENCE_UK` recognizer (DVLA 16-character format).
 
-use super::Recognizer;
-use crate::pattern::Pattern;
-use crate::score::Score;
-use crate::{Category, Entity};
+use crate::recognizers::prelude::*;
 
 /// Context keywords for UK driving licence.
 const CONTEXT: &[&str] = &[

--- a/crates/pii/src/recognizers/gbr/mod.rs
+++ b/crates/pii/src/recognizers/gbr/mod.rs
@@ -1,7 +1,5 @@
 //! United Kingdom-specific recognizers (ISO 3166-1 alpha-3 `GBR`).
 
-pub(super) use super::Recognizer;
-
 mod bank_account;
 mod driving_licence;
 mod nhs_number;

--- a/crates/pii/src/recognizers/gbr/nhs_number.rs
+++ b/crates/pii/src/recognizers/gbr/nhs_number.rs
@@ -1,10 +1,6 @@
 //! `NHS_NUMBER` recognizer (UK NHS patient identifier with mod-11 checksum).
 
-use super::Recognizer;
-use crate::pattern::Pattern;
-use crate::score::Score;
-use crate::validators::Validator;
-use crate::{Category, Entity};
+use crate::recognizers::prelude::*;
 
 /// Context keywords for UK NHS number.
 const CONTEXT: &[&str] = &[

--- a/crates/pii/src/recognizers/gbr/nino.rs
+++ b/crates/pii/src/recognizers/gbr/nino.rs
@@ -1,9 +1,6 @@
 //! `NINO_UK` recognizer (UK National Insurance Number; blocklist enforced in regex).
 
-use super::Recognizer;
-use crate::pattern::Pattern;
-use crate::score::Score;
-use crate::{Category, Entity};
+use crate::recognizers::prelude::*;
 
 /// Context keywords for UK NINO.
 const CONTEXT: &[&str] = &["national insurance", "ni number", "nino"];

--- a/crates/pii/src/recognizers/gbr/passport.rs
+++ b/crates/pii/src/recognizers/gbr/passport.rs
@@ -1,9 +1,6 @@
 //! `PASSPORT_UK` recognizer (post-2015 format: 2 letters + 7 digits).
 
-use super::Recognizer;
-use crate::pattern::Pattern;
-use crate::score::Score;
-use crate::{Category, Entity};
+use crate::recognizers::prelude::*;
 
 /// Context keywords for UK passport.
 const CONTEXT: &[&str] = &[

--- a/crates/pii/src/recognizers/gbr/postcode.rs
+++ b/crates/pii/src/recognizers/gbr/postcode.rs
@@ -1,9 +1,6 @@
 //! `POSTCODE_UK` recognizer (six standard formats plus special GIR 0AA).
 
-use super::Recognizer;
-use crate::pattern::Pattern;
-use crate::score::Score;
-use crate::{Category, Entity};
+use crate::recognizers::prelude::*;
 
 /// Context keywords for UK postcode.
 const CONTEXT: &[&str] = &[

--- a/crates/pii/src/recognizers/gbr/sort_code.rs
+++ b/crates/pii/src/recognizers/gbr/sort_code.rs
@@ -1,9 +1,6 @@
 //! `SORT_CODE_UK` recognizer (weak digit pattern, keyword-context gated).
 
-use super::Recognizer;
-use crate::pattern::Pattern;
-use crate::score::Score;
-use crate::{Category, Entity};
+use crate::recognizers::prelude::*;
 
 /// Context keywords for UK sort code.
 const CONTEXT: &[&str] = &["sort", "sortcode"];

--- a/crates/pii/src/recognizers/gbr/vehicle_registration.rs
+++ b/crates/pii/src/recognizers/gbr/vehicle_registration.rs
@@ -1,9 +1,6 @@
 //! `VEHICLE_REGISTRATION_UK` recognizer (current + prefix + suffix formats).
 
-use super::Recognizer;
-use crate::pattern::Pattern;
-use crate::score::Score;
-use crate::{Category, Entity};
+use crate::recognizers::prelude::*;
 
 /// Context keywords for UK vehicle registration.
 const CONTEXT: &[&str] = &[

--- a/crates/pii/src/recognizers/generic/api_key.rs
+++ b/crates/pii/src/recognizers/generic/api_key.rs
@@ -7,10 +7,7 @@
 //! confidence boost lifts it whenever a keyword like `aws_secret_access_key`
 //! sits in the surrounding window.
 
-use super::Recognizer;
-use crate::pattern::Pattern;
-use crate::score::Score;
-use crate::{Category, Entity};
+use crate::recognizers::prelude::*;
 
 /// Build the strongly-anchored `API_KEY` recognizer (AWS access, `GitHub`, Stripe, Google, `OpenAI`).
 ///

--- a/crates/pii/src/recognizers/generic/credit_card.rs
+++ b/crates/pii/src/recognizers/generic/credit_card.rs
@@ -1,10 +1,6 @@
 //! `CREDIT_CARD` recognizer with Luhn checksum validator.
 
-use super::Recognizer;
-use crate::pattern::Pattern;
-use crate::score::Score;
-use crate::validators::Validator;
-use crate::{Category, Entity};
+use crate::recognizers::prelude::*;
 
 /// Context keywords boosted by the context-aware scoring pass.
 const CONTEXT: &[&str] = &[

--- a/crates/pii/src/recognizers/generic/crypto.rs
+++ b/crates/pii/src/recognizers/generic/crypto.rs
@@ -3,11 +3,7 @@
 //! BTC checksums (`Base58Check` + Bech32/Bech32m) enforced via [`Validator::Crypto`].
 //! ETH (`0x...`) candidates are unvalidated.
 
-use super::Recognizer;
-use crate::pattern::Pattern;
-use crate::score::Score;
-use crate::validators::Validator;
-use crate::{Category, Entity};
+use crate::recognizers::prelude::*;
 
 /// Context keywords for crypto wallet addresses.
 const CONTEXT: &[&str] = &["wallet", "btc", "bitcoin", "crypto"];

--- a/crates/pii/src/recognizers/generic/cvv.rs
+++ b/crates/pii/src/recognizers/generic/cvv.rs
@@ -1,9 +1,6 @@
 //! `CVV` recognizer (keyword-context required).
 
-use super::Recognizer;
-use crate::pattern::Pattern;
-use crate::score::Score;
-use crate::{Category, Entity};
+use crate::recognizers::prelude::*;
 
 /// Build the `CVV` recognizer.
 ///

--- a/crates/pii/src/recognizers/generic/date_of_birth.rs
+++ b/crates/pii/src/recognizers/generic/date_of_birth.rs
@@ -1,9 +1,6 @@
 //! `DATE_OF_BIRTH` recognizer (weak date pattern, keyword-context gated).
 
-use super::Recognizer;
-use crate::pattern::Pattern;
-use crate::score::Score;
-use crate::{Category, Entity};
+use crate::recognizers::prelude::*;
 
 /// Context keywords for date of birth (English + German).
 const CONTEXT: &[&str] = &[

--- a/crates/pii/src/recognizers/generic/email.rs
+++ b/crates/pii/src/recognizers/generic/email.rs
@@ -1,9 +1,6 @@
 //! `EMAIL_ADDRESS` recognizer.
 
-use super::Recognizer;
-use crate::pattern::Pattern;
-use crate::score::Score;
-use crate::{Category, Entity};
+use crate::recognizers::prelude::*;
 
 /// Context keywords for email.
 const CONTEXT: &[&str] = &["email"];

--- a/crates/pii/src/recognizers/generic/iban.rs
+++ b/crates/pii/src/recognizers/generic/iban.rs
@@ -1,10 +1,6 @@
 //! `IBAN_CODE` recognizer with mod-97 validator.
 
-use super::Recognizer;
-use crate::pattern::Pattern;
-use crate::score::Score;
-use crate::validators::Validator;
-use crate::{Category, Entity};
+use crate::recognizers::prelude::*;
 
 /// Context keywords for IBAN.
 const CONTEXT: &[&str] = &["iban", "bank", "transaction"];

--- a/crates/pii/src/recognizers/generic/ip.rs
+++ b/crates/pii/src/recognizers/generic/ip.rs
@@ -4,11 +4,7 @@
 //! the precise validity check to [`std::net::IpAddr::from_str`]. False
 //! positives the regex lets through are dropped by the parser.
 
-use super::Recognizer;
-use crate::pattern::Pattern;
-use crate::score::Score;
-use crate::validators::Validator;
-use crate::{Category, Entity};
+use crate::recognizers::prelude::*;
 
 /// Context keywords for IP addresses.
 const CONTEXT: &[&str] = &["ip", "ipv4", "ipv6"];

--- a/crates/pii/src/recognizers/generic/jwt_token.rs
+++ b/crates/pii/src/recognizers/generic/jwt_token.rs
@@ -1,10 +1,6 @@
 //! `JWT_TOKEN` recognizer (header `alg` field validated; signature NOT verified).
 
-use super::Recognizer;
-use crate::pattern::Pattern;
-use crate::score::Score;
-use crate::validators::Validator;
-use crate::{Category, Entity};
+use crate::recognizers::prelude::*;
 
 /// Build the `JWT_TOKEN` recognizer.
 ///

--- a/crates/pii/src/recognizers/generic/mac_address.rs
+++ b/crates/pii/src/recognizers/generic/mac_address.rs
@@ -1,9 +1,6 @@
 //! `MAC_ADDRESS` recognizer.
 
-use super::Recognizer;
-use crate::pattern::Pattern;
-use crate::score::Score;
-use crate::{Category, Entity};
+use crate::recognizers::prelude::*;
 
 /// Context keywords for MAC addresses.
 const CONTEXT: &[&str] = &["mac", "mac address", "hardware address", "physical address", "ethernet"];

--- a/crates/pii/src/recognizers/generic/mod.rs
+++ b/crates/pii/src/recognizers/generic/mod.rs
@@ -1,7 +1,5 @@
 //! Region-neutral recognizers.
 
-pub(super) use super::Recognizer;
-
 mod api_key;
 mod credit_card;
 mod crypto;

--- a/crates/pii/src/recognizers/generic/password_hash.rs
+++ b/crates/pii/src/recognizers/generic/password_hash.rs
@@ -7,10 +7,7 @@
 //! Lengths follow each scheme's spec; no lookaround, so the fast regex engine
 //! is used and a hash-shaped prefix of an over-long value still redacts.
 
-use super::Recognizer;
-use crate::pattern::Pattern;
-use crate::score::Score;
-use crate::{Category, Entity};
+use crate::recognizers::prelude::*;
 
 /// Build the `PASSWORD_HASH` recognizer (bcrypt, sha-crypt, argon2).
 ///

--- a/crates/pii/src/recognizers/generic/phone.rs
+++ b/crates/pii/src/recognizers/generic/phone.rs
@@ -4,10 +4,7 @@
 //! then 8–15 significant digits with optional punctuation. The required
 //! international prefix keeps bare digit runs (timestamps, IDs, references) out.
 
-use super::Recognizer;
-use crate::pattern::Pattern;
-use crate::score::Score;
-use crate::{Category, Entity};
+use crate::recognizers::prelude::*;
 
 /// Context keywords used by the boost step.
 const CONTEXT: &[&str] = &["phone", "number", "telephone", "cell", "cellphone", "mobile", "call"];

--- a/crates/pii/src/recognizers/generic/private_key.rs
+++ b/crates/pii/src/recognizers/generic/private_key.rs
@@ -1,10 +1,6 @@
 //! `PRIVATE_KEY` recognizer (PEM-fenced block; BEGIN-type == END-type).
 
-use super::Recognizer;
-use crate::pattern::Pattern;
-use crate::score::Score;
-use crate::validators::Validator;
-use crate::{Category, Entity};
+use crate::recognizers::prelude::*;
 
 /// Build the `PRIVATE_KEY` recognizer.
 ///

--- a/crates/pii/src/recognizers/generic/url.rs
+++ b/crates/pii/src/recognizers/generic/url.rs
@@ -1,9 +1,6 @@
 //! `URL` recognizer.
 
-use super::Recognizer;
-use crate::pattern::Pattern;
-use crate::score::Score;
-use crate::{Category, Entity};
+use crate::recognizers::prelude::*;
 
 /// Context keywords for URLs.
 const CONTEXT: &[&str] = &["url", "website", "link"];

--- a/crates/pii/src/recognizers/mod.rs
+++ b/crates/pii/src/recognizers/mod.rs
@@ -18,6 +18,7 @@ pub mod deu;
 pub mod eur;
 pub mod gbr;
 pub mod generic;
+mod prelude;
 pub mod usa;
 
 // Flat re-exports preserve the `dbmcp_pii::recognizers::<name>` public API.

--- a/crates/pii/src/recognizers/prelude.rs
+++ b/crates/pii/src/recognizers/prelude.rs
@@ -1,0 +1,7 @@
+//! Shared imports for recognizer builder modules.
+
+pub(crate) use super::Recognizer;
+pub(crate) use crate::pattern::Pattern;
+pub(crate) use crate::score::Score;
+pub(crate) use crate::validators::Validator;
+pub(crate) use crate::{Category, Entity};

--- a/crates/pii/src/recognizers/usa/bank_account.rs
+++ b/crates/pii/src/recognizers/usa/bank_account.rs
@@ -6,10 +6,7 @@
 //! contains a banking keyword. Matches without a nearby keyword fall below
 //! the redactor's `min_score` floor and are dropped.
 
-use super::Recognizer;
-use crate::pattern::Pattern;
-use crate::score::Score;
-use crate::{Category, Entity};
+use crate::recognizers::prelude::*;
 
 /// Context keywords for US bank account.
 const CONTEXT: &[&str] = &["check", "account", "acct", "bank", "save", "debit"];

--- a/crates/pii/src/recognizers/usa/driver_license.rs
+++ b/crates/pii/src/recognizers/usa/driver_license.rs
@@ -5,10 +5,7 @@
 //! licence is purely numeric (score `0.01`). Both are gated by a keyword
 //! context validator because the regex alone matches too many false positives.
 
-use super::Recognizer;
-use crate::pattern::Pattern;
-use crate::score::Score;
-use crate::{Category, Entity};
+use crate::recognizers::prelude::*;
 
 /// Context keywords for US driver licence.
 const CONTEXT: &[&str] = &[

--- a/crates/pii/src/recognizers/usa/itin.rs
+++ b/crates/pii/src/recognizers/usa/itin.rs
@@ -1,9 +1,6 @@
 //! `ITIN` recognizer (US Individual Taxpayer Identification Number).
 
-use super::Recognizer;
-use crate::pattern::Pattern;
-use crate::score::Score;
-use crate::{Category, Entity};
+use crate::recognizers::prelude::*;
 
 /// Context keywords for US ITIN.
 const CONTEXT: &[&str] = &["individual", "taxpayer", "itin", "tax", "payer", "taxid", "tin"];

--- a/crates/pii/src/recognizers/usa/mbi.rs
+++ b/crates/pii/src/recognizers/usa/mbi.rs
@@ -5,10 +5,7 @@
 //! (`0.3`) and dashed `XXXX-XXX-XXXX` (`0.5`); both regex-only — no
 //! published checksum.
 
-use super::Recognizer;
-use crate::pattern::Pattern;
-use crate::score::Score;
-use crate::{Category, Entity};
+use crate::recognizers::prelude::*;
 
 const ALPHA: &str = "ACDEFGHJKMNPQRTUVWXY";
 const ALNUM: &str = "0-9ACDEFGHJKMNPQRTUVWXY";

--- a/crates/pii/src/recognizers/usa/medical_license.rs
+++ b/crates/pii/src/recognizers/usa/medical_license.rs
@@ -5,11 +5,7 @@
 //! `0.4` and gated by keyword context to suppress false positives on
 //! arbitrary alphanumeric tokens.
 
-use super::Recognizer;
-use crate::pattern::Pattern;
-use crate::score::Score;
-use crate::validators::Validator;
-use crate::{Category, Entity};
+use crate::recognizers::prelude::*;
 
 /// Context keywords for US medical license.
 const CONTEXT: &[&str] = &["medical", "certificate", "dea"];

--- a/crates/pii/src/recognizers/usa/mod.rs
+++ b/crates/pii/src/recognizers/usa/mod.rs
@@ -1,7 +1,5 @@
 //! United States-specific recognizers (ISO 3166-1 alpha-3 `USA`).
 
-pub(super) use super::Recognizer;
-
 mod bank_account;
 mod driver_license;
 mod itin;

--- a/crates/pii/src/recognizers/usa/npi.rs
+++ b/crates/pii/src/recognizers/usa/npi.rs
@@ -5,11 +5,7 @@
 //! algorithm — `"80840"` prefix prepended before the standard Luhn pass —
 //! with an additional filter rejecting all-identical-body numbers.
 
-use super::Recognizer;
-use crate::pattern::Pattern;
-use crate::score::Score;
-use crate::validators::Validator;
-use crate::{Category, Entity};
+use crate::recognizers::prelude::*;
 
 /// Context keywords for US NPI.
 const CONTEXT: &[&str] = &[

--- a/crates/pii/src/recognizers/usa/passport.rs
+++ b/crates/pii/src/recognizers/usa/passport.rs
@@ -1,9 +1,6 @@
 //! `PASSPORT_US` recognizer (9-digit weak + Next Generation [letter + 8 digits]).
 
-use super::Recognizer;
-use crate::pattern::Pattern;
-use crate::score::Score;
-use crate::{Category, Entity};
+use crate::recognizers::prelude::*;
 
 /// Context keywords for US passport.
 const CONTEXT: &[&str] = &["us", "united", "states", "passport", "travel", "document"];

--- a/crates/pii/src/recognizers/usa/routing_number.rs
+++ b/crates/pii/src/recognizers/usa/routing_number.rs
@@ -1,10 +1,6 @@
 //! `ROUTING_NUMBER_US` recognizer (ABA checksum + keyword-context).
 
-use super::Recognizer;
-use crate::pattern::Pattern;
-use crate::score::Score;
-use crate::validators::Validator;
-use crate::{Category, Entity};
+use crate::recognizers::prelude::*;
 
 /// Context keywords for US ABA routing number.
 const CONTEXT: &[&str] = &["aba", "routing", "abarouting", "association", "bankrouting"];

--- a/crates/pii/src/recognizers/usa/ssn.rs
+++ b/crates/pii/src/recognizers/usa/ssn.rs
@@ -3,11 +3,7 @@
 //! Plain regex matches `XXX-XX-XXXX` shape; reserved area/group/serial values
 //! are rejected by [`UsSsnValidator`].
 
-use super::Recognizer;
-use crate::pattern::Pattern;
-use crate::score::Score;
-use crate::validators::Validator;
-use crate::{Category, Entity};
+use crate::recognizers::prelude::*;
 
 /// Context keywords for US SSN.
 const CONTEXT: &[&str] = &["social", "security", "ssn", "ssns", "ssid"];

--- a/crates/pii/src/recognizers/usa/tax_id_ein.rs
+++ b/crates/pii/src/recognizers/usa/tax_id_ein.rs
@@ -1,10 +1,6 @@
 //! `TAX_ID_EIN` recognizer (US Employer Identification Number).
 
-use super::Recognizer;
-use crate::pattern::Pattern;
-use crate::score::Score;
-use crate::validators::Validator;
-use crate::{Category, Entity};
+use crate::recognizers::prelude::*;
 
 /// Build the `TAX_ID_EIN` recognizer.
 ///

--- a/crates/pii/src/validators/aba_routing_usa.rs
+++ b/crates/pii/src/validators/aba_routing_usa.rs
@@ -1,7 +1,6 @@
 //! US ABA routing-number checksum validator.
 
-use super::digits::collect_digits;
-use crate::ValidationOutcome;
+use super::prelude::*;
 
 /// US ABA routing-number checksum.
 ///

--- a/crates/pii/src/validators/crypto.rs
+++ b/crates/pii/src/validators/crypto.rs
@@ -1,6 +1,6 @@
 //! Bitcoin address checksum validator: `Base58Check` (P2PKH/P2SH) and Bech32/Bech32m (segwit).
 
-use crate::ValidationOutcome;
+use super::prelude::*;
 
 /// Validate a Bitcoin address candidate by checksum.
 ///

--- a/crates/pii/src/validators/digits.rs
+++ b/crates/pii/src/validators/digits.rs
@@ -4,7 +4,7 @@
 ///
 /// Iterates bytes (not chars) since every candidate that reaches a numeric
 /// validator is ASCII-only post-regex-match.
-pub(super) fn collect_digits<const N: usize>(candidate: &str) -> Option<[u32; N]> {
+pub(crate) fn collect_digits<const N: usize>(candidate: &str) -> Option<[u32; N]> {
     let mut out = [0u32; N];
     let mut i = 0usize;
     for &b in candidate.as_bytes() {

--- a/crates/pii/src/validators/ein_prefix_usa.rs
+++ b/crates/pii/src/validators/ein_prefix_usa.rs
@@ -1,7 +1,6 @@
 //! US EIN (employer ID) prefix validator.
 
-use super::digits::collect_digits;
-use crate::ValidationOutcome;
+use super::prelude::*;
 
 /// IRS-published valid EIN prefixes, sorted ascending for binary search.
 const EIN_VALID_PREFIXES: &[u32] = &[

--- a/crates/pii/src/validators/health_insurance_deu.rs
+++ b/crates/pii/src/validators/health_insurance_deu.rs
@@ -7,7 +7,7 @@
 //! plus the first eight body digits; products ≥10 are Quersumme-collapsed;
 //! the sum modulo 10 must equal the trailing check digit.
 
-use crate::ValidationOutcome;
+use super::prelude::*;
 
 pub(super) fn validate(candidate: &str) -> ValidationOutcome {
     let trimmed = candidate.trim();

--- a/crates/pii/src/validators/iban.rs
+++ b/crates/pii/src/validators/iban.rs
@@ -1,6 +1,6 @@
 //! IBAN mod-97 checksum validator.
 
-use crate::ValidationOutcome;
+use super::prelude::*;
 
 /// IBAN mod-97 validator. Accepts upper-case input; whitespace stripped before checking.
 pub(super) fn validate(candidate: &str) -> ValidationOutcome {

--- a/crates/pii/src/validators/icao_mrz9.rs
+++ b/crates/pii/src/validators/icao_mrz9.rs
@@ -5,7 +5,7 @@
 //! must equal the trailing digit. Visually ambiguous letters `A B D E I O Q S U`
 //! are rejected outright per ICAO Doc 9303 §3.
 
-use crate::ValidationOutcome;
+use super::prelude::*;
 
 const FORBIDDEN: &[u8] = b"ABDEIOQSU";
 

--- a/crates/pii/src/validators/id_card_deu.rs
+++ b/crates/pii/src/validators/id_card_deu.rs
@@ -6,7 +6,7 @@
 //! 2010 and carries no check digit — for that branch the validator returns
 //! [`ValidationOutcome::Unknown`] so the pattern score is preserved.
 
-use crate::ValidationOutcome;
+use super::prelude::*;
 
 pub(super) fn validate(candidate: &str) -> ValidationOutcome {
     let trimmed = candidate.trim();

--- a/crates/pii/src/validators/ip.rs
+++ b/crates/pii/src/validators/ip.rs
@@ -3,7 +3,7 @@
 use std::net::IpAddr;
 use std::str::FromStr;
 
-use crate::ValidationOutcome;
+use super::prelude::*;
 
 /// IP-address validator that delegates to [`std::net::IpAddr::from_str`].
 ///

--- a/crates/pii/src/validators/jwt_header.rs
+++ b/crates/pii/src/validators/jwt_header.rs
@@ -3,7 +3,7 @@
 use base64::Engine;
 use serde::Deserialize;
 
-use crate::ValidationOutcome;
+use super::prelude::*;
 
 #[derive(Deserialize)]
 struct Header {

--- a/crates/pii/src/validators/lifetime_physician_number_deu.rs
+++ b/crates/pii/src/validators/lifetime_physician_number_deu.rs
@@ -5,8 +5,7 @@
 //! Digits 8 and 9 encode the medical specialty and are not part of the
 //! checksum.
 
-use super::digits::collect_digits;
-use crate::ValidationOutcome;
+use super::prelude::*;
 
 pub(super) fn validate(candidate: &str) -> ValidationOutcome {
     let Some(digits) = collect_digits::<9>(candidate) else {

--- a/crates/pii/src/validators/luhn.rs
+++ b/crates/pii/src/validators/luhn.rs
@@ -1,6 +1,6 @@
 //! Luhn checksum validator for credit-card numbers.
 
-use crate::ValidationOutcome;
+use super::prelude::*;
 
 /// Luhn checksum validator for credit-card numbers.
 ///

--- a/crates/pii/src/validators/luhn_sin_can.rs
+++ b/crates/pii/src/validators/luhn_sin_can.rs
@@ -1,8 +1,7 @@
 //! Luhn checksum validator gated to exactly 9 digits, used by `SIN_CA`.
 
-use super::digits::collect_digits;
 use super::luhn::luhn_passes;
-use crate::ValidationOutcome;
+use super::prelude::*;
 
 /// Luhn checksum gated to exactly 9 digits, used by `SIN_CA`.
 ///

--- a/crates/pii/src/validators/medical_license_usa.rs
+++ b/crates/pii/src/validators/medical_license_usa.rs
@@ -5,8 +5,7 @@
 //! spec: `(2·(d1 + d3 + d5) + (d0 + d2 + d4)) mod 10 == check`. Letters and
 //! the optional middle `9` are ignored by the math.
 
-use super::digits::collect_digits;
-use crate::ValidationOutcome;
+use super::prelude::*;
 
 pub(super) fn validate(candidate: &str) -> ValidationOutcome {
     let Some(digits) = candidate.get(2..).and_then(collect_digits::<7>) else {

--- a/crates/pii/src/validators/medical_practice_id_deu.rs
+++ b/crates/pii/src/validators/medical_practice_id_deu.rs
@@ -4,8 +4,7 @@
 //! invariants documented by the Kassenärztliche Bundesvereinigung: exactly
 //! nine digits and not the all-zero placeholder.
 
-use super::digits::collect_digits;
-use crate::ValidationOutcome;
+use super::prelude::*;
 
 pub(super) fn validate(candidate: &str) -> ValidationOutcome {
     let Some(digits) = collect_digits::<9>(candidate) else {

--- a/crates/pii/src/validators/mod.rs
+++ b/crates/pii/src/validators/mod.rs
@@ -17,6 +17,7 @@ mod medical_license_usa;
 mod medical_practice_id_deu;
 mod mod11_nhs_gbr;
 mod npi_usa;
+mod prelude;
 mod private_key_type;
 mod social_security_deu;
 mod ssn_usa;

--- a/crates/pii/src/validators/mod11_nhs_gbr.rs
+++ b/crates/pii/src/validators/mod11_nhs_gbr.rs
@@ -1,7 +1,6 @@
 //! UK NHS-number mod-11 checksum validator.
 
-use super::digits::collect_digits;
-use crate::ValidationOutcome;
+use super::prelude::*;
 
 /// UK NHS number mod-11 validator.
 ///

--- a/crates/pii/src/validators/npi_usa.rs
+++ b/crates/pii/src/validators/npi_usa.rs
@@ -7,9 +7,8 @@
 //! (e.g. `1111111110`); without this filter the Luhn check passes for several
 //! such sequences and produces noisy false positives.
 
-use super::digits::collect_digits;
 use super::luhn::luhn_passes;
-use crate::ValidationOutcome;
+use super::prelude::*;
 
 const NPI_PREFIX: [u32; 5] = [8, 0, 8, 4, 0];
 

--- a/crates/pii/src/validators/prelude.rs
+++ b/crates/pii/src/validators/prelude.rs
@@ -1,0 +1,4 @@
+//! Shared imports for validator modules.
+
+pub(crate) use super::digits::collect_digits;
+pub(crate) use crate::ValidationOutcome;

--- a/crates/pii/src/validators/private_key_type.rs
+++ b/crates/pii/src/validators/private_key_type.rs
@@ -1,6 +1,6 @@
 //! PEM private-key block type validator.
 
-use crate::ValidationOutcome;
+use super::prelude::*;
 
 /// PEM private-key block type validator: BEGIN-type MUST equal END-type.
 ///

--- a/crates/pii/src/validators/social_security_deu.rs
+++ b/crates/pii/src/validators/social_security_deu.rs
@@ -8,7 +8,7 @@
 //! resulting digits; each product is Quersumme-collapsed; sum modulo 10
 //! must equal the trailing check digit.
 
-use crate::ValidationOutcome;
+use super::prelude::*;
 
 pub(super) fn validate(candidate: &str) -> ValidationOutcome {
     let trimmed = candidate.trim();

--- a/crates/pii/src/validators/ssn_usa.rs
+++ b/crates/pii/src/validators/ssn_usa.rs
@@ -1,7 +1,6 @@
 //! US SSN validator filtering reserved area, group, and serial values.
 
-use super::digits::collect_digits;
-use crate::ValidationOutcome;
+use super::prelude::*;
 
 /// US Social Security Number validator. Rejects reserved area / group / serial values.
 pub(super) fn validate(candidate: &str) -> ValidationOutcome {

--- a/crates/pii/src/validators/tax_id_deu.rs
+++ b/crates/pii/src/validators/tax_id_deu.rs
@@ -5,8 +5,7 @@
 //! times in positions 1-10. The checksum is ISO 7064 Mod 11, 10 over the
 //! first ten digits.
 
-use super::digits::collect_digits;
-use crate::ValidationOutcome;
+use super::prelude::*;
 
 pub(super) fn validate(candidate: &str) -> ValidationOutcome {
     let Some(digits) = collect_digits::<11>(candidate) else {

--- a/crates/pii/src/validators/vat_country_length_eur.rs
+++ b/crates/pii/src/validators/vat_country_length_eur.rs
@@ -1,6 +1,6 @@
 //! EU / UK VAT-number country-length validator.
 
-use crate::ValidationOutcome;
+use super::prelude::*;
 
 const VAT_COUNTRY_LENGTHS: &[([u8; 2], usize, usize)] = &[
     (*b"AT", 9, 9),

--- a/crates/postgres/src/tools/create_database.rs
+++ b/crates/postgres/src/tools/create_database.rs
@@ -1,14 +1,9 @@
 //! MCP tool: `createDatabase`.
 
-use std::borrow::Cow;
-
 use dbmcp_server::types::{CreateDatabaseRequest, MessageResponse};
-use dbmcp_sql::Connection as _;
 use dbmcp_sql::SqlError;
-use rmcp::handler::server::router::tool::{AsyncTool, ToolBase};
-use rmcp::model::{ErrorData, ToolAnnotations};
 
-use crate::PostgresHandler;
+use super::prelude::*;
 use crate::connection::quote_ident;
 
 const NAME: &str = "createDatabase";

--- a/crates/postgres/src/tools/drop_database.rs
+++ b/crates/postgres/src/tools/drop_database.rs
@@ -1,14 +1,9 @@
 //! MCP tool: `dropDatabase`.
 
-use std::borrow::Cow;
-
 use dbmcp_server::types::{DropDatabaseRequest, MessageResponse};
-use dbmcp_sql::Connection as _;
 use dbmcp_sql::SqlError;
-use rmcp::handler::server::router::tool::{AsyncTool, ToolBase};
-use rmcp::model::{ErrorData, ToolAnnotations};
 
-use crate::PostgresHandler;
+use super::prelude::*;
 use crate::connection::quote_ident;
 
 const NAME: &str = "dropDatabase";

--- a/crates/postgres/src/tools/drop_table.rs
+++ b/crates/postgres/src/tools/drop_table.rs
@@ -1,14 +1,9 @@
 //! MCP tool: `dropTable`.
 
-use std::borrow::Cow;
-
 use dbmcp_server::types::MessageResponse;
-use dbmcp_sql::Connection as _;
 use dbmcp_sql::SqlError;
-use rmcp::handler::server::router::tool::{AsyncTool, ToolBase};
-use rmcp::model::{ErrorData, ToolAnnotations};
 
-use crate::PostgresHandler;
+use super::prelude::*;
 use crate::connection::quote_ident;
 use crate::types::{PinnedDropTableRequest, UnpinnedDropTableRequest};
 

--- a/crates/postgres/src/tools/explain_query.rs
+++ b/crates/postgres/src/tools/explain_query.rs
@@ -1,15 +1,10 @@
 //! MCP tool: `explainQuery`.
 
-use std::borrow::Cow;
-
 use dbmcp_pii::MaybeRedact as _;
 use dbmcp_server::types::{PinnedExplainQueryRequest, QueryResponse, UnpinnedExplainQueryRequest};
-use dbmcp_sql::Connection as _;
 use dbmcp_sql::validation::validate_read_only;
-use rmcp::handler::server::router::tool::{AsyncTool, ToolBase};
-use rmcp::model::{ErrorData, ToolAnnotations};
 
-use crate::PostgresHandler;
+use super::prelude::*;
 
 const NAME: &str = "explainQuery";
 const TITLE: &str = "Explain Query";

--- a/crates/postgres/src/tools/list_databases.rs
+++ b/crates/postgres/src/tools/list_databases.rs
@@ -1,14 +1,9 @@
 //! MCP tool: `listDatabases`.
 
-use std::borrow::Cow;
-
 use dbmcp_server::pagination::Pager;
 use dbmcp_server::types::{ListDatabasesRequest, ListDatabasesResponse};
-use dbmcp_sql::Connection as _;
-use rmcp::handler::server::router::tool::{AsyncTool, ToolBase};
-use rmcp::model::{ErrorData, ToolAnnotations};
 
-use crate::PostgresHandler;
+use super::prelude::*;
 
 const NAME: &str = "listDatabases";
 const TITLE: &str = "List Databases";

--- a/crates/postgres/src/tools/list_functions.rs
+++ b/crates/postgres/src/tools/list_functions.rs
@@ -1,13 +1,8 @@
 //! MCP tool: `listFunctions`.
 
-use std::borrow::Cow;
-
 use dbmcp_server::pagination::{Cursor, Pager};
-use dbmcp_sql::Connection as _;
-use rmcp::handler::server::router::tool::{AsyncTool, ToolBase};
-use rmcp::model::{ErrorData, ToolAnnotations};
 
-use crate::PostgresHandler;
+use super::prelude::*;
 use crate::types::{ListFunctionsResponse, PinnedListFunctionsRequest, UnpinnedListFunctionsRequest};
 
 const NAME: &str = "listFunctions";

--- a/crates/postgres/src/tools/list_materialized_views.rs
+++ b/crates/postgres/src/tools/list_materialized_views.rs
@@ -1,13 +1,8 @@
 //! MCP tool: `listMaterializedViews`.
 
-use std::borrow::Cow;
-
 use dbmcp_server::pagination::{Cursor, Pager};
-use dbmcp_sql::Connection as _;
-use rmcp::handler::server::router::tool::{AsyncTool, ToolBase};
-use rmcp::model::{ErrorData, ToolAnnotations};
 
-use crate::PostgresHandler;
+use super::prelude::*;
 use crate::types::{
     ListMaterializedViewsResponse, PinnedListMaterializedViewsRequest, UnpinnedListMaterializedViewsRequest,
 };

--- a/crates/postgres/src/tools/list_procedures.rs
+++ b/crates/postgres/src/tools/list_procedures.rs
@@ -1,13 +1,8 @@
 //! MCP tool: `listProcedures`.
 
-use std::borrow::Cow;
-
 use dbmcp_server::pagination::{Cursor, Pager};
-use dbmcp_sql::Connection as _;
-use rmcp::handler::server::router::tool::{AsyncTool, ToolBase};
-use rmcp::model::{ErrorData, ToolAnnotations};
 
-use crate::PostgresHandler;
+use super::prelude::*;
 use crate::types::{ListProceduresResponse, PinnedListProceduresRequest, UnpinnedListProceduresRequest};
 
 const NAME: &str = "listProcedures";

--- a/crates/postgres/src/tools/list_tables.rs
+++ b/crates/postgres/src/tools/list_tables.rs
@@ -1,15 +1,9 @@
 //! MCP tool: `listTables`.
 
-use std::borrow::Cow;
-
 use dbmcp_server::pagination::{Cursor, Pager};
-use dbmcp_sql::Connection as _;
 
+use super::prelude::*;
 use crate::types::{ListTablesResponse, PinnedListTablesRequest, UnpinnedListTablesRequest};
-use rmcp::handler::server::router::tool::{AsyncTool, ToolBase};
-use rmcp::model::{ErrorData, ToolAnnotations};
-
-use crate::PostgresHandler;
 
 const NAME: &str = "listTables";
 const TITLE: &str = "List Tables";

--- a/crates/postgres/src/tools/list_triggers.rs
+++ b/crates/postgres/src/tools/list_triggers.rs
@@ -1,13 +1,8 @@
 //! MCP tool: `listTriggers`.
 
-use std::borrow::Cow;
-
 use dbmcp_server::pagination::{Cursor, Pager};
-use dbmcp_sql::Connection as _;
-use rmcp::handler::server::router::tool::{AsyncTool, ToolBase};
-use rmcp::model::{ErrorData, ToolAnnotations};
 
-use crate::PostgresHandler;
+use super::prelude::*;
 use crate::types::{ListTriggersResponse, PinnedListTriggersRequest, UnpinnedListTriggersRequest};
 
 const NAME: &str = "listTriggers";

--- a/crates/postgres/src/tools/list_views.rs
+++ b/crates/postgres/src/tools/list_views.rs
@@ -1,13 +1,8 @@
 //! MCP tool: `listViews`.
 
-use std::borrow::Cow;
-
 use dbmcp_server::pagination::{Cursor, Pager};
-use dbmcp_sql::Connection as _;
-use rmcp::handler::server::router::tool::{AsyncTool, ToolBase};
-use rmcp::model::{ErrorData, ToolAnnotations};
 
-use crate::PostgresHandler;
+use super::prelude::*;
 use crate::types::{ListViewsResponse, PinnedListViewsRequest, UnpinnedListViewsRequest};
 
 const NAME: &str = "listViews";

--- a/crates/postgres/src/tools/mod.rs
+++ b/crates/postgres/src/tools/mod.rs
@@ -16,6 +16,7 @@ mod list_procedures;
 mod list_tables;
 mod list_triggers;
 mod list_views;
+mod prelude;
 mod read_query;
 mod write_query;
 

--- a/crates/postgres/src/tools/prelude.rs
+++ b/crates/postgres/src/tools/prelude.rs
@@ -1,0 +1,9 @@
+//! Shared imports for the `PostgreSQL` tool modules.
+
+pub(crate) use std::borrow::Cow;
+
+pub(crate) use dbmcp_sql::Connection as _;
+pub(crate) use rmcp::handler::server::router::tool::{AsyncTool, ToolBase};
+pub(crate) use rmcp::model::{ErrorData, ToolAnnotations};
+
+pub(crate) use crate::PostgresHandler;

--- a/crates/postgres/src/tools/read_query.rs
+++ b/crates/postgres/src/tools/read_query.rs
@@ -1,18 +1,13 @@
 //! MCP tool: `readQuery`.
 
-use std::borrow::Cow;
-
 use dbmcp_pii::MaybeRedact as _;
 use dbmcp_server::pagination::{Cursor, Pager};
 use dbmcp_server::types::{PinnedReadQueryRequest, ReadQueryResponse, UnpinnedReadQueryRequest};
-use dbmcp_sql::Connection as _;
 use dbmcp_sql::StatementKind;
 use dbmcp_sql::pagination::with_limit_offset;
 use dbmcp_sql::validation::validate_read_only;
-use rmcp::handler::server::router::tool::{AsyncTool, ToolBase};
-use rmcp::model::{ErrorData, ToolAnnotations};
 
-use crate::PostgresHandler;
+use super::prelude::*;
 
 const NAME: &str = "readQuery";
 const TITLE: &str = "Read Query";

--- a/crates/postgres/src/tools/write_query.rs
+++ b/crates/postgres/src/tools/write_query.rs
@@ -1,14 +1,9 @@
 //! MCP tool: `writeQuery`.
 
-use std::borrow::Cow;
-
 use dbmcp_pii::MaybeRedact as _;
 use dbmcp_server::types::{PinnedQueryRequest, QueryResponse, UnpinnedQueryRequest};
-use dbmcp_sql::Connection as _;
-use rmcp::handler::server::router::tool::{AsyncTool, ToolBase};
-use rmcp::model::{ErrorData, ToolAnnotations};
 
-use crate::PostgresHandler;
+use super::prelude::*;
 
 const NAME: &str = "writeQuery";
 const TITLE: &str = "Write Query";

--- a/crates/sqlite/src/tools/drop_table.rs
+++ b/crates/sqlite/src/tools/drop_table.rs
@@ -1,15 +1,9 @@
 //! MCP tool: `dropTable`.
 
-use std::borrow::Cow;
-
 use dbmcp_server::types::MessageResponse;
 use dbmcp_sql::SqlError;
 
-use dbmcp_sql::Connection as _;
-use rmcp::handler::server::router::tool::{AsyncTool, ToolBase};
-use rmcp::model::{ErrorData, ToolAnnotations};
-
-use crate::SqliteHandler;
+use super::prelude::*;
 use crate::connection::quote_ident;
 use crate::types::DropTableRequest;
 

--- a/crates/sqlite/src/tools/explain_query.rs
+++ b/crates/sqlite/src/tools/explain_query.rs
@@ -1,15 +1,9 @@
 //! MCP tool: `explainQuery`.
 
-use std::borrow::Cow;
-
 use dbmcp_pii::MaybeRedact as _;
 use dbmcp_server::types::QueryResponse;
 
-use dbmcp_sql::Connection as _;
-use rmcp::handler::server::router::tool::{AsyncTool, ToolBase};
-use rmcp::model::{ErrorData, ToolAnnotations};
-
-use crate::SqliteHandler;
+use super::prelude::*;
 use crate::types::ExplainQueryRequest;
 
 const NAME: &str = "explainQuery";

--- a/crates/sqlite/src/tools/list_tables.rs
+++ b/crates/sqlite/src/tools/list_tables.rs
@@ -1,13 +1,8 @@
 //! MCP tool: `listTables`.
 
-use std::borrow::Cow;
-
 use dbmcp_server::pagination::Pager;
-use dbmcp_sql::Connection as _;
-use rmcp::handler::server::router::tool::{AsyncTool, ToolBase};
-use rmcp::model::{ErrorData, ToolAnnotations};
 
-use crate::SqliteHandler;
+use super::prelude::*;
 use crate::types::{ListTablesRequest, ListTablesResponse};
 
 const NAME: &str = "listTables";

--- a/crates/sqlite/src/tools/list_triggers.rs
+++ b/crates/sqlite/src/tools/list_triggers.rs
@@ -1,15 +1,9 @@
 //! MCP tool: `listTriggers`.
 
-use std::borrow::Cow;
-
 use dbmcp_server::pagination::Pager;
 use dbmcp_server::types::ListTriggersResponse;
 
-use dbmcp_sql::Connection as _;
-use rmcp::handler::server::router::tool::{AsyncTool, ToolBase};
-use rmcp::model::{ErrorData, ToolAnnotations};
-
-use crate::SqliteHandler;
+use super::prelude::*;
 use crate::types::ListTriggersRequest;
 
 const NAME: &str = "listTriggers";

--- a/crates/sqlite/src/tools/list_views.rs
+++ b/crates/sqlite/src/tools/list_views.rs
@@ -1,16 +1,13 @@
 //! MCP tool: `listViews`.
 
-use std::borrow::Cow;
 use std::sync::Arc;
 
 use dbmcp_server::pagination::Pager;
 use dbmcp_server::types::ListViewsResponse;
 
-use dbmcp_sql::Connection as _;
-use rmcp::handler::server::router::tool::{AsyncTool, ToolBase};
-use rmcp::model::{ErrorData, JsonObject, ToolAnnotations};
+use rmcp::model::JsonObject;
 
-use crate::SqliteHandler;
+use super::prelude::*;
 use crate::types::ListViewsRequest;
 
 const NAME: &str = "listViews";

--- a/crates/sqlite/src/tools/mod.rs
+++ b/crates/sqlite/src/tools/mod.rs
@@ -10,6 +10,7 @@ mod explain_query;
 mod list_tables;
 mod list_triggers;
 mod list_views;
+mod prelude;
 mod read_query;
 mod write_query;
 

--- a/crates/sqlite/src/tools/prelude.rs
+++ b/crates/sqlite/src/tools/prelude.rs
@@ -1,0 +1,9 @@
+//! Shared imports for the `SQLite` tool modules.
+
+pub(crate) use std::borrow::Cow;
+
+pub(crate) use dbmcp_sql::Connection as _;
+pub(crate) use rmcp::handler::server::router::tool::{AsyncTool, ToolBase};
+pub(crate) use rmcp::model::{ErrorData, ToolAnnotations};
+
+pub(crate) use crate::SqliteHandler;

--- a/crates/sqlite/src/tools/read_query.rs
+++ b/crates/sqlite/src/tools/read_query.rs
@@ -1,19 +1,14 @@
 //! MCP tool: `readQuery`.
 
-use std::borrow::Cow;
-
 use dbmcp_pii::MaybeRedact as _;
 use dbmcp_server::pagination::Pager;
 use dbmcp_server::types::ReadQueryResponse;
 
-use dbmcp_sql::Connection as _;
 use dbmcp_sql::StatementKind;
 use dbmcp_sql::pagination::with_limit_offset;
 use dbmcp_sql::validation::validate_read_only;
-use rmcp::handler::server::router::tool::{AsyncTool, ToolBase};
-use rmcp::model::{ErrorData, ToolAnnotations};
 
-use crate::SqliteHandler;
+use super::prelude::*;
 use crate::types::ReadQueryRequest;
 
 const NAME: &str = "readQuery";

--- a/crates/sqlite/src/tools/write_query.rs
+++ b/crates/sqlite/src/tools/write_query.rs
@@ -1,15 +1,9 @@
 //! MCP tool: `writeQuery`.
 
-use std::borrow::Cow;
-
 use dbmcp_pii::MaybeRedact as _;
 use dbmcp_server::types::QueryResponse;
 
-use dbmcp_sql::Connection as _;
-use rmcp::handler::server::router::tool::{AsyncTool, ToolBase};
-use rmcp::model::{ErrorData, ToolAnnotations};
-
-use crate::SqliteHandler;
+use super::prelude::*;
 use crate::types::QueryRequest;
 
 const NAME: &str = "writeQuery";

--- a/crates/sqlx-json/src/lib.rs
+++ b/crates/sqlx-json/src/lib.rs
@@ -10,6 +10,7 @@
 mod mysql;
 mod numeric;
 mod postgres;
+mod prelude;
 mod sqlite;
 mod traits;
 

--- a/crates/sqlx-json/src/mysql.rs
+++ b/crates/sqlx-json/src/mysql.rs
@@ -8,16 +8,12 @@
 //! is decoded via `BigDecimal` to preserve precision; `FLOAT` is decoded as
 //! `f32` (sqlx-mysql strict-checks the column type), `DOUBLE` as `f64`.
 
-use base64::Engine as _;
-use base64::engine::general_purpose::STANDARD as BASE64;
 use bigdecimal::BigDecimal;
-use serde_json::{Map, Value};
 use sqlx::mysql::MySqlRow;
 use sqlx::types::chrono::{DateTime, NaiveDate, NaiveDateTime, NaiveTime, Utc};
-use sqlx::{Column, Row, TypeInfo, ValueRef};
 
-use crate::RowExt;
 use crate::numeric::bigdecimal_to_json;
+use crate::prelude::*;
 
 impl RowExt for MySqlRow {
     fn to_json(&self) -> Value {

--- a/crates/sqlx-json/src/postgres.rs
+++ b/crates/sqlx-json/src/postgres.rs
@@ -12,16 +12,12 @@
 
 use std::str::FromStr;
 
-use base64::Engine as _;
-use base64::engine::general_purpose::STANDARD as BASE64;
 use bigdecimal::BigDecimal;
-use serde_json::{Map, Value};
 use sqlx::postgres::PgRow;
 use sqlx::types::chrono::{DateTime, NaiveDate, NaiveDateTime, NaiveTime, Utc};
-use sqlx::{Column, Row, TypeInfo, ValueRef};
 
-use crate::RowExt;
 use crate::numeric::bigdecimal_to_json;
+use crate::prelude::*;
 
 /// Parses a locale-formatted Postgres `MONEY` text value into a `BigDecimal`.
 ///

--- a/crates/sqlx-json/src/prelude.rs
+++ b/crates/sqlx-json/src/prelude.rs
@@ -1,0 +1,8 @@
+//! Shared imports for the per-backend `RowExt` implementations.
+
+pub(crate) use base64::Engine as _;
+pub(crate) use base64::engine::general_purpose::STANDARD as BASE64;
+pub(crate) use serde_json::{Map, Value};
+pub(crate) use sqlx::{Column, Row, TypeInfo, ValueRef};
+
+pub(crate) use crate::RowExt;

--- a/crates/sqlx-json/src/sqlite.rs
+++ b/crates/sqlx-json/src/sqlite.rs
@@ -1,12 +1,8 @@
 //! [`RowExt`](crate::RowExt) implementation for `SQLite` rows.
 
-use base64::Engine as _;
-use base64::engine::general_purpose::STANDARD as BASE64;
-use serde_json::{Map, Value};
 use sqlx::sqlite::SqliteRow;
-use sqlx::{Column, Row, TypeInfo, ValueRef};
 
-use crate::RowExt;
+use crate::prelude::*;
 
 impl RowExt for SqliteRow {
     fn to_json(&self) -> Value {


### PR DESCRIPTION
## Summary

Replaces repeated per-file `use` blocks with private `mod prelude;` re-export modules consumed via glob import.

Scope (import/visibility only — no behavior change):
- `crates/pii` recognizers and validators
- `crates/{mysql,postgres,sqlite}` tools
- `crates/sqlx-json` per-backend `RowExt` impls

## Design
- Each prelude holds only broadly-shared vocabulary; file-specific imports stay local (e.g. `JsonObject`).
- All six prelude modules are private `mod prelude;` (least-privilege, uniform).
- Every leaf module globs its group prelude; parent mods and `#[cfg(test)]` modules keep explicit imports.
- Complies with M-NO-GLOB-REEXPORTS (individual `pub(crate) use`, no glob re-exports); the prelude glob import is the sanctioned exception.

Net **-350 lines**.

## Verification
- `cargo fmt --check` ✓
- `cargo clippy --workspace --tests -- -D warnings` ✓
- `cargo test --workspace --lib --bins` ✓
- `./tests/run.sh` ✓ — 734 integration tests (mariadb 207, mysql 207, postgres 221, sqlite 99)