### PR TITLE
refactor(server): generate slim tool schemas via schemars Transform

### DIFF
--- a/crates/mysql/src/tools/create_database.rs
+++ b/crates/mysql/src/tools/create_database.rs
@@ -39,6 +39,14 @@ impl ToolBase for CreateDatabaseTool {
                 .open_world(false),
         )
     }
+
+    fn input_schema() -> Option<Arc<JsonObject>> {
+        Some(input_schema::<Self::Parameter>())
+    }
+
+    fn output_schema() -> Option<Arc<JsonObject>> {
+        Some(output_schema::<Self::Output>())
+    }
 }
 
 impl AsyncTool<MysqlHandler> for CreateDatabaseTool {

--- a/crates/mysql/src/tools/drop_database.rs
+++ b/crates/mysql/src/tools/drop_database.rs
@@ -39,6 +39,14 @@ impl ToolBase for DropDatabaseTool {
                 .open_world(false),
         )
     }
+
+    fn input_schema() -> Option<Arc<JsonObject>> {
+        Some(input_schema::<Self::Parameter>())
+    }
+
+    fn output_schema() -> Option<Arc<JsonObject>> {
+        Some(output_schema::<Self::Output>())
+    }
 }
 
 impl AsyncTool<MysqlHandler> for DropDatabaseTool {

--- a/crates/mysql/src/tools/drop_table.rs
+++ b/crates/mysql/src/tools/drop_table.rs
@@ -43,6 +43,14 @@ impl ToolBase for PinnedDropTableTool {
     fn annotations() -> Option<ToolAnnotations> {
         Some(annotations())
     }
+
+    fn input_schema() -> Option<Arc<JsonObject>> {
+        Some(input_schema::<Self::Parameter>())
+    }
+
+    fn output_schema() -> Option<Arc<JsonObject>> {
+        Some(output_schema::<Self::Output>())
+    }
 }
 
 impl AsyncTool<MysqlHandler> for PinnedDropTableTool {
@@ -73,6 +81,14 @@ impl ToolBase for UnpinnedDropTableTool {
 
     fn annotations() -> Option<ToolAnnotations> {
         Some(annotations())
+    }
+
+    fn input_schema() -> Option<Arc<JsonObject>> {
+        Some(input_schema::<Self::Parameter>())
+    }
+
+    fn output_schema() -> Option<Arc<JsonObject>> {
+        Some(output_schema::<Self::Output>())
     }
 }
 

--- a/crates/mysql/src/tools/explain_query.rs
+++ b/crates/mysql/src/tools/explain_query.rs
@@ -42,6 +42,14 @@ impl ToolBase for PinnedExplainQueryTool {
     fn annotations() -> Option<ToolAnnotations> {
         Some(annotations())
     }
+
+    fn input_schema() -> Option<Arc<JsonObject>> {
+        Some(input_schema::<Self::Parameter>())
+    }
+
+    fn output_schema() -> Option<Arc<JsonObject>> {
+        Some(output_schema::<Self::Output>())
+    }
 }
 
 impl AsyncTool<MysqlHandler> for PinnedExplainQueryTool {
@@ -72,6 +80,14 @@ impl ToolBase for UnpinnedExplainQueryTool {
 
     fn annotations() -> Option<ToolAnnotations> {
         Some(annotations())
+    }
+
+    fn input_schema() -> Option<Arc<JsonObject>> {
+        Some(input_schema::<Self::Parameter>())
+    }
+
+    fn output_schema() -> Option<Arc<JsonObject>> {
+        Some(output_schema::<Self::Output>())
     }
 }
 

--- a/crates/mysql/src/tools/list_databases.rs
+++ b/crates/mysql/src/tools/list_databases.rs
@@ -38,6 +38,14 @@ impl ToolBase for ListDatabasesTool {
                 .open_world(false),
         )
     }
+
+    fn input_schema() -> Option<Arc<JsonObject>> {
+        Some(input_schema::<Self::Parameter>())
+    }
+
+    fn output_schema() -> Option<Arc<JsonObject>> {
+        Some(output_schema::<Self::Output>())
+    }
 }
 
 impl AsyncTool<MysqlHandler> for ListDatabasesTool {

--- a/crates/mysql/src/tools/list_functions.rs
+++ b/crates/mysql/src/tools/list_functions.rs
@@ -42,6 +42,14 @@ impl ToolBase for PinnedListFunctionsTool {
     fn annotations() -> Option<ToolAnnotations> {
         Some(annotations())
     }
+
+    fn input_schema() -> Option<Arc<JsonObject>> {
+        Some(input_schema::<Self::Parameter>())
+    }
+
+    fn output_schema() -> Option<Arc<JsonObject>> {
+        Some(output_schema::<Self::Output>())
+    }
 }
 
 impl AsyncTool<MysqlHandler> for PinnedListFunctionsTool {
@@ -74,6 +82,14 @@ impl ToolBase for UnpinnedListFunctionsTool {
 
     fn annotations() -> Option<ToolAnnotations> {
         Some(annotations())
+    }
+
+    fn input_schema() -> Option<Arc<JsonObject>> {
+        Some(input_schema::<Self::Parameter>())
+    }
+
+    fn output_schema() -> Option<Arc<JsonObject>> {
+        Some(output_schema::<Self::Output>())
     }
 }
 

--- a/crates/mysql/src/tools/list_procedures.rs
+++ b/crates/mysql/src/tools/list_procedures.rs
@@ -41,6 +41,14 @@ impl ToolBase for PinnedListProceduresTool {
     fn annotations() -> Option<ToolAnnotations> {
         Some(annotations())
     }
+
+    fn input_schema() -> Option<Arc<JsonObject>> {
+        Some(input_schema::<Self::Parameter>())
+    }
+
+    fn output_schema() -> Option<Arc<JsonObject>> {
+        Some(output_schema::<Self::Output>())
+    }
 }
 
 impl AsyncTool<MysqlHandler> for PinnedListProceduresTool {
@@ -73,6 +81,14 @@ impl ToolBase for UnpinnedListProceduresTool {
 
     fn annotations() -> Option<ToolAnnotations> {
         Some(annotations())
+    }
+
+    fn input_schema() -> Option<Arc<JsonObject>> {
+        Some(input_schema::<Self::Parameter>())
+    }
+
+    fn output_schema() -> Option<Arc<JsonObject>> {
+        Some(output_schema::<Self::Output>())
     }
 }
 

--- a/crates/mysql/src/tools/list_tables.rs
+++ b/crates/mysql/src/tools/list_tables.rs
@@ -320,6 +320,14 @@ impl ToolBase for PinnedListTablesTool {
     fn annotations() -> Option<ToolAnnotations> {
         Some(annotations())
     }
+
+    fn input_schema() -> Option<Arc<JsonObject>> {
+        Some(input_schema::<Self::Parameter>())
+    }
+
+    fn output_schema() -> Option<Arc<JsonObject>> {
+        Some(output_schema::<Self::Output>())
+    }
 }
 
 impl AsyncTool<MysqlHandler> for PinnedListTablesTool {
@@ -352,6 +360,14 @@ impl ToolBase for UnpinnedListTablesTool {
 
     fn annotations() -> Option<ToolAnnotations> {
         Some(annotations())
+    }
+
+    fn input_schema() -> Option<Arc<JsonObject>> {
+        Some(input_schema::<Self::Parameter>())
+    }
+
+    fn output_schema() -> Option<Arc<JsonObject>> {
+        Some(output_schema::<Self::Output>())
     }
 }
 

--- a/crates/mysql/src/tools/list_triggers.rs
+++ b/crates/mysql/src/tools/list_triggers.rs
@@ -41,6 +41,14 @@ impl ToolBase for PinnedListTriggersTool {
     fn annotations() -> Option<ToolAnnotations> {
         Some(annotations())
     }
+
+    fn input_schema() -> Option<Arc<JsonObject>> {
+        Some(input_schema::<Self::Parameter>())
+    }
+
+    fn output_schema() -> Option<Arc<JsonObject>> {
+        Some(output_schema::<Self::Output>())
+    }
 }
 
 impl AsyncTool<MysqlHandler> for PinnedListTriggersTool {
@@ -73,6 +81,14 @@ impl ToolBase for UnpinnedListTriggersTool {
 
     fn annotations() -> Option<ToolAnnotations> {
         Some(annotations())
+    }
+
+    fn input_schema() -> Option<Arc<JsonObject>> {
+        Some(input_schema::<Self::Parameter>())
+    }
+
+    fn output_schema() -> Option<Arc<JsonObject>> {
+        Some(output_schema::<Self::Output>())
     }
 }
 

--- a/crates/mysql/src/tools/list_views.rs
+++ b/crates/mysql/src/tools/list_views.rs
@@ -41,6 +41,14 @@ impl ToolBase for PinnedListViewsTool {
     fn annotations() -> Option<ToolAnnotations> {
         Some(annotations())
     }
+
+    fn input_schema() -> Option<Arc<JsonObject>> {
+        Some(input_schema::<Self::Parameter>())
+    }
+
+    fn output_schema() -> Option<Arc<JsonObject>> {
+        Some(output_schema::<Self::Output>())
+    }
 }
 
 impl AsyncTool<MysqlHandler> for PinnedListViewsTool {
@@ -73,6 +81,14 @@ impl ToolBase for UnpinnedListViewsTool {
 
     fn annotations() -> Option<ToolAnnotations> {
         Some(annotations())
+    }
+
+    fn input_schema() -> Option<Arc<JsonObject>> {
+        Some(input_schema::<Self::Parameter>())
+    }
+
+    fn output_schema() -> Option<Arc<JsonObject>> {
+        Some(output_schema::<Self::Output>())
     }
 }
 

--- a/crates/mysql/src/tools/prelude.rs
+++ b/crates/mysql/src/tools/prelude.rs
@@ -1,9 +1,11 @@
 //! Shared imports for the `MySQL` tool modules.
 
 pub(crate) use std::borrow::Cow;
+pub(crate) use std::sync::Arc;
 
+pub(crate) use dbmcp_server::{input_schema, output_schema};
 pub(crate) use dbmcp_sql::Connection as _;
 pub(crate) use rmcp::handler::server::router::tool::{AsyncTool, ToolBase};
-pub(crate) use rmcp::model::{ErrorData, ToolAnnotations};
+pub(crate) use rmcp::model::{ErrorData, JsonObject, ToolAnnotations};
 
 pub(crate) use crate::MysqlHandler;

--- a/crates/mysql/src/tools/read_query.rs
+++ b/crates/mysql/src/tools/read_query.rs
@@ -45,6 +45,14 @@ impl ToolBase for PinnedReadQueryTool {
     fn annotations() -> Option<ToolAnnotations> {
         Some(annotations())
     }
+
+    fn input_schema() -> Option<Arc<JsonObject>> {
+        Some(input_schema::<Self::Parameter>())
+    }
+
+    fn output_schema() -> Option<Arc<JsonObject>> {
+        Some(output_schema::<Self::Output>())
+    }
 }
 
 impl AsyncTool<MysqlHandler> for PinnedReadQueryTool {
@@ -75,6 +83,14 @@ impl ToolBase for UnpinnedReadQueryTool {
 
     fn annotations() -> Option<ToolAnnotations> {
         Some(annotations())
+    }
+
+    fn input_schema() -> Option<Arc<JsonObject>> {
+        Some(input_schema::<Self::Parameter>())
+    }
+
+    fn output_schema() -> Option<Arc<JsonObject>> {
+        Some(output_schema::<Self::Output>())
     }
 }
 

--- a/crates/mysql/src/tools/write_query.rs
+++ b/crates/mysql/src/tools/write_query.rs
@@ -41,6 +41,14 @@ impl ToolBase for PinnedWriteQueryTool {
     fn annotations() -> Option<ToolAnnotations> {
         Some(annotations())
     }
+
+    fn input_schema() -> Option<Arc<JsonObject>> {
+        Some(input_schema::<Self::Parameter>())
+    }
+
+    fn output_schema() -> Option<Arc<JsonObject>> {
+        Some(output_schema::<Self::Output>())
+    }
 }
 
 impl AsyncTool<MysqlHandler> for PinnedWriteQueryTool {
@@ -71,6 +79,14 @@ impl ToolBase for UnpinnedWriteQueryTool {
 
     fn annotations() -> Option<ToolAnnotations> {
         Some(annotations())
+    }
+
+    fn input_schema() -> Option<Arc<JsonObject>> {
+        Some(input_schema::<Self::Parameter>())
+    }
+
+    fn output_schema() -> Option<Arc<JsonObject>> {
+        Some(output_schema::<Self::Output>())
     }
 }
 

--- a/crates/mysql/src/types.rs
+++ b/crates/mysql/src/types.rs
@@ -14,7 +14,6 @@ pub use dbmcp_server::types::{
 
 /// Request for the `dropTable` tool.
 #[derive(Debug, Default, Deserialize, JsonSchema)]
-#[schemars(rename = "DropTableRequest")]
 pub struct PinnedDropTableRequest {
     /// Name of the table to drop. Must be non-empty.
     pub table: String,
@@ -22,7 +21,6 @@ pub struct PinnedDropTableRequest {
 
 /// Request for the `dropTable` tool.
 #[derive(Debug, Default, Deserialize, JsonSchema)]
-#[schemars(rename = "DropTableRequest")]
 pub struct UnpinnedDropTableRequest {
     #[serde(flatten)]
     pub inner: PinnedDropTableRequest,
@@ -33,7 +31,6 @@ pub struct UnpinnedDropTableRequest {
 
 /// Request for the MySQL/MariaDB `listTables` tool — supports search + detailed mode.
 #[derive(Debug, Default, Deserialize, JsonSchema)]
-#[schemars(rename = "ListTablesRequest")]
 pub struct PinnedListTablesRequest {
     /// Opaque cursor from a prior response's `nextCursor`; omit for the first page.
     #[serde(default)]
@@ -51,7 +48,6 @@ pub struct PinnedListTablesRequest {
 
 /// Request for the MySQL/MariaDB `listTables` tool — supports search + detailed mode.
 #[derive(Debug, Default, Deserialize, JsonSchema)]
-#[schemars(rename = "ListTablesRequest")]
 pub struct UnpinnedListTablesRequest {
     #[serde(flatten)]
     pub inner: PinnedListTablesRequest,
@@ -62,7 +58,6 @@ pub struct UnpinnedListTablesRequest {
 
 /// Request for the MySQL/MariaDB `listFunctions` tool — supports search + detailed mode.
 #[derive(Debug, Default, Deserialize, JsonSchema)]
-#[schemars(rename = "ListFunctionsRequest")]
 pub struct PinnedListFunctionsRequest {
     /// Opaque cursor from a prior response's `nextCursor`; omit for the first page.
     #[serde(default)]
@@ -82,7 +77,6 @@ pub struct PinnedListFunctionsRequest {
 
 /// Request for the MySQL/MariaDB `listFunctions` tool — supports search + detailed mode.
 #[derive(Debug, Default, Deserialize, JsonSchema)]
-#[schemars(rename = "ListFunctionsRequest")]
 pub struct UnpinnedListFunctionsRequest {
     #[serde(flatten)]
     pub inner: PinnedListFunctionsRequest,
@@ -93,7 +87,6 @@ pub struct UnpinnedListFunctionsRequest {
 
 /// Request for the MySQL/MariaDB `listProcedures` tool — supports search + detailed mode.
 #[derive(Debug, Default, Deserialize, JsonSchema)]
-#[schemars(rename = "ListProceduresRequest")]
 pub struct PinnedListProceduresRequest {
     /// Opaque cursor from a prior response's `nextCursor`; omit for the first page.
     #[serde(default)]
@@ -113,7 +106,6 @@ pub struct PinnedListProceduresRequest {
 
 /// Request for the MySQL/MariaDB `listProcedures` tool — supports search + detailed mode.
 #[derive(Debug, Default, Deserialize, JsonSchema)]
-#[schemars(rename = "ListProceduresRequest")]
 pub struct UnpinnedListProceduresRequest {
     #[serde(flatten)]
     pub inner: PinnedListProceduresRequest,
@@ -124,7 +116,6 @@ pub struct UnpinnedListProceduresRequest {
 
 /// Request for the MySQL/MariaDB `listViews` tool — supports search + detailed mode.
 #[derive(Debug, Default, Deserialize, JsonSchema)]
-#[schemars(rename = "ListViewsRequest")]
 pub struct PinnedListViewsRequest {
     /// Opaque cursor from a prior response's `nextCursor`; omit for the first page.
     #[serde(default)]
@@ -142,7 +133,6 @@ pub struct PinnedListViewsRequest {
 
 /// Request for the MySQL/MariaDB `listViews` tool — supports search + detailed mode.
 #[derive(Debug, Default, Deserialize, JsonSchema)]
-#[schemars(rename = "ListViewsRequest")]
 pub struct UnpinnedListViewsRequest {
     #[serde(flatten)]
     pub inner: PinnedListViewsRequest,

--- a/crates/postgres/src/tools/create_database.rs
+++ b/crates/postgres/src/tools/create_database.rs
@@ -39,6 +39,14 @@ impl ToolBase for CreateDatabaseTool {
                 .open_world(false),
         )
     }
+
+    fn input_schema() -> Option<Arc<JsonObject>> {
+        Some(input_schema::<Self::Parameter>())
+    }
+
+    fn output_schema() -> Option<Arc<JsonObject>> {
+        Some(output_schema::<Self::Output>())
+    }
 }
 
 impl AsyncTool<PostgresHandler> for CreateDatabaseTool {

--- a/crates/postgres/src/tools/drop_database.rs
+++ b/crates/postgres/src/tools/drop_database.rs
@@ -39,6 +39,14 @@ impl ToolBase for DropDatabaseTool {
                 .open_world(false),
         )
     }
+
+    fn input_schema() -> Option<Arc<JsonObject>> {
+        Some(input_schema::<Self::Parameter>())
+    }
+
+    fn output_schema() -> Option<Arc<JsonObject>> {
+        Some(output_schema::<Self::Output>())
+    }
 }
 
 impl AsyncTool<PostgresHandler> for DropDatabaseTool {

--- a/crates/postgres/src/tools/drop_table.rs
+++ b/crates/postgres/src/tools/drop_table.rs
@@ -43,6 +43,14 @@ impl ToolBase for PinnedDropTableTool {
     fn annotations() -> Option<ToolAnnotations> {
         Some(annotations())
     }
+
+    fn input_schema() -> Option<Arc<JsonObject>> {
+        Some(input_schema::<Self::Parameter>())
+    }
+
+    fn output_schema() -> Option<Arc<JsonObject>> {
+        Some(output_schema::<Self::Output>())
+    }
 }
 
 impl AsyncTool<PostgresHandler> for PinnedDropTableTool {
@@ -73,6 +81,14 @@ impl ToolBase for UnpinnedDropTableTool {
 
     fn annotations() -> Option<ToolAnnotations> {
         Some(annotations())
+    }
+
+    fn input_schema() -> Option<Arc<JsonObject>> {
+        Some(input_schema::<Self::Parameter>())
+    }
+
+    fn output_schema() -> Option<Arc<JsonObject>> {
+        Some(output_schema::<Self::Output>())
     }
 }
 

--- a/crates/postgres/src/tools/explain_query.rs
+++ b/crates/postgres/src/tools/explain_query.rs
@@ -42,6 +42,14 @@ impl ToolBase for PinnedExplainQueryTool {
     fn annotations() -> Option<ToolAnnotations> {
         Some(annotations())
     }
+
+    fn input_schema() -> Option<Arc<JsonObject>> {
+        Some(input_schema::<Self::Parameter>())
+    }
+
+    fn output_schema() -> Option<Arc<JsonObject>> {
+        Some(output_schema::<Self::Output>())
+    }
 }
 
 impl AsyncTool<PostgresHandler> for PinnedExplainQueryTool {
@@ -72,6 +80,14 @@ impl ToolBase for UnpinnedExplainQueryTool {
 
     fn annotations() -> Option<ToolAnnotations> {
         Some(annotations())
+    }
+
+    fn input_schema() -> Option<Arc<JsonObject>> {
+        Some(input_schema::<Self::Parameter>())
+    }
+
+    fn output_schema() -> Option<Arc<JsonObject>> {
+        Some(output_schema::<Self::Output>())
     }
 }
 

--- a/crates/postgres/src/tools/list_databases.rs
+++ b/crates/postgres/src/tools/list_databases.rs
@@ -38,6 +38,14 @@ impl ToolBase for ListDatabasesTool {
                 .open_world(false),
         )
     }
+
+    fn input_schema() -> Option<Arc<JsonObject>> {
+        Some(input_schema::<Self::Parameter>())
+    }
+
+    fn output_schema() -> Option<Arc<JsonObject>> {
+        Some(output_schema::<Self::Output>())
+    }
 }
 
 impl AsyncTool<PostgresHandler> for ListDatabasesTool {

--- a/crates/postgres/src/tools/list_functions.rs
+++ b/crates/postgres/src/tools/list_functions.rs
@@ -41,6 +41,14 @@ impl ToolBase for PinnedListFunctionsTool {
     fn annotations() -> Option<ToolAnnotations> {
         Some(annotations())
     }
+
+    fn input_schema() -> Option<Arc<JsonObject>> {
+        Some(input_schema::<Self::Parameter>())
+    }
+
+    fn output_schema() -> Option<Arc<JsonObject>> {
+        Some(output_schema::<Self::Output>())
+    }
 }
 
 impl AsyncTool<PostgresHandler> for PinnedListFunctionsTool {
@@ -73,6 +81,14 @@ impl ToolBase for UnpinnedListFunctionsTool {
 
     fn annotations() -> Option<ToolAnnotations> {
         Some(annotations())
+    }
+
+    fn input_schema() -> Option<Arc<JsonObject>> {
+        Some(input_schema::<Self::Parameter>())
+    }
+
+    fn output_schema() -> Option<Arc<JsonObject>> {
+        Some(output_schema::<Self::Output>())
     }
 }
 

--- a/crates/postgres/src/tools/list_materialized_views.rs
+++ b/crates/postgres/src/tools/list_materialized_views.rs
@@ -43,6 +43,14 @@ impl ToolBase for PinnedListMaterializedViewsTool {
     fn annotations() -> Option<ToolAnnotations> {
         Some(annotations())
     }
+
+    fn input_schema() -> Option<Arc<JsonObject>> {
+        Some(input_schema::<Self::Parameter>())
+    }
+
+    fn output_schema() -> Option<Arc<JsonObject>> {
+        Some(output_schema::<Self::Output>())
+    }
 }
 
 impl AsyncTool<PostgresHandler> for PinnedListMaterializedViewsTool {
@@ -75,6 +83,14 @@ impl ToolBase for UnpinnedListMaterializedViewsTool {
 
     fn annotations() -> Option<ToolAnnotations> {
         Some(annotations())
+    }
+
+    fn input_schema() -> Option<Arc<JsonObject>> {
+        Some(input_schema::<Self::Parameter>())
+    }
+
+    fn output_schema() -> Option<Arc<JsonObject>> {
+        Some(output_schema::<Self::Output>())
     }
 }
 

--- a/crates/postgres/src/tools/list_procedures.rs
+++ b/crates/postgres/src/tools/list_procedures.rs
@@ -41,6 +41,14 @@ impl ToolBase for PinnedListProceduresTool {
     fn annotations() -> Option<ToolAnnotations> {
         Some(annotations())
     }
+
+    fn input_schema() -> Option<Arc<JsonObject>> {
+        Some(input_schema::<Self::Parameter>())
+    }
+
+    fn output_schema() -> Option<Arc<JsonObject>> {
+        Some(output_schema::<Self::Output>())
+    }
 }
 
 impl AsyncTool<PostgresHandler> for PinnedListProceduresTool {
@@ -73,6 +81,14 @@ impl ToolBase for UnpinnedListProceduresTool {
 
     fn annotations() -> Option<ToolAnnotations> {
         Some(annotations())
+    }
+
+    fn input_schema() -> Option<Arc<JsonObject>> {
+        Some(input_schema::<Self::Parameter>())
+    }
+
+    fn output_schema() -> Option<Arc<JsonObject>> {
+        Some(output_schema::<Self::Output>())
     }
 }
 

--- a/crates/postgres/src/tools/list_tables.rs
+++ b/crates/postgres/src/tools/list_tables.rs
@@ -41,6 +41,14 @@ impl ToolBase for PinnedListTablesTool {
     fn annotations() -> Option<ToolAnnotations> {
         Some(annotations())
     }
+
+    fn input_schema() -> Option<Arc<JsonObject>> {
+        Some(input_schema::<Self::Parameter>())
+    }
+
+    fn output_schema() -> Option<Arc<JsonObject>> {
+        Some(output_schema::<Self::Output>())
+    }
 }
 
 impl AsyncTool<PostgresHandler> for PinnedListTablesTool {
@@ -73,6 +81,14 @@ impl ToolBase for UnpinnedListTablesTool {
 
     fn annotations() -> Option<ToolAnnotations> {
         Some(annotations())
+    }
+
+    fn input_schema() -> Option<Arc<JsonObject>> {
+        Some(input_schema::<Self::Parameter>())
+    }
+
+    fn output_schema() -> Option<Arc<JsonObject>> {
+        Some(output_schema::<Self::Output>())
     }
 }
 

--- a/crates/postgres/src/tools/list_triggers.rs
+++ b/crates/postgres/src/tools/list_triggers.rs
@@ -41,6 +41,14 @@ impl ToolBase for PinnedListTriggersTool {
     fn annotations() -> Option<ToolAnnotations> {
         Some(annotations())
     }
+
+    fn input_schema() -> Option<Arc<JsonObject>> {
+        Some(input_schema::<Self::Parameter>())
+    }
+
+    fn output_schema() -> Option<Arc<JsonObject>> {
+        Some(output_schema::<Self::Output>())
+    }
 }
 
 impl AsyncTool<PostgresHandler> for PinnedListTriggersTool {
@@ -73,6 +81,14 @@ impl ToolBase for UnpinnedListTriggersTool {
 
     fn annotations() -> Option<ToolAnnotations> {
         Some(annotations())
+    }
+
+    fn input_schema() -> Option<Arc<JsonObject>> {
+        Some(input_schema::<Self::Parameter>())
+    }
+
+    fn output_schema() -> Option<Arc<JsonObject>> {
+        Some(output_schema::<Self::Output>())
     }
 }
 

--- a/crates/postgres/src/tools/list_views.rs
+++ b/crates/postgres/src/tools/list_views.rs
@@ -41,6 +41,14 @@ impl ToolBase for PinnedListViewsTool {
     fn annotations() -> Option<ToolAnnotations> {
         Some(annotations())
     }
+
+    fn input_schema() -> Option<Arc<JsonObject>> {
+        Some(input_schema::<Self::Parameter>())
+    }
+
+    fn output_schema() -> Option<Arc<JsonObject>> {
+        Some(output_schema::<Self::Output>())
+    }
 }
 
 impl AsyncTool<PostgresHandler> for PinnedListViewsTool {
@@ -73,6 +81,14 @@ impl ToolBase for UnpinnedListViewsTool {
 
     fn annotations() -> Option<ToolAnnotations> {
         Some(annotations())
+    }
+
+    fn input_schema() -> Option<Arc<JsonObject>> {
+        Some(input_schema::<Self::Parameter>())
+    }
+
+    fn output_schema() -> Option<Arc<JsonObject>> {
+        Some(output_schema::<Self::Output>())
     }
 }
 

--- a/crates/postgres/src/tools/prelude.rs
+++ b/crates/postgres/src/tools/prelude.rs
@@ -1,9 +1,11 @@
 //! Shared imports for the `PostgreSQL` tool modules.
 
 pub(crate) use std::borrow::Cow;
+pub(crate) use std::sync::Arc;
 
+pub(crate) use dbmcp_server::{input_schema, output_schema};
 pub(crate) use dbmcp_sql::Connection as _;
 pub(crate) use rmcp::handler::server::router::tool::{AsyncTool, ToolBase};
-pub(crate) use rmcp::model::{ErrorData, ToolAnnotations};
+pub(crate) use rmcp::model::{ErrorData, JsonObject, ToolAnnotations};
 
 pub(crate) use crate::PostgresHandler;

--- a/crates/postgres/src/tools/read_query.rs
+++ b/crates/postgres/src/tools/read_query.rs
@@ -45,6 +45,14 @@ impl ToolBase for PinnedReadQueryTool {
     fn annotations() -> Option<ToolAnnotations> {
         Some(annotations())
     }
+
+    fn input_schema() -> Option<Arc<JsonObject>> {
+        Some(input_schema::<Self::Parameter>())
+    }
+
+    fn output_schema() -> Option<Arc<JsonObject>> {
+        Some(output_schema::<Self::Output>())
+    }
 }
 
 impl AsyncTool<PostgresHandler> for PinnedReadQueryTool {
@@ -75,6 +83,14 @@ impl ToolBase for UnpinnedReadQueryTool {
 
     fn annotations() -> Option<ToolAnnotations> {
         Some(annotations())
+    }
+
+    fn input_schema() -> Option<Arc<JsonObject>> {
+        Some(input_schema::<Self::Parameter>())
+    }
+
+    fn output_schema() -> Option<Arc<JsonObject>> {
+        Some(output_schema::<Self::Output>())
     }
 }
 

--- a/crates/postgres/src/tools/write_query.rs
+++ b/crates/postgres/src/tools/write_query.rs
@@ -41,6 +41,14 @@ impl ToolBase for PinnedWriteQueryTool {
     fn annotations() -> Option<ToolAnnotations> {
         Some(annotations())
     }
+
+    fn input_schema() -> Option<Arc<JsonObject>> {
+        Some(input_schema::<Self::Parameter>())
+    }
+
+    fn output_schema() -> Option<Arc<JsonObject>> {
+        Some(output_schema::<Self::Output>())
+    }
 }
 
 impl AsyncTool<PostgresHandler> for PinnedWriteQueryTool {
@@ -71,6 +79,14 @@ impl ToolBase for UnpinnedWriteQueryTool {
 
     fn annotations() -> Option<ToolAnnotations> {
         Some(annotations())
+    }
+
+    fn input_schema() -> Option<Arc<JsonObject>> {
+        Some(input_schema::<Self::Parameter>())
+    }
+
+    fn output_schema() -> Option<Arc<JsonObject>> {
+        Some(output_schema::<Self::Output>())
     }
 }
 

--- a/crates/postgres/src/types.rs
+++ b/crates/postgres/src/types.rs
@@ -18,7 +18,6 @@ pub use dbmcp_server::types::{
 
 /// Request for the `dropTable` tool.
 #[derive(Debug, Default, Deserialize, JsonSchema)]
-#[schemars(rename = "DropTableRequest")]
 pub struct PinnedDropTableRequest {
     /// Name of the table to drop. Must be non-empty.
     pub table: String,
@@ -29,7 +28,6 @@ pub struct PinnedDropTableRequest {
 
 /// Request for the `dropTable` tool.
 #[derive(Debug, Default, Deserialize, JsonSchema)]
-#[schemars(rename = "DropTableRequest")]
 pub struct UnpinnedDropTableRequest {
     #[serde(flatten)]
     pub inner: PinnedDropTableRequest,
@@ -40,7 +38,6 @@ pub struct UnpinnedDropTableRequest {
 
 /// Request for the Postgres `listTables` tool — extends the shared shape with `search` and `detailed`.
 #[derive(Debug, Default, Deserialize, JsonSchema)]
-#[schemars(rename = "ListTablesRequest")]
 pub struct PinnedListTablesRequest {
     /// Opaque cursor from a prior response's `nextCursor`; omit for the first page.
     #[serde(default)]
@@ -58,7 +55,6 @@ pub struct PinnedListTablesRequest {
 
 /// Request for the Postgres `listTables` tool — extends the shared shape with `search` and `detailed`.
 #[derive(Debug, Default, Deserialize, JsonSchema)]
-#[schemars(rename = "ListTablesRequest")]
 pub struct UnpinnedListTablesRequest {
     #[serde(flatten)]
     pub inner: PinnedListTablesRequest,
@@ -69,7 +65,6 @@ pub struct UnpinnedListTablesRequest {
 
 /// Request for the Postgres `listFunctions` tool — extends the shared shape with `search` and `detailed`.
 #[derive(Debug, Default, Deserialize, JsonSchema)]
-#[schemars(rename = "ListFunctionsRequest")]
 pub struct PinnedListFunctionsRequest {
     /// Opaque cursor from a prior response's `nextCursor`; omit for the first page.
     #[serde(default)]
@@ -88,7 +83,6 @@ pub struct PinnedListFunctionsRequest {
 
 /// Request for the Postgres `listFunctions` tool — extends the shared shape with `search` and `detailed`.
 #[derive(Debug, Default, Deserialize, JsonSchema)]
-#[schemars(rename = "ListFunctionsRequest")]
 pub struct UnpinnedListFunctionsRequest {
     #[serde(flatten)]
     pub inner: PinnedListFunctionsRequest,
@@ -99,7 +93,6 @@ pub struct UnpinnedListFunctionsRequest {
 
 /// Request for the Postgres `listViews` tool — extends the shared shape with `search` and `detailed`.
 #[derive(Debug, Default, Deserialize, JsonSchema)]
-#[schemars(rename = "ListViewsRequest")]
 pub struct PinnedListViewsRequest {
     /// Opaque cursor from a prior response's `nextCursor`; omit for the first page.
     #[serde(default)]
@@ -117,7 +110,6 @@ pub struct PinnedListViewsRequest {
 
 /// Request for the Postgres `listViews` tool — extends the shared shape with `search` and `detailed`.
 #[derive(Debug, Default, Deserialize, JsonSchema)]
-#[schemars(rename = "ListViewsRequest")]
 pub struct UnpinnedListViewsRequest {
     #[serde(flatten)]
     pub inner: PinnedListViewsRequest,
@@ -128,7 +120,6 @@ pub struct UnpinnedListViewsRequest {
 
 /// Request for the Postgres `listMaterializedViews` tool — extends the shared shape with `search` and `detailed`.
 #[derive(Debug, Default, Deserialize, JsonSchema)]
-#[schemars(rename = "ListMaterializedViewsRequest")]
 pub struct PinnedListMaterializedViewsRequest {
     /// Opaque cursor from a prior response's `nextCursor`; omit for the first page.
     #[serde(default)]
@@ -146,7 +137,6 @@ pub struct PinnedListMaterializedViewsRequest {
 
 /// Request for the Postgres `listMaterializedViews` tool — extends the shared shape with `search` and `detailed`.
 #[derive(Debug, Default, Deserialize, JsonSchema)]
-#[schemars(rename = "ListMaterializedViewsRequest")]
 pub struct UnpinnedListMaterializedViewsRequest {
     #[serde(flatten)]
     pub inner: PinnedListMaterializedViewsRequest,
@@ -188,7 +178,6 @@ impl ListMaterializedViewsResponse {
 
 /// Request for the Postgres `listProcedures` tool — extends the shared shape with `search` and `detailed`.
 #[derive(Debug, Default, Deserialize, JsonSchema)]
-#[schemars(rename = "ListProceduresRequest")]
 pub struct PinnedListProceduresRequest {
     /// Opaque cursor from a prior response's `nextCursor`; omit for the first page.
     #[serde(default)]
@@ -206,7 +195,6 @@ pub struct PinnedListProceduresRequest {
 
 /// Request for the Postgres `listProcedures` tool — extends the shared shape with `search` and `detailed`.
 #[derive(Debug, Default, Deserialize, JsonSchema)]
-#[schemars(rename = "ListProceduresRequest")]
 pub struct UnpinnedListProceduresRequest {
     #[serde(flatten)]
     pub inner: PinnedListProceduresRequest,

--- a/crates/server/src/lib.rs
+++ b/crates/server/src/lib.rs
@@ -1,14 +1,17 @@
 //! Shared MCP server utilities and request types.
 //!
 //! Provides [`types`] for tool request/response schemas,
-//! [`pagination`] cursor helpers, the [`tool`] registry, and the
-//! [`Server`] wrapper plus [`server_info`] used by per-backend servers.
+//! [`pagination`] cursor helpers, the [`tool`] registry, [`schema`] slim
+//! schema generators, and the [`Server`] wrapper plus [`server_info`] used
+//! by per-backend servers.
 
 pub mod pagination;
+pub mod schema;
 mod server;
 pub mod tool;
 pub mod types;
 
 pub use pagination::{Cursor, Pager};
+pub use schema::{input_schema, output_schema};
 pub use server::{Server, server_info};
 pub use tool::{ToolRouterExt, ToolSpec};

--- a/crates/server/src/lib.rs
+++ b/crates/server/src/lib.rs
@@ -1,9 +1,9 @@
 //! Shared MCP server utilities and request types.
 //!
 //! Provides [`types`] for tool request/response schemas,
-//! [`pagination`] cursor helpers, the [`tool`] registry, [`schema`] slim
-//! schema generators, and the [`Server`] wrapper plus [`server_info`] used
-//! by per-backend servers.
+//! [`pagination`] cursor helpers, the [`tool`] registry, [`schema`] input
+//! and output schema generators, and the [`Server`] wrapper plus
+//! [`server_info`] used by per-backend servers.
 
 pub mod pagination;
 pub mod schema;

--- a/crates/server/src/schema.rs
+++ b/crates/server/src/schema.rs
@@ -1,0 +1,209 @@
+//! Slim JSON-schema generators for MCP tool input and output schemas.
+//!
+//! These helpers replace the default [`rmcp::handler::server::router::tool::ToolBase`]
+//! schema generators with versions that strip the four metadata fields no MCP
+//! client consumes — root `$schema`, root `title`, root `description`, and the
+//! `$defs` / `$ref` indirection — while preserving every keyword the model and
+//! clients actually use. Each backend's `ToolBase` impls override
+//! [`input_schema`] / [`output_schema`] to call into this module so the slim
+//! shape is established at schema-generation time, not by post-processing the
+//! `tools/list` response.
+//!
+//! [`input_schema`]: rmcp::handler::server::router::tool::ToolBase::input_schema
+//! [`output_schema`]: rmcp::handler::server::router::tool::ToolBase::output_schema
+
+use std::any::{Any, TypeId, type_name};
+use std::collections::HashMap;
+use std::sync::{Arc, RwLock};
+
+use rmcp::model::JsonObject;
+use schemars::JsonSchema;
+use schemars::generate::SchemaSettings;
+use serde_json::Value;
+
+thread_local! {
+    static INPUT_SCHEMA_CACHE: RwLock<HashMap<TypeId, Arc<JsonObject>>> = RwLock::new(HashMap::new());
+    static OUTPUT_SCHEMA_CACHE: RwLock<HashMap<TypeId, Arc<JsonObject>>> = RwLock::new(HashMap::new());
+}
+
+/// Returns a slim JSON schema for the tool input parameter type `T`.
+///
+/// Strips root `$schema`, `title`, and `description`, and inlines every
+/// `$defs` / `$ref` indirection. Results are cached per [`TypeId`] in a
+/// thread-local map, so repeated calls for the same `T` return the same
+/// [`Arc`].
+///
+/// # Panics
+///
+/// Panics if `T`'s `JsonSchema` impl produces a non-object JSON value, which
+/// would indicate a broken derive.
+#[must_use]
+pub fn input_schema<T: JsonSchema + Any>() -> Arc<JsonObject> {
+    INPUT_SCHEMA_CACHE.with(|cache| {
+        if let Some(cached) = cache.read().expect("slim input cache poisoned").get(&TypeId::of::<T>()) {
+            return cached.clone();
+        }
+        let schema = Arc::new(build::<T>());
+        cache
+            .write()
+            .expect("slim input cache poisoned")
+            .insert(TypeId::of::<T>(), schema.clone());
+        schema
+    })
+}
+
+/// Returns a slim JSON schema for the tool output type `T`.
+///
+/// Same trimming as [`input_schema`], plus an MCP-spec invariant: the
+/// schema's root `type` must be `"object"`. Results are cached per [`TypeId`].
+///
+/// # Panics
+///
+/// Panics when `T`'s schema does not have `"type": "object"` at the root, or
+/// when `T`'s `JsonSchema` impl produces a non-object JSON value.
+#[must_use]
+pub fn output_schema<T: JsonSchema + Any>() -> Arc<JsonObject> {
+    OUTPUT_SCHEMA_CACHE.with(|cache| {
+        if let Some(cached) = cache
+            .read()
+            .expect("slim output cache poisoned")
+            .get(&TypeId::of::<T>())
+        {
+            return cached.clone();
+        }
+        let object = build::<T>();
+        match object.get("type") {
+            Some(Value::String(t)) if t == "object" => {}
+            other => panic!(
+                "Invalid output schema for type `{}`: root `type` must be \"object\", got {:?}",
+                type_name::<T>(),
+                other
+            ),
+        }
+        let schema = Arc::new(object);
+        cache
+            .write()
+            .expect("slim output cache poisoned")
+            .insert(TypeId::of::<T>(), schema.clone());
+        schema
+    })
+}
+
+/// Builds the slim JSON object for `T` via schemars draft-2020-12 with
+/// `inline_subschemas = true`, then removes the four root metadata keys.
+fn build<T: JsonSchema>() -> JsonObject {
+    let mut settings = SchemaSettings::draft2020_12();
+    settings.inline_subschemas = true;
+    let generator = settings.into_generator();
+    let schema = generator.into_root_schema_for::<T>();
+    let value = serde_json::to_value(schema).expect("schema serialises to JSON");
+    let Value::Object(mut object) = value else {
+        panic!("schema for `{}` did not produce a JSON object", type_name::<T>());
+    };
+    object.remove("$schema");
+    object.remove("title");
+    object.remove("description");
+    object
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{build, input_schema, output_schema};
+    use schemars::JsonSchema;
+    use serde::{Deserialize, Serialize};
+    use serde_json::Value;
+
+    /// Outer fixture struct whose schemars docs we expect to be stripped.
+    #[derive(Deserialize, Serialize, JsonSchema)]
+    #[schemars(title = "FixtureTitle", description = "Fixture root description.")]
+    struct Fixture {
+        /// Doc-comment kept on the property — must survive slimming.
+        name: String,
+        nested: Nested,
+    }
+
+    #[derive(Deserialize, Serialize, JsonSchema)]
+    struct Nested {
+        value: u32,
+    }
+
+    /// Distinct fixture to confirm the cache keys by type, not by name.
+    #[derive(Deserialize, Serialize, JsonSchema)]
+    struct OtherFixture {
+        value: u32,
+    }
+
+    fn contains_key(value: &Value, key: &str) -> bool {
+        match value {
+            Value::Object(map) => map.contains_key(key) || map.values().any(|v| contains_key(v, key)),
+            Value::Array(items) => items.iter().any(|v| contains_key(v, key)),
+            _ => false,
+        }
+    }
+
+    #[test]
+    fn slim_input_strips_dollar_schema_title_and_description() {
+        let schema = input_schema::<Fixture>();
+        assert!(!schema.contains_key("$schema"), "root $schema not stripped: {schema:?}");
+        assert!(!schema.contains_key("title"), "root title not stripped: {schema:?}");
+        assert!(
+            !schema.contains_key("description"),
+            "root description not stripped: {schema:?}"
+        );
+        assert_eq!(schema.get("type"), Some(&Value::String("object".into())));
+    }
+
+    #[test]
+    fn slim_inlines_nested_subschemas() {
+        let schema = input_schema::<Fixture>();
+        let value = Value::Object((*schema).clone());
+        assert!(!contains_key(&value, "$defs"), "$defs not inlined: {value}");
+        assert!(!contains_key(&value, "$ref"), "$ref not inlined: {value}");
+    }
+
+    #[test]
+    fn slim_input_caches_by_type() {
+        let first = input_schema::<Fixture>();
+        let second = input_schema::<Fixture>();
+        assert!(
+            std::sync::Arc::ptr_eq(&first, &second),
+            "same type should return cached Arc"
+        );
+        let other = input_schema::<OtherFixture>();
+        assert!(
+            !std::sync::Arc::ptr_eq(&first, &other),
+            "different types must not share cache entry"
+        );
+    }
+
+    #[test]
+    fn slim_output_accepts_object_root() {
+        let schema = output_schema::<Fixture>();
+        assert_eq!(schema.get("type"), Some(&Value::String("object".into())));
+        let again = output_schema::<Fixture>();
+        assert!(std::sync::Arc::ptr_eq(&schema, &again));
+    }
+
+    #[test]
+    #[should_panic(expected = "root `type` must be \"object\"")]
+    fn slim_output_panics_on_non_object_root() {
+        let _ = output_schema::<u32>();
+    }
+
+    #[test]
+    fn slim_preserves_properties() {
+        let schema = build::<Fixture>();
+        let properties = schema
+            .get("properties")
+            .and_then(Value::as_object)
+            .expect("properties survive slimming");
+        assert!(properties.contains_key("name"));
+        assert!(properties.contains_key("nested"));
+        let name = properties.get("name").and_then(Value::as_object).unwrap();
+        assert_eq!(
+            name.get("description").and_then(Value::as_str),
+            Some("Doc-comment kept on the property — must survive slimming."),
+            "per-property descriptions must survive slimming"
+        );
+    }
+}

--- a/crates/server/src/schema.rs
+++ b/crates/server/src/schema.rs
@@ -1,13 +1,13 @@
-//! Slim JSON-schema generators for MCP tool input and output schemas.
+//! JSON-schema generators for MCP tool input and output schemas.
 //!
 //! These helpers replace the default [`rmcp::handler::server::router::tool::ToolBase`]
 //! schema generators with versions that strip the four metadata fields no MCP
 //! client consumes — root `$schema`, root `title`, root `description`, and the
 //! `$defs` / `$ref` indirection — while preserving every keyword the model and
 //! clients actually use. Each backend's `ToolBase` impls override
-//! [`input_schema`] / [`output_schema`] to call into this module so the slim
-//! shape is established at schema-generation time, not by post-processing the
-//! `tools/list` response.
+//! [`input_schema`] / [`output_schema`] to call into this module so the input
+//! and output shapes are established at schema-generation time, not by
+//! post-processing the `tools/list` response.
 //!
 //! [`input_schema`]: rmcp::handler::server::router::tool::ToolBase::input_schema
 //! [`output_schema`]: rmcp::handler::server::router::tool::ToolBase::output_schema
@@ -18,7 +18,9 @@ use std::sync::{Arc, RwLock};
 
 use rmcp::model::JsonObject;
 use schemars::JsonSchema;
+use schemars::Schema;
 use schemars::generate::SchemaSettings;
+use schemars::transform::Transform;
 use serde_json::Value;
 
 thread_local! {
@@ -26,7 +28,7 @@ thread_local! {
     static OUTPUT_SCHEMA_CACHE: RwLock<HashMap<TypeId, Arc<JsonObject>>> = RwLock::new(HashMap::new());
 }
 
-/// Returns a slim JSON schema for the tool input parameter type `T`.
+/// Returns the input JSON schema for the tool parameter type `T`.
 ///
 /// Strips root `$schema`, `title`, and `description`, and inlines every
 /// `$defs` / `$ref` indirection. Results are cached per [`TypeId`] in a
@@ -40,22 +42,27 @@ thread_local! {
 #[must_use]
 pub fn input_schema<T: JsonSchema + Any>() -> Arc<JsonObject> {
     INPUT_SCHEMA_CACHE.with(|cache| {
-        if let Some(cached) = cache.read().expect("slim input cache poisoned").get(&TypeId::of::<T>()) {
+        if let Some(cached) = cache
+            .read()
+            .expect("input schema cache poisoned")
+            .get(&TypeId::of::<T>())
+        {
             return cached.clone();
         }
         let schema = Arc::new(build::<T>());
         cache
             .write()
-            .expect("slim input cache poisoned")
+            .expect("input schema cache poisoned")
             .insert(TypeId::of::<T>(), schema.clone());
         schema
     })
 }
 
-/// Returns a slim JSON schema for the tool output type `T`.
+/// Returns the output JSON schema for the tool result type `T`.
 ///
-/// Same trimming as [`input_schema`], plus an MCP-spec invariant: the
-/// schema's root `type` must be `"object"`. Results are cached per [`TypeId`].
+/// Same generation pipeline as [`input_schema`], plus an MCP-spec invariant:
+/// the schema's root `type` must be `"object"`. Results are cached per
+/// [`TypeId`].
 ///
 /// # Panics
 ///
@@ -66,7 +73,7 @@ pub fn output_schema<T: JsonSchema + Any>() -> Arc<JsonObject> {
     OUTPUT_SCHEMA_CACHE.with(|cache| {
         if let Some(cached) = cache
             .read()
-            .expect("slim output cache poisoned")
+            .expect("output schema cache poisoned")
             .get(&TypeId::of::<T>())
         {
             return cached.clone();
@@ -83,27 +90,41 @@ pub fn output_schema<T: JsonSchema + Any>() -> Arc<JsonObject> {
         let schema = Arc::new(object);
         cache
             .write()
-            .expect("slim output cache poisoned")
+            .expect("output schema cache poisoned")
             .insert(TypeId::of::<T>(), schema.clone());
         schema
     })
 }
 
-/// Builds the slim JSON object for `T` via schemars draft-2020-12 with
-/// `inline_subschemas = true`, then removes the four root metadata keys.
+/// Builds the JSON schema object for `T` via schemars draft-2020-12 with
+/// `inline_subschemas = true` and the [`StripRootMetadata`] transform that
+/// drops the root `$schema`, `title`, and `description` keys.
 fn build<T: JsonSchema>() -> JsonObject {
-    let mut settings = SchemaSettings::draft2020_12();
-    settings.inline_subschemas = true;
-    let generator = settings.into_generator();
-    let schema = generator.into_root_schema_for::<T>();
+    let schema = SchemaSettings::draft2020_12()
+        .with(|s| s.inline_subschemas = true)
+        .with_transform(StripRootMetadata)
+        .into_generator()
+        .into_root_schema_for::<T>();
+
     let value = serde_json::to_value(schema).expect("schema serialises to JSON");
-    let Value::Object(mut object) = value else {
+    let Value::Object(object) = value else {
         panic!("schema for `{}` did not produce a JSON object", type_name::<T>());
     };
-    object.remove("$schema");
-    object.remove("title");
-    object.remove("description");
     object
+}
+
+/// Schemars [`Transform`] that drops root-only metadata keys MCP clients ignore.
+#[derive(Clone)]
+struct StripRootMetadata;
+
+impl Transform for StripRootMetadata {
+    fn transform(&mut self, schema: &mut Schema) {
+        if let Some(object) = schema.as_object_mut() {
+            object.remove("$schema");
+            object.remove("title");
+            object.remove("description");
+        }
+    }
 }
 
 #[cfg(test)]
@@ -117,7 +138,7 @@ mod tests {
     #[derive(Deserialize, Serialize, JsonSchema)]
     #[schemars(title = "FixtureTitle", description = "Fixture root description.")]
     struct Fixture {
-        /// Doc-comment kept on the property — must survive slimming.
+        /// Doc-comment kept on the property — must survive schema generation.
         name: String,
         nested: Nested,
     }
@@ -142,7 +163,7 @@ mod tests {
     }
 
     #[test]
-    fn slim_input_strips_dollar_schema_title_and_description() {
+    fn input_schema_strips_dollar_schema_title_and_description() {
         let schema = input_schema::<Fixture>();
         assert!(!schema.contains_key("$schema"), "root $schema not stripped: {schema:?}");
         assert!(!schema.contains_key("title"), "root title not stripped: {schema:?}");
@@ -154,7 +175,7 @@ mod tests {
     }
 
     #[test]
-    fn slim_inlines_nested_subschemas() {
+    fn input_schema_inlines_nested_subschemas() {
         let schema = input_schema::<Fixture>();
         let value = Value::Object((*schema).clone());
         assert!(!contains_key(&value, "$defs"), "$defs not inlined: {value}");
@@ -162,7 +183,7 @@ mod tests {
     }
 
     #[test]
-    fn slim_input_caches_by_type() {
+    fn input_schema_caches_by_type() {
         let first = input_schema::<Fixture>();
         let second = input_schema::<Fixture>();
         assert!(
@@ -177,7 +198,7 @@ mod tests {
     }
 
     #[test]
-    fn slim_output_accepts_object_root() {
+    fn output_schema_accepts_object_root() {
         let schema = output_schema::<Fixture>();
         assert_eq!(schema.get("type"), Some(&Value::String("object".into())));
         let again = output_schema::<Fixture>();
@@ -186,24 +207,24 @@ mod tests {
 
     #[test]
     #[should_panic(expected = "root `type` must be \"object\"")]
-    fn slim_output_panics_on_non_object_root() {
+    fn output_schema_panics_on_non_object_root() {
         let _ = output_schema::<u32>();
     }
 
     #[test]
-    fn slim_preserves_properties() {
+    fn build_preserves_properties() {
         let schema = build::<Fixture>();
         let properties = schema
             .get("properties")
             .and_then(Value::as_object)
-            .expect("properties survive slimming");
+            .expect("properties survive generation");
         assert!(properties.contains_key("name"));
         assert!(properties.contains_key("nested"));
         let name = properties.get("name").and_then(Value::as_object).unwrap();
         assert_eq!(
             name.get("description").and_then(Value::as_str),
-            Some("Doc-comment kept on the property — must survive slimming."),
-            "per-property descriptions must survive slimming"
+            Some("Doc-comment kept on the property — must survive schema generation."),
+            "per-property descriptions must survive schema generation"
         );
     }
 }

--- a/crates/server/src/schema.rs
+++ b/crates/server/src/schema.rs
@@ -14,18 +14,16 @@
 
 use std::any::{Any, TypeId, type_name};
 use std::collections::HashMap;
-use std::sync::{Arc, RwLock};
+use std::sync::{Arc, Mutex};
 
 use rmcp::model::JsonObject;
 use schemars::JsonSchema;
 use schemars::Schema;
 use schemars::generate::SchemaSettings;
-use schemars::transform::Transform;
 use serde_json::Value;
 
 thread_local! {
-    static INPUT_SCHEMA_CACHE: RwLock<HashMap<TypeId, Arc<JsonObject>>> = RwLock::new(HashMap::new());
-    static OUTPUT_SCHEMA_CACHE: RwLock<HashMap<TypeId, Arc<JsonObject>>> = RwLock::new(HashMap::new());
+    static SCHEMA_CACHE: Mutex<HashMap<TypeId, Arc<JsonObject>>> = Mutex::new(HashMap::new());
 }
 
 /// Returns the input JSON schema for the tool parameter type `T`.
@@ -41,28 +39,20 @@ thread_local! {
 /// would indicate a broken derive.
 #[must_use]
 pub fn input_schema<T: JsonSchema + Any>() -> Arc<JsonObject> {
-    INPUT_SCHEMA_CACHE.with(|cache| {
-        if let Some(cached) = cache
-            .read()
-            .expect("input schema cache poisoned")
-            .get(&TypeId::of::<T>())
-        {
-            return cached.clone();
-        }
-        let schema = Arc::new(build::<T>());
+    SCHEMA_CACHE.with(|cache| {
         cache
-            .write()
-            .expect("input schema cache poisoned")
-            .insert(TypeId::of::<T>(), schema.clone());
-        schema
+            .lock()
+            .expect("schema cache poisoned")
+            .entry(TypeId::of::<T>())
+            .or_insert_with(|| Arc::new(build::<T>()))
+            .clone()
     })
 }
 
 /// Returns the output JSON schema for the tool result type `T`.
 ///
-/// Same generation pipeline as [`input_schema`], plus an MCP-spec invariant:
-/// the schema's root `type` must be `"object"`. Results are cached per
-/// [`TypeId`].
+/// Delegates to [`input_schema`] (same cache, same generation pipeline) and
+/// enforces the MCP-spec invariant that the schema's root `type` is `"object"`.
 ///
 /// # Panics
 ///
@@ -70,60 +60,52 @@ pub fn input_schema<T: JsonSchema + Any>() -> Arc<JsonObject> {
 /// when `T`'s `JsonSchema` impl produces a non-object JSON value.
 #[must_use]
 pub fn output_schema<T: JsonSchema + Any>() -> Arc<JsonObject> {
-    OUTPUT_SCHEMA_CACHE.with(|cache| {
-        if let Some(cached) = cache
-            .read()
-            .expect("output schema cache poisoned")
-            .get(&TypeId::of::<T>())
-        {
-            return cached.clone();
-        }
-        let object = build::<T>();
-        match object.get("type") {
-            Some(Value::String(t)) if t == "object" => {}
-            other => panic!(
-                "Invalid output schema for type `{}`: root `type` must be \"object\", got {:?}",
-                type_name::<T>(),
-                other
-            ),
-        }
-        let schema = Arc::new(object);
-        cache
-            .write()
-            .expect("output schema cache poisoned")
-            .insert(TypeId::of::<T>(), schema.clone());
-        schema
-    })
+    let schema = input_schema::<T>();
+    match schema.get("type") {
+        Some(Value::String(t)) if t == "object" => schema,
+        other => panic!(
+            "Invalid output schema for type `{}`: root `type` must be \"object\", got {:?}",
+            type_name::<T>(),
+            other,
+        ),
+    }
 }
 
-/// Builds the JSON schema object for `T` via schemars draft-2020-12 with
-/// `inline_subschemas = true` and the [`StripRootMetadata`] transform that
-/// drops the root `$schema`, `title`, and `description` keys.
+/// Builds the JSON schema object for `T` via schemars draft-2020-12.
+///
+/// Configures `inline_subschemas = true` to fold every `$defs` / `$ref` into
+/// the parent, `meta_schema = None` to suppress the root `$schema` key
+/// natively (schemars only inserts it when this is `Some`), and a root-only
+/// transform that strips the `title` and `description` schemars derives from
+/// the type's name and doc-comment.
 fn build<T: JsonSchema>() -> JsonObject {
-    let schema = SchemaSettings::draft2020_12()
-        .with(|s| s.inline_subschemas = true)
-        .with_transform(StripRootMetadata)
+    let value = SchemaSettings::draft2020_12()
+        .with(|s| {
+            s.inline_subschemas = true;
+            s.meta_schema = None;
+        })
+        .with_transform(strip_root_metadata)
         .into_generator()
-        .into_root_schema_for::<T>();
+        .into_root_schema_for::<T>()
+        .to_value();
 
-    let value = serde_json::to_value(schema).expect("schema serialises to JSON");
     let Value::Object(object) = value else {
         panic!("schema for `{}` did not produce a JSON object", type_name::<T>());
     };
     object
 }
 
-/// Schemars [`Transform`] that drops root-only metadata keys MCP clients ignore.
-#[derive(Clone)]
-struct StripRootMetadata;
-
-impl Transform for StripRootMetadata {
-    fn transform(&mut self, schema: &mut Schema) {
-        if let Some(object) = schema.as_object_mut() {
-            object.remove("$schema");
-            object.remove("title");
-            object.remove("description");
-        }
+/// Removes the root `title` and `description` keys MCP clients ignore.
+///
+/// Works as a schemars [`Transform`] via the
+/// `impl<F: FnMut(&mut Schema)> Transform for F` blanket. Root-only: the
+/// schemars generator calls each transform once on the root schema and never
+/// recurses into subschemas unless the transform itself calls
+/// [`transform_subschemas`][schemars::transform::transform_subschemas].
+fn strip_root_metadata(schema: &mut Schema) {
+    if let Some(object) = schema.as_object_mut() {
+        object.remove("title");
+        object.remove("description");
     }
 }
 

--- a/crates/server/src/types.rs
+++ b/crates/server/src/types.rs
@@ -129,7 +129,6 @@ pub struct DropDatabaseRequest {
 
 /// Request for the `listViews` tool.
 #[derive(Debug, Default, Deserialize, JsonSchema)]
-#[schemars(rename = "ListViewsRequest")]
 pub struct PinnedListViewsRequest {
     /// Opaque cursor from a prior response's `nextCursor`; omit for the first page.
     #[serde(default)]
@@ -138,7 +137,6 @@ pub struct PinnedListViewsRequest {
 
 /// Request for the `listViews` tool.
 #[derive(Debug, Default, Deserialize, JsonSchema)]
-#[schemars(rename = "ListViewsRequest")]
 pub struct UnpinnedListViewsRequest {
     #[serde(flatten)]
     pub inner: PinnedListViewsRequest,
@@ -179,7 +177,6 @@ impl ListViewsResponse {
 
 /// Request for the `listTriggers` tool.
 #[derive(Debug, Default, Deserialize, JsonSchema)]
-#[schemars(rename = "ListTriggersRequest")]
 pub struct PinnedListTriggersRequest {
     /// Opaque cursor from a prior response's `nextCursor`; omit for the first page.
     #[serde(default)]
@@ -197,7 +194,6 @@ pub struct PinnedListTriggersRequest {
 
 /// Request for the `listTriggers` tool.
 #[derive(Debug, Default, Deserialize, JsonSchema)]
-#[schemars(rename = "ListTriggersRequest")]
 pub struct UnpinnedListTriggersRequest {
     #[serde(flatten)]
     pub inner: PinnedListTriggersRequest,
@@ -238,7 +234,6 @@ impl ListTriggersResponse {
 
 /// Request for the `listFunctions` tool.
 #[derive(Debug, Default, Deserialize, JsonSchema)]
-#[schemars(rename = "ListFunctionsRequest")]
 pub struct PinnedListFunctionsRequest {
     /// Opaque cursor from a prior response's `nextCursor`; omit for the first page.
     #[serde(default)]
@@ -247,7 +242,6 @@ pub struct PinnedListFunctionsRequest {
 
 /// Request for the `listFunctions` tool.
 #[derive(Debug, Default, Deserialize, JsonSchema)]
-#[schemars(rename = "ListFunctionsRequest")]
 pub struct UnpinnedListFunctionsRequest {
     #[serde(flatten)]
     pub inner: PinnedListFunctionsRequest,
@@ -318,7 +312,6 @@ impl ListProceduresResponse {
 
 /// Request for the `writeQuery` tool.
 #[derive(Debug, Default, Deserialize, JsonSchema)]
-#[schemars(rename = "QueryRequest")]
 pub struct PinnedQueryRequest {
     /// The SQL query to execute.
     pub query: String,
@@ -326,7 +319,6 @@ pub struct PinnedQueryRequest {
 
 /// Request for the `writeQuery` tool.
 #[derive(Debug, Default, Deserialize, JsonSchema)]
-#[schemars(rename = "QueryRequest")]
 pub struct UnpinnedQueryRequest {
     #[serde(flatten)]
     pub inner: PinnedQueryRequest,
@@ -337,7 +329,6 @@ pub struct UnpinnedQueryRequest {
 
 /// Request for the `readQuery` tool.
 #[derive(Debug, Default, Deserialize, JsonSchema)]
-#[schemars(rename = "ReadQueryRequest")]
 pub struct PinnedReadQueryRequest {
     /// The SQL query to execute.
     pub query: String,
@@ -348,7 +339,6 @@ pub struct PinnedReadQueryRequest {
 
 /// Request for the `readQuery` tool.
 #[derive(Debug, Default, Deserialize, JsonSchema)]
-#[schemars(rename = "ReadQueryRequest")]
 pub struct UnpinnedReadQueryRequest {
     #[serde(flatten)]
     pub inner: PinnedReadQueryRequest,
@@ -378,7 +368,6 @@ pub struct ReadQueryResponse {
 
 /// Request for the `explainQuery` tool.
 #[derive(Debug, Default, Deserialize, JsonSchema)]
-#[schemars(rename = "ExplainQueryRequest")]
 pub struct PinnedExplainQueryRequest {
     /// The SQL query to explain.
     pub query: String,
@@ -389,7 +378,6 @@ pub struct PinnedExplainQueryRequest {
 
 /// Request for the `explainQuery` tool.
 #[derive(Debug, Default, Deserialize, JsonSchema)]
-#[schemars(rename = "ExplainQueryRequest")]
 pub struct UnpinnedExplainQueryRequest {
     #[serde(flatten)]
     pub inner: PinnedExplainQueryRequest,

--- a/crates/sqlite/src/tools/drop_table.rs
+++ b/crates/sqlite/src/tools/drop_table.rs
@@ -40,6 +40,14 @@ impl ToolBase for DropTableTool {
                 .open_world(false),
         )
     }
+
+    fn input_schema() -> Option<Arc<JsonObject>> {
+        Some(input_schema::<Self::Parameter>())
+    }
+
+    fn output_schema() -> Option<Arc<JsonObject>> {
+        Some(output_schema::<Self::Output>())
+    }
 }
 
 impl AsyncTool<SqliteHandler> for DropTableTool {

--- a/crates/sqlite/src/tools/explain_query.rs
+++ b/crates/sqlite/src/tools/explain_query.rs
@@ -39,6 +39,14 @@ impl ToolBase for ExplainQueryTool {
                 .open_world(true),
         )
     }
+
+    fn input_schema() -> Option<Arc<JsonObject>> {
+        Some(input_schema::<Self::Parameter>())
+    }
+
+    fn output_schema() -> Option<Arc<JsonObject>> {
+        Some(output_schema::<Self::Output>())
+    }
 }
 
 impl AsyncTool<SqliteHandler> for ExplainQueryTool {

--- a/crates/sqlite/src/tools/list_tables.rs
+++ b/crates/sqlite/src/tools/list_tables.rs
@@ -38,6 +38,14 @@ impl ToolBase for ListTablesTool {
                 .open_world(false),
         )
     }
+
+    fn input_schema() -> Option<Arc<JsonObject>> {
+        Some(input_schema::<Self::Parameter>())
+    }
+
+    fn output_schema() -> Option<Arc<JsonObject>> {
+        Some(output_schema::<Self::Output>())
+    }
 }
 
 impl AsyncTool<SqliteHandler> for ListTablesTool {

--- a/crates/sqlite/src/tools/list_triggers.rs
+++ b/crates/sqlite/src/tools/list_triggers.rs
@@ -39,6 +39,14 @@ impl ToolBase for ListTriggersTool {
                 .open_world(false),
         )
     }
+
+    fn input_schema() -> Option<Arc<JsonObject>> {
+        Some(input_schema::<Self::Parameter>())
+    }
+
+    fn output_schema() -> Option<Arc<JsonObject>> {
+        Some(output_schema::<Self::Output>())
+    }
 }
 
 impl AsyncTool<SqliteHandler> for ListTriggersTool {

--- a/crates/sqlite/src/tools/list_views.rs
+++ b/crates/sqlite/src/tools/list_views.rs
@@ -1,11 +1,7 @@
 //! MCP tool: `listViews`.
 
-use std::sync::Arc;
-
 use dbmcp_server::pagination::Pager;
 use dbmcp_server::types::ListViewsResponse;
-
-use rmcp::model::JsonObject;
 
 use super::prelude::*;
 use crate::types::ListViewsRequest;
@@ -36,6 +32,10 @@ impl ToolBase for ListViewsTool {
 
     fn input_schema() -> Option<Arc<JsonObject>> {
         None
+    }
+
+    fn output_schema() -> Option<Arc<JsonObject>> {
+        Some(output_schema::<Self::Output>())
     }
 
     fn annotations() -> Option<ToolAnnotations> {

--- a/crates/sqlite/src/tools/prelude.rs
+++ b/crates/sqlite/src/tools/prelude.rs
@@ -1,9 +1,11 @@
 //! Shared imports for the `SQLite` tool modules.
 
 pub(crate) use std::borrow::Cow;
+pub(crate) use std::sync::Arc;
 
+pub(crate) use dbmcp_server::{input_schema, output_schema};
 pub(crate) use dbmcp_sql::Connection as _;
 pub(crate) use rmcp::handler::server::router::tool::{AsyncTool, ToolBase};
-pub(crate) use rmcp::model::{ErrorData, ToolAnnotations};
+pub(crate) use rmcp::model::{ErrorData, JsonObject, ToolAnnotations};
 
 pub(crate) use crate::SqliteHandler;

--- a/crates/sqlite/src/tools/read_query.rs
+++ b/crates/sqlite/src/tools/read_query.rs
@@ -44,6 +44,14 @@ impl ToolBase for ReadQueryTool {
                 .open_world(true),
         )
     }
+
+    fn input_schema() -> Option<Arc<JsonObject>> {
+        Some(input_schema::<Self::Parameter>())
+    }
+
+    fn output_schema() -> Option<Arc<JsonObject>> {
+        Some(output_schema::<Self::Output>())
+    }
 }
 
 impl AsyncTool<SqliteHandler> for ReadQueryTool {

--- a/crates/sqlite/src/tools/write_query.rs
+++ b/crates/sqlite/src/tools/write_query.rs
@@ -39,6 +39,14 @@ impl ToolBase for WriteQueryTool {
                 .open_world(true),
         )
     }
+
+    fn input_schema() -> Option<Arc<JsonObject>> {
+        Some(input_schema::<Self::Parameter>())
+    }
+
+    fn output_schema() -> Option<Arc<JsonObject>> {
+        Some(output_schema::<Self::Output>())
+    }
 }
 
 impl AsyncTool<SqliteHandler> for WriteQueryTool {

--- a/tests/approval/snapshots/approval_mysql__list_tools_read_only_pinned.snap
+++ b/tests/approval/snapshots/approval_mysql__list_tools_read_only_pinned.snap
@@ -1,6 +1,5 @@
 ---
 source: tests/approval/mysql.rs
-assertion_line: 99
 expression: tools
 ---
 [
@@ -9,8 +8,6 @@ expression: tools
     "title": "Explain Query",
     "description": "Return the execution plan for a SQL query to diagnose performance. Use this tool instead of running EXPLAIN directly through readQuery — it provides structured output.\n\n<usecase>\nUse when:\n- A query runs slowly and you need to understand why\n- Investigating performance bottlenecks\n- Planning index creation to optimize queries\n- Analyzing join methods, table scan strategies, and sort operations\n</usecase>\n\n<when_not_to_use>\n- Running actual queries → use readQuery or writeQuery\n- Checking table structure → use listTables(detailed=true)\n</when_not_to_use>\n\n<examples>\n✓ \"Why is my SELECT on orders slow?\" → explainQuery(query=\"SELECT ...\")\n✓ \"Should I add an index?\" → explainQuery with analyze=true\n✗ \"Run this SELECT\" → use readQuery\n</examples>\n\n<safety>\nSet `analyze` to true for actual execution statistics (EXPLAIN ANALYZE).\nIMPORTANT: EXPLAIN ANALYZE actually executes the query! In read-only mode, only read-only statements are allowed with analyze.\nWhen analyze is false, returns EXPLAIN FORMAT=JSON output without executing.\n</safety>\n\n<what_it_returns>\nA JSON array of execution plan rows showing access methods, join types, row estimates, and costs.\n</what_it_returns>",
     "inputSchema": {
-      "$schema": "https://json-schema.org/draft/2020-12/schema",
-      "description": "Request for the `explainQuery` tool.",
       "properties": {
         "analyze": {
           "default": false,
@@ -25,12 +22,9 @@ expression: tools
       "required": [
         "query"
       ],
-      "title": "ExplainQueryRequest",
       "type": "object"
     },
     "outputSchema": {
-      "$schema": "https://json-schema.org/draft/2020-12/schema",
-      "description": "Response for the `writeQuery` and `explainQuery` tools.",
       "properties": {
         "rows": {
           "description": "Result rows, each a JSON object keyed by a column name.",
@@ -41,7 +35,6 @@ expression: tools
       "required": [
         "rows"
       ],
-      "title": "QueryResponse",
       "type": "object"
     },
     "annotations": {
@@ -56,8 +49,6 @@ expression: tools
     "title": "List Functions",
     "description": "List user-defined SQL functions, optionally filtered and/or with full metadata. Loadable UDFs (`mysql.func`) and stored procedures are excluded.\n\n<usecase>\nUse when:\n- Auditing stored functions across the database (brief mode, default).\n- Searching for a function by partial name (pass `search`).\n- Inspecting a function's language, signature, return type, determinism, SQL-data-access classification, security mode, definer, comment, session context, and full reconstructed `CREATE FUNCTION` text before reasoning about correctness or invocation safety (pass `detailed: true`). Detailed mode supersedes ad-hoc `readQuery` against `information_schema.ROUTINES` / `information_schema.PARAMETERS`.\n</usecase>\n\n<parameters>\n- `cursor` — Opaque pagination cursor; echo the prior response's `nextCursor`.\n- `search` — Case-insensitive filter on function names via `LIKE`. `%` matches any sequence; `_` matches a single character.\n- `detailed` — When `true`, returns full metadata objects keyed by function name instead of bare name strings. Default `false`.\n</parameters>\n\n<examples>\n✓ \"What functions are here?\" → listFunctions()\n✓ \"Find the order-total calculation\" → listFunctions(search=\"order\")\n✓ \"What does calc_order_total do?\" → listFunctions(search=\"calc_order_total\", detailed=true)\n✗ \"List stored procedures\" → use listProcedures instead\n✗ \"List loadable UDFs from mysql.func\" → not supported; only routines in information_schema.ROUTINES are returned\n</examples>\n\n<what_it_returns>\nBrief mode (default): a sorted JSON array of function-name strings, e.g. `[\"calc_order_subtotal\", \"calc_order_total\", \"double_it\"]`.\nDetailed mode: a JSON object keyed by bare function name (MySQL/MariaDB do not allow function overloading, so no signature suffix is needed); each value carries `schema`, `language` (typically `\"SQL\"`; MariaDB external-language functions report the external language name), `arguments` (comma-separated `name type` pairs from `information_schema.PARAMETERS`, empty string for zero-parameter functions), `returnType` (full `DTD_IDENTIFIER` including length/precision/unsigned/enum/set members), `deterministic` (boolean), `sqlDataAccess` (one of `CONTAINS_SQL`, `NO_SQL`, `READS_SQL_DATA`, `MODIFIES_SQL_DATA`), `security` (`INVOKER` or `DEFINER`), `definer` (`user@host`), `description` (the `COMMENT` text or `null` when no comment was set — the empty string MySQL stores is coerced to JSON `null`), `definition` (the canonical reconstructed `CREATE FUNCTION` text including `DEFINER=` in `` `user`@`host` `` form), `sqlMode`, `characterSetClient`, `collationConnection`, and `databaseCollation`. Versus the Postgres detailed payload: `volatility`, `parallelSafety`, and `strict` are intentionally absent (no MySQL/MariaDB analogues), `owner` is renamed to `definer` (more accurate for the MySQL `DEFINER` concept), keys are bare names rather than `name(arguments)` (no overloads possible), and the four session-context fields (`sqlMode`, `characterSetClient`, `collationConnection`, `databaseCollation`) are MySQL/MariaDB-only additions.\n</what_it_returns>\n\n<pagination>\nPaginated. Pass the prior response's `nextCursor` as `cursor` to fetch the next page. The `search` filter must stay the same across pages for cursor continuity.\n</pagination>\n",
     "inputSchema": {
-      "$schema": "https://json-schema.org/draft/2020-12/schema",
-      "description": "Request for the MySQL/MariaDB `listFunctions` tool — supports search + detailed mode.",
       "properties": {
         "cursor": {
           "default": null,
@@ -81,12 +72,11 @@ expression: tools
           ]
         }
       },
-      "title": "ListFunctionsRequest",
       "type": "object"
     },
     "outputSchema": {
-      "$defs": {
-        "ListEntries": {
+      "properties": {
+        "functions": {
           "anyOf": [
             {
               "description": "Brief mode: sorted array of bare entity-name strings.",
@@ -101,14 +91,6 @@ expression: tools
               "type": "object"
             }
           ],
-          "description": "Two-shape listing payload: bare names in brief mode, name-keyed metadata in detailed mode.\n\nShared by [`ListTablesResponse`] and [`ListTriggersResponse`]. Serialises untagged:\nbrief mode → JSON array of strings, detailed mode → JSON object whose keys are\nentity names and whose values are the per-entity metadata."
-        }
-      },
-      "$schema": "https://json-schema.org/draft/2020-12/schema",
-      "description": "Response for the `listFunctions` tool.",
-      "properties": {
-        "functions": {
-          "$ref": "#/$defs/ListEntries",
           "description": "Page of matching functions. Shape depends on the request's `detailed` flag."
         },
         "nextCursor": {
@@ -122,7 +104,6 @@ expression: tools
       "required": [
         "functions"
       ],
-      "title": "ListFunctionsResponse",
       "type": "object"
     },
     "annotations": {
@@ -137,8 +118,6 @@ expression: tools
     "title": "List Procedures",
     "description": "List user-defined stored procedures, optionally filtered and/or with full metadata. Stored functions and loadable UDFs (`mysql.func`) are excluded.\n\n<usecase>\nUse when:\n- Auditing stored procedures across the database (brief mode, default).\n- Searching for a procedure by partial name (pass `search`).\n- Inspecting a procedure's language, parameter list (with `IN`/`OUT`/`INOUT` modes), determinism, SQL-data-access classification, security mode, definer, comment, session context, and full reconstructed `CREATE PROCEDURE` text before reasoning about correctness or invocation safety (pass `detailed: true`). Detailed mode supersedes ad-hoc `readQuery` against `information_schema.ROUTINES` / `information_schema.PARAMETERS`.\n</usecase>\n\n<parameters>\n- `cursor` — Opaque pagination cursor; echo the prior response's `nextCursor`.\n- `search` — Case-insensitive filter on procedure names via `LIKE`. `%` matches any sequence; `_` matches a single character.\n- `detailed` — When `true`, returns full metadata objects keyed by procedure name instead of bare name strings. Default `false`.\n</parameters>\n\n<examples>\n✓ \"What procedures are here?\" → listProcedures()\n✓ \"Find the order archival routine\" → listProcedures(search=\"archive\")\n✓ \"What does archive_order do?\" → listProcedures(search=\"archive_order\", detailed=true)\n✗ \"List functions\" → use listFunctions instead\n✗ \"List loadable UDFs from mysql.func\" → not supported; only routines in information_schema.ROUTINES are returned\n</examples>\n\n<what_it_returns>\nBrief mode (default): a sorted JSON array of procedure-name strings, e.g. `[\"archive_order\", \"archive_order_history\", \"purge_order_archive\", \"touch_post\"]`.\nDetailed mode: a JSON object keyed by bare procedure name (MySQL/MariaDB do not allow procedure overloading, so no signature suffix is needed); each value carries `schema`, `language` (typically `\"SQL\"`; MariaDB external-language procedures report the external language name), `arguments` (comma-separated `MODE name type` triples from `information_schema.PARAMETERS` — `MODE` is one of `IN`, `OUT`, `INOUT`; empty string for zero-parameter procedures), `deterministic` (boolean), `sqlDataAccess` (one of `CONTAINS_SQL`, `NO_SQL`, `READS_SQL_DATA`, `MODIFIES_SQL_DATA`), `security` (`INVOKER` or `DEFINER`), `definer` (`user@host`), `description` (the `COMMENT` text or `null` when no comment was set — the empty string MySQL stores is coerced to JSON `null`), `definition` (the canonical reconstructed `CREATE PROCEDURE` text including `DEFINER=` in `` `user`@`host` `` form; no `RETURNS` clause — procedures have no return type), `sqlMode`, `characterSetClient`, `collationConnection`, and `databaseCollation`. Versus the Postgres `listProcedures` detailed payload: `volatility`, `parallelSafety`, `strict`, and `returnType` are intentionally absent (no MySQL/MariaDB analogues for the first three; procedures have no return type for the fourth — the Postgres-side payload also omits all four), `owner` is renamed to `definer` (more accurate for the MySQL `DEFINER` concept), keys are bare names rather than `name(arguments)` (no overloads possible), the four session-context fields (`sqlMode`, `characterSetClient`, `collationConnection`, `databaseCollation`) are MySQL/MariaDB-only additions, and `deterministic` plus `sqlDataAccess` are MySQL/MariaDB-only additions versus the Postgres `listProcedures` detailed payload (which omits both because Postgres procedures have no equivalent attributes).\n</what_it_returns>\n\n<pagination>\nPaginated. Pass the prior response's `nextCursor` as `cursor` to fetch the next page. The `search` filter must stay the same across pages for cursor continuity.\n</pagination>\n",
     "inputSchema": {
-      "$schema": "https://json-schema.org/draft/2020-12/schema",
-      "description": "Request for the MySQL/MariaDB `listProcedures` tool — supports search + detailed mode.",
       "properties": {
         "cursor": {
           "default": null,
@@ -162,12 +141,18 @@ expression: tools
           ]
         }
       },
-      "title": "ListProceduresRequest",
       "type": "object"
     },
     "outputSchema": {
-      "$defs": {
-        "ListEntries": {
+      "properties": {
+        "nextCursor": {
+          "description": "Opaque cursor pointing to the next page. Absent when this is the final page.",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "procedures": {
           "anyOf": [
             {
               "description": "Brief mode: sorted array of bare entity-name strings.",
@@ -182,28 +167,12 @@ expression: tools
               "type": "object"
             }
           ],
-          "description": "Two-shape listing payload: bare names in brief mode, name-keyed metadata in detailed mode.\n\nShared by [`ListTablesResponse`] and [`ListTriggersResponse`]. Serialises untagged:\nbrief mode → JSON array of strings, detailed mode → JSON object whose keys are\nentity names and whose values are the per-entity metadata."
-        }
-      },
-      "$schema": "https://json-schema.org/draft/2020-12/schema",
-      "description": "Response for the `listProcedures` tool.",
-      "properties": {
-        "nextCursor": {
-          "description": "Opaque cursor pointing to the next page. Absent when this is the final page.",
-          "type": [
-            "string",
-            "null"
-          ]
-        },
-        "procedures": {
-          "$ref": "#/$defs/ListEntries",
           "description": "Page of matching procedures. Shape depends on the request's `detailed` flag."
         }
       },
       "required": [
         "procedures"
       ],
-      "title": "ListProceduresResponse",
       "type": "object"
     },
     "annotations": {
@@ -218,8 +187,6 @@ expression: tools
     "title": "List Tables",
     "description": "List tables, optionally filtered and/or with full metadata.\n\n<usecase>\nUse when:\n- Exploring the database to find relevant tables (brief mode, default).\n- Searching for a table by partial name (pass `search`).\n- Inspecting a table's columns, constraints, indexes, and triggers before writing a query (pass `detailed: true`). This supersedes the legacy `getTableSchema` workflow.\n</usecase>\n\n<parameters>\n- `cursor` — Opaque pagination cursor; echo the prior response's `nextCursor`.\n- `search` — Case-insensitive filter on table names via `LIKE`. `%` matches any sequence; `_` matches a single character.\n- `detailed` — When `true`, returns full metadata objects keyed by table name instead of bare name strings. Default `false`.\n</parameters>\n\n<examples>\n✓ \"What tables are here?\" → listTables()\n✓ \"Find the orders table\" → listTables(search=\"order\")\n✓ \"What columns does orders have?\" → listTables(search=\"orders\", detailed=true)\n</examples>\n\n<what_it_returns>\nBrief mode (default): a sorted JSON array of table-name strings, e.g. `[\"customers\", \"orders\"]`.\nDetailed mode: a JSON object keyed by table name; each value carries `schema`, `kind`, `owner`, `comment`, `columns`, `constraints`, `indexes`, and `triggers` (the name is the key and is not repeated inside the value). Keys iterate in the same alphabetical order brief mode uses. Example: `{\"orders\": {\"schema\": \"mydb\", \"kind\": \"TABLE\", …}}`.\n</what_it_returns>\n\n<pagination>\nPaginated. Pass the prior response's `nextCursor` as `cursor` to fetch the next page. The `search` filter must stay the same across pages for cursor continuity.\n</pagination>\n",
     "inputSchema": {
-      "$schema": "https://json-schema.org/draft/2020-12/schema",
-      "description": "Request for the MySQL/MariaDB `listTables` tool — supports search + detailed mode.",
       "properties": {
         "cursor": {
           "default": null,
@@ -243,12 +210,18 @@ expression: tools
           ]
         }
       },
-      "title": "ListTablesRequest",
       "type": "object"
     },
     "outputSchema": {
-      "$defs": {
-        "ListEntries": {
+      "properties": {
+        "nextCursor": {
+          "description": "Opaque cursor pointing to the next page. Absent when this is the final page.",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "tables": {
           "anyOf": [
             {
               "description": "Brief mode: sorted array of bare entity-name strings.",
@@ -263,28 +236,12 @@ expression: tools
               "type": "object"
             }
           ],
-          "description": "Two-shape listing payload: bare names in brief mode, name-keyed metadata in detailed mode.\n\nShared by [`ListTablesResponse`] and [`ListTriggersResponse`]. Serialises untagged:\nbrief mode → JSON array of strings, detailed mode → JSON object whose keys are\nentity names and whose values are the per-entity metadata."
-        }
-      },
-      "$schema": "https://json-schema.org/draft/2020-12/schema",
-      "description": "Response for the `listTables` tool.",
-      "properties": {
-        "nextCursor": {
-          "description": "Opaque cursor pointing to the next page. Absent when this is the final page.",
-          "type": [
-            "string",
-            "null"
-          ]
-        },
-        "tables": {
-          "$ref": "#/$defs/ListEntries",
           "description": "Page of matching tables. Shape depends on the request's `detailed` flag."
         }
       },
       "required": [
         "tables"
       ],
-      "title": "ListTablesResponse",
       "type": "object"
     },
     "annotations": {
@@ -299,8 +256,6 @@ expression: tools
     "title": "List Triggers",
     "description": "List user-defined triggers, optionally filtered and/or with full metadata.\n\n<usecase>\nUse when:\n- Auditing trigger coverage across the database (brief mode, default).\n- Searching for a trigger by partial name (pass `search`).\n- Inspecting a trigger's timing, event, activation level, full `CREATE TRIGGER` text, and the session context active at trigger-creation time before reasoning about side-effects (pass `detailed: true`). Detailed mode supersedes ad-hoc `readQuery` against `information_schema.TRIGGERS`.\n</usecase>\n\n<parameters>\n- `cursor` — Opaque pagination cursor; echo the prior response's `nextCursor`.\n- `search` — Case-insensitive filter on trigger names via `LIKE`. `%` matches any sequence; `_` matches a single character.\n- `detailed` — When `true`, returns full metadata objects keyed by trigger name instead of bare name strings. Default `false`.\n</parameters>\n\n<examples>\n✓ \"What triggers are here?\" → listTriggers()\n✓ \"Find the audit triggers\" → listTriggers(search=\"audit\")\n✓ \"What does orders_audit_after_insert do?\" → listTriggers(search=\"orders_audit_after_insert\", detailed=true)\n✗ \"Show me a trigger's body\" → use detailed mode; the `definition` field carries the full `CREATE TRIGGER` text\n</examples>\n\n<what_it_returns>\nBrief mode (default): a sorted JSON array of trigger-name strings, e.g. `[\"customers_audit_after_insert\", \"orders_audit_after_insert\"]`.\nDetailed mode: a JSON object keyed by trigger name; each value carries `schema`, `table`, `timing` (BEFORE/AFTER), `events` (single-element array — `INSERT`, `UPDATE`, or `DELETE`), `activationLevel` (always `ROW` on MySQL/MariaDB), `definition` (the canonical `CREATE TRIGGER` text including `DEFINER=` in `` `user`@`host` `` form), `sqlMode`, `characterSetClient`, `collationConnection`, and `databaseCollation`. The Postgres-only `status` and `functionName` fields are intentionally absent (no per-trigger enabled/disabled flag and no separate handler-function reference on MySQL/MariaDB); the four session-context fields are MySQL/MariaDB-only additions versus the Postgres detailed payload.\n</what_it_returns>\n\n<pagination>\nPaginated. Pass the prior response's `nextCursor` as `cursor` to fetch the next page. The `search` filter must stay the same across pages for cursor continuity.\n</pagination>\n",
     "inputSchema": {
-      "$schema": "https://json-schema.org/draft/2020-12/schema",
-      "description": "Request for the `listTriggers` tool.",
       "properties": {
         "cursor": {
           "default": null,
@@ -324,12 +279,18 @@ expression: tools
           ]
         }
       },
-      "title": "ListTriggersRequest",
       "type": "object"
     },
     "outputSchema": {
-      "$defs": {
-        "ListEntries": {
+      "properties": {
+        "nextCursor": {
+          "description": "Opaque cursor pointing to the next page. Absent when this is the final page.",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "triggers": {
           "anyOf": [
             {
               "description": "Brief mode: sorted array of bare entity-name strings.",
@@ -344,28 +305,12 @@ expression: tools
               "type": "object"
             }
           ],
-          "description": "Two-shape listing payload: bare names in brief mode, name-keyed metadata in detailed mode.\n\nShared by [`ListTablesResponse`] and [`ListTriggersResponse`]. Serialises untagged:\nbrief mode → JSON array of strings, detailed mode → JSON object whose keys are\nentity names and whose values are the per-entity metadata."
-        }
-      },
-      "$schema": "https://json-schema.org/draft/2020-12/schema",
-      "description": "Response for the `listTriggers` tool.",
-      "properties": {
-        "nextCursor": {
-          "description": "Opaque cursor pointing to the next page. Absent when this is the final page.",
-          "type": [
-            "string",
-            "null"
-          ]
-        },
-        "triggers": {
-          "$ref": "#/$defs/ListEntries",
           "description": "Page of matching triggers. Shape depends on the request's `detailed` flag."
         }
       },
       "required": [
         "triggers"
       ],
-      "title": "ListTriggersResponse",
       "type": "object"
     },
     "annotations": {
@@ -380,8 +325,6 @@ expression: tools
     "title": "List Views",
     "description": "List user-defined views, optionally filtered and/or with full metadata. Base tables and system-schema views are excluded.\n\n<usecase>\nUse when:\n- Auditing views across the database (brief mode, default).\n- Searching for a view by partial name (pass `search`).\n- Inspecting a view's definer, security mode, check-option level, updatable flag, session character set/collation, and full SELECT body before querying it (pass `detailed: true`). Detailed mode supersedes ad-hoc `readQuery` against `information_schema.VIEWS`.\n</usecase>\n\n<parameters>\n- `cursor` — Opaque pagination cursor; echo the prior response's `nextCursor`.\n- `search` — Case-insensitive filter on view names via `LIKE`. `%` matches any sequence; `_` matches a single character.\n- `detailed` — When `true`, returns full metadata objects keyed by view name instead of bare name strings. Default `false`.\n</parameters>\n\n<examples>\n✓ \"What views are here?\" → listViews()\n✓ \"Find the active-users view\" → listViews(search=\"active\")\n✓ \"What does active_users select?\" → listViews(search=\"active_users\", detailed=true)\n✗ \"Show me the columns of a view\" → use listTables with `detailed: true` instead\n✗ \"List materialized views\" → MySQL/MariaDB have no materialized-view concept\n</examples>\n\n<what_it_returns>\nBrief mode (default): a sorted JSON array of view-name strings, e.g. `[\"active_orders\", \"active_users\", \"published_posts\"]`.\nDetailed mode: a JSON object keyed by bare view name; each value carries `schema`, `definer` (`user@host`), `security` (`INVOKER` or `DEFINER`), `checkOption` (`NONE`, `CASCADED`, or `LOCAL`), `updatable` (boolean), `characterSetClient`, `collationConnection`, and `definition` (the SELECT body verbatim from `information_schema.VIEWS.VIEW_DEFINITION`, with no `CREATE VIEW` wrapper). The view name is the map key only — it is not repeated inside the value.\n\nVersus the Postgres `listViews` detailed payload: `description` is intentionally absent (neither MySQL nor MariaDB exposes a user-comment column for views — `CREATE VIEW` syntax has no `COMMENT` clause), `algorithm` is intentionally absent (MariaDB-only column on `information_schema.VIEWS`), `owner` is renamed to `definer` (more accurate for the MySQL `DEFINER` concept), and the five MySQL/MariaDB-only structured fields (`security`, `checkOption`, `updatable`, `characterSetClient`, `collationConnection`) are added. The `definition` field shape is byte-identical to Postgres — raw SELECT body verbatim, no DDL wrapper. When the connected role lacks the `SHOW VIEW` privilege on a particular view, the engine redacts `VIEW_DEFINITION` to the empty string; the row remains in the response with `definition` reflecting that empty value.\n</what_it_returns>\n\n<pagination>\nPaginated. Pass the prior response's `nextCursor` as `cursor` to fetch the next page. The `search` filter must stay the same across pages for cursor continuity. Brief and detailed modes share the same `TABLE_NAME` row order, so a client can switch `detailed` between pages without losing position.\n</pagination>\n",
     "inputSchema": {
-      "$schema": "https://json-schema.org/draft/2020-12/schema",
-      "description": "Request for the MySQL/MariaDB `listViews` tool — supports search + detailed mode.",
       "properties": {
         "cursor": {
           "default": null,
@@ -405,12 +348,18 @@ expression: tools
           ]
         }
       },
-      "title": "ListViewsRequest",
       "type": "object"
     },
     "outputSchema": {
-      "$defs": {
-        "ListEntries": {
+      "properties": {
+        "nextCursor": {
+          "description": "Opaque cursor pointing to the next page. Absent when this is the final page.",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "views": {
           "anyOf": [
             {
               "description": "Brief mode: sorted array of bare entity-name strings.",
@@ -425,28 +374,12 @@ expression: tools
               "type": "object"
             }
           ],
-          "description": "Two-shape listing payload: bare names in brief mode, name-keyed metadata in detailed mode.\n\nShared by [`ListTablesResponse`] and [`ListTriggersResponse`]. Serialises untagged:\nbrief mode → JSON array of strings, detailed mode → JSON object whose keys are\nentity names and whose values are the per-entity metadata."
-        }
-      },
-      "$schema": "https://json-schema.org/draft/2020-12/schema",
-      "description": "Response for the `listViews` tool.",
-      "properties": {
-        "nextCursor": {
-          "description": "Opaque cursor pointing to the next page. Absent when this is the final page.",
-          "type": [
-            "string",
-            "null"
-          ]
-        },
-        "views": {
-          "$ref": "#/$defs/ListEntries",
           "description": "Page of matching views. Shape depends on the request's `detailed` flag."
         }
       },
       "required": [
         "views"
       ],
-      "title": "ListViewsResponse",
       "type": "object"
     },
     "annotations": {
@@ -461,8 +394,6 @@ expression: tools
     "title": "Read Query",
     "description": "Execute a read-only SQL query. Allowed statements: SELECT, SHOW, DESCRIBE, USE, EXPLAIN.\n\n<usecase>\nUse when:\n- Querying data from tables (SELECT with WHERE, JOIN, GROUP BY, etc.)\n- Aggregations: COUNT, SUM, AVG, GROUP BY, HAVING\n- Listing server variables or status (SHOW)\n- Viewing table structure (DESCRIBE)\n- Switching database context (USE)\n</usecase>\n\n<when_not_to_use>\n- Data changes (INSERT, UPDATE, DELETE) → use writeQuery\n- Query performance analysis → use explainQuery\n- Discovering tables or columns → use listTables (pass detailed=true for column-level metadata)\n</when_not_to_use>\n\n<examples>\n✓ \"SELECT * FROM users WHERE status = 'active'\"\n✓ \"SELECT COUNT(*) FROM orders GROUP BY region\"\n✓ \"SHOW TABLES\" or \"DESCRIBE users\"\n✗ \"INSERT INTO users ...\" → use writeQuery\n✗ \"EXPLAIN SELECT ...\" → use explainQuery for structured analysis\n</examples>\n\n<what_it_returns>\nA JSON array of row objects, each keyed by column name.\n</what_it_returns>\n\n<pagination>\n`SELECT` results are paginated. Pass the prior response's `nextCursor` as `cursor` to fetch the next page. `SHOW`, `DESCRIBE`, `USE`, and `EXPLAIN` return a single page and ignore `cursor`.\n</pagination>",
     "inputSchema": {
-      "$schema": "https://json-schema.org/draft/2020-12/schema",
-      "description": "Request for the `readQuery` tool.",
       "properties": {
         "cursor": {
           "default": null,
@@ -480,12 +411,9 @@ expression: tools
       "required": [
         "query"
       ],
-      "title": "ReadQueryRequest",
       "type": "object"
     },
     "outputSchema": {
-      "$schema": "https://json-schema.org/draft/2020-12/schema",
-      "description": "Response for the `readQuery` tool.",
       "properties": {
         "nextCursor": {
           "description": "Opaque cursor pointing to the next page. Absent when this is the final\npage, when the result fits in one page, or when the statement is a\nnon-`SELECT` kind that does not paginate (e.g. `SHOW`, `EXPLAIN`).",
@@ -503,7 +431,6 @@ expression: tools
       "required": [
         "rows"
       ],
-      "title": "ReadQueryResponse",
       "type": "object"
     },
     "annotations": {

--- a/tests/approval/snapshots/approval_mysql__list_tools_read_only_unpinned.snap
+++ b/tests/approval/snapshots/approval_mysql__list_tools_read_only_unpinned.snap
@@ -8,8 +8,6 @@ expression: tools
     "title": "Explain Query",
     "description": "Return the execution plan for a SQL query to diagnose performance. Use this tool instead of running EXPLAIN directly through readQuery — it provides structured output.\n\n<usecase>\nUse when:\n- A query runs slowly and you need to understand why\n- Investigating performance bottlenecks\n- Planning index creation to optimize queries\n- Analyzing join methods, table scan strategies, and sort operations\n</usecase>\n\n<when_not_to_use>\n- Running actual queries → use readQuery or writeQuery\n- Checking table structure → use listTables(detailed=true)\n</when_not_to_use>\n\n<examples>\n✓ \"Why is my SELECT on orders slow?\" → explainQuery(query=\"SELECT ...\")\n✓ \"Should I add an index?\" → explainQuery with analyze=true\n✗ \"Run this SELECT\" → use readQuery\n</examples>\n\n<safety>\nSet `analyze` to true for actual execution statistics (EXPLAIN ANALYZE).\nIMPORTANT: EXPLAIN ANALYZE actually executes the query! In read-only mode, only read-only statements are allowed with analyze.\nWhen analyze is false, returns EXPLAIN FORMAT=JSON output without executing.\n</safety>\n\n<what_it_returns>\nA JSON array of execution plan rows showing access methods, join types, row estimates, and costs.\n</what_it_returns>",
     "inputSchema": {
-      "$schema": "https://json-schema.org/draft/2020-12/schema",
-      "description": "Request for the `explainQuery` tool.",
       "properties": {
         "analyze": {
           "default": false,
@@ -32,12 +30,9 @@ expression: tools
       "required": [
         "query"
       ],
-      "title": "ExplainQueryRequest",
       "type": "object"
     },
     "outputSchema": {
-      "$schema": "https://json-schema.org/draft/2020-12/schema",
-      "description": "Response for the `writeQuery` and `explainQuery` tools.",
       "properties": {
         "rows": {
           "description": "Result rows, each a JSON object keyed by a column name.",
@@ -48,7 +43,6 @@ expression: tools
       "required": [
         "rows"
       ],
-      "title": "QueryResponse",
       "type": "object"
     },
     "annotations": {
@@ -63,8 +57,6 @@ expression: tools
     "title": "List Databases",
     "description": "List all accessible databases on the connected server. Use this tool to discover what databases are available before using other tools.\n\n<usecase>\nALWAYS call this tool FIRST when:\n- You need to explore what databases exist on the server\n- You need a database name for listTables or query tools\n- The user asks what data is available\n</usecase>\n\n<examples>\n✓ \"What databases are on this server?\"\n✓ \"Show me what's available\" → call listDatabases first\n</examples>\n\n<what_it_returns>\nA sorted JSON array of database name strings.\n</what_it_returns>\n\n<pagination>\nPaginated. Pass the prior response's `nextCursor` as `cursor` to fetch the next page.\n</pagination>",
     "inputSchema": {
-      "$schema": "https://json-schema.org/draft/2020-12/schema",
-      "description": "Request for the `listDatabases` tool.",
       "properties": {
         "cursor": {
           "default": null,
@@ -75,12 +67,9 @@ expression: tools
           ]
         }
       },
-      "title": "ListDatabasesRequest",
       "type": "object"
     },
     "outputSchema": {
-      "$schema": "https://json-schema.org/draft/2020-12/schema",
-      "description": "Response for the `listDatabases` tool.",
       "properties": {
         "databases": {
           "description": "Sorted list of database names for this page.",
@@ -100,7 +89,6 @@ expression: tools
       "required": [
         "databases"
       ],
-      "title": "ListDatabasesResponse",
       "type": "object"
     },
     "annotations": {
@@ -115,8 +103,6 @@ expression: tools
     "title": "List Functions",
     "description": "List user-defined SQL functions in a database, optionally filtered and/or with full metadata. Loadable UDFs (`mysql.func`) and stored procedures are excluded.\n\n<usecase>\nUse when:\n- Auditing stored functions across a database (brief mode, default).\n- Searching for a function by partial name (pass `search`).\n- Inspecting a function's language, signature, return type, determinism, SQL-data-access classification, security mode, definer, comment, session context, and full reconstructed `CREATE FUNCTION` text before reasoning about correctness or invocation safety (pass `detailed: true`). Detailed mode supersedes ad-hoc `readQuery` against `information_schema.ROUTINES` / `information_schema.PARAMETERS`.\n</usecase>\n\n<parameters>\n- `database` — Database to target. Defaults to the active database.\n- `cursor` — Opaque pagination cursor; echo the prior response's `nextCursor`.\n- `search` — Case-insensitive filter on function names via `LIKE`. `%` matches any sequence; `_` matches a single character.\n- `detailed` — When `true`, returns full metadata objects keyed by function name instead of bare name strings. Default `false`.\n</parameters>\n\n<examples>\n✓ \"What functions are in the mydb database?\" → listFunctions(database=\"mydb\")\n✓ \"Find the order-total calculation\" → listFunctions(search=\"order\")\n✓ \"What does calc_order_total do?\" → listFunctions(search=\"calc_order_total\", detailed=true)\n✗ \"List stored procedures\" → use listProcedures instead\n✗ \"List loadable UDFs from mysql.func\" → not supported; only routines in information_schema.ROUTINES are returned\n</examples>\n\n<what_it_returns>\nBrief mode (default): a sorted JSON array of function-name strings, e.g. `[\"calc_order_subtotal\", \"calc_order_total\", \"double_it\"]`.\nDetailed mode: a JSON object keyed by bare function name (MySQL/MariaDB do not allow function overloading, so no signature suffix is needed); each value carries `schema`, `language` (typically `\"SQL\"`; MariaDB external-language functions report the external language name), `arguments` (comma-separated `name type` pairs from `information_schema.PARAMETERS`, empty string for zero-parameter functions), `returnType` (full `DTD_IDENTIFIER` including length/precision/unsigned/enum/set members), `deterministic` (boolean), `sqlDataAccess` (one of `CONTAINS_SQL`, `NO_SQL`, `READS_SQL_DATA`, `MODIFIES_SQL_DATA`), `security` (`INVOKER` or `DEFINER`), `definer` (`user@host`), `description` (the `COMMENT` text or `null` when no comment was set — the empty string MySQL stores is coerced to JSON `null`), `definition` (the canonical reconstructed `CREATE FUNCTION` text including `DEFINER=` in `` `user`@`host` `` form), `sqlMode`, `characterSetClient`, `collationConnection`, and `databaseCollation`. Versus the Postgres detailed payload: `volatility`, `parallelSafety`, and `strict` are intentionally absent (no MySQL/MariaDB analogues), `owner` is renamed to `definer` (more accurate for the MySQL `DEFINER` concept), keys are bare names rather than `name(arguments)` (no overloads possible), and the four session-context fields (`sqlMode`, `characterSetClient`, `collationConnection`, `databaseCollation`) are MySQL/MariaDB-only additions.\n</what_it_returns>\n\n<pagination>\nPaginated. Pass the prior response's `nextCursor` as `cursor` to fetch the next page. The `search` filter must stay the same across pages for cursor continuity.\n</pagination>",
     "inputSchema": {
-      "$schema": "https://json-schema.org/draft/2020-12/schema",
-      "description": "Request for the MySQL/MariaDB `listFunctions` tool — supports search + detailed mode.",
       "properties": {
         "cursor": {
           "default": null,
@@ -148,12 +134,11 @@ expression: tools
           ]
         }
       },
-      "title": "ListFunctionsRequest",
       "type": "object"
     },
     "outputSchema": {
-      "$defs": {
-        "ListEntries": {
+      "properties": {
+        "functions": {
           "anyOf": [
             {
               "description": "Brief mode: sorted array of bare entity-name strings.",
@@ -168,14 +153,6 @@ expression: tools
               "type": "object"
             }
           ],
-          "description": "Two-shape listing payload: bare names in brief mode, name-keyed metadata in detailed mode.\n\nShared by [`ListTablesResponse`] and [`ListTriggersResponse`]. Serialises untagged:\nbrief mode → JSON array of strings, detailed mode → JSON object whose keys are\nentity names and whose values are the per-entity metadata."
-        }
-      },
-      "$schema": "https://json-schema.org/draft/2020-12/schema",
-      "description": "Response for the `listFunctions` tool.",
-      "properties": {
-        "functions": {
-          "$ref": "#/$defs/ListEntries",
           "description": "Page of matching functions. Shape depends on the request's `detailed` flag."
         },
         "nextCursor": {
@@ -189,7 +166,6 @@ expression: tools
       "required": [
         "functions"
       ],
-      "title": "ListFunctionsResponse",
       "type": "object"
     },
     "annotations": {
@@ -204,8 +180,6 @@ expression: tools
     "title": "List Procedures",
     "description": "List user-defined stored procedures in a database, optionally filtered and/or with full metadata. Stored functions and loadable UDFs (`mysql.func`) are excluded.\n\n<usecase>\nUse when:\n- Auditing stored procedures across a database (brief mode, default).\n- Searching for a procedure by partial name (pass `search`).\n- Inspecting a procedure's language, parameter list (with `IN`/`OUT`/`INOUT` modes), determinism, SQL-data-access classification, security mode, definer, comment, session context, and full reconstructed `CREATE PROCEDURE` text before reasoning about correctness or invocation safety (pass `detailed: true`). Detailed mode supersedes ad-hoc `readQuery` against `information_schema.ROUTINES` / `information_schema.PARAMETERS`.\n</usecase>\n\n<parameters>\n- `database` — Database to target. Defaults to the active database.\n- `cursor` — Opaque pagination cursor; echo the prior response's `nextCursor`.\n- `search` — Case-insensitive filter on procedure names via `LIKE`. `%` matches any sequence; `_` matches a single character.\n- `detailed` — When `true`, returns full metadata objects keyed by procedure name instead of bare name strings. Default `false`.\n</parameters>\n\n<examples>\n✓ \"What procedures are in the mydb database?\" → listProcedures(database=\"mydb\")\n✓ \"Find the order archival routine\" → listProcedures(search=\"archive\")\n✓ \"What does archive_order do?\" → listProcedures(search=\"archive_order\", detailed=true)\n✗ \"List functions\" → use listFunctions instead\n✗ \"List loadable UDFs from mysql.func\" → not supported; only routines in information_schema.ROUTINES are returned\n</examples>\n\n<what_it_returns>\nBrief mode (default): a sorted JSON array of procedure-name strings, e.g. `[\"archive_order\", \"archive_order_history\", \"purge_order_archive\", \"touch_post\"]`.\nDetailed mode: a JSON object keyed by bare procedure name (MySQL/MariaDB do not allow procedure overloading, so no signature suffix is needed); each value carries `schema`, `language` (typically `\"SQL\"`; MariaDB external-language procedures report the external language name), `arguments` (comma-separated `MODE name type` triples from `information_schema.PARAMETERS` — `MODE` is one of `IN`, `OUT`, `INOUT`; empty string for zero-parameter procedures), `deterministic` (boolean), `sqlDataAccess` (one of `CONTAINS_SQL`, `NO_SQL`, `READS_SQL_DATA`, `MODIFIES_SQL_DATA`), `security` (`INVOKER` or `DEFINER`), `definer` (`user@host`), `description` (the `COMMENT` text or `null` when no comment was set — the empty string MySQL stores is coerced to JSON `null`), `definition` (the canonical reconstructed `CREATE PROCEDURE` text including `DEFINER=` in `` `user`@`host` `` form; no `RETURNS` clause — procedures have no return type), `sqlMode`, `characterSetClient`, `collationConnection`, and `databaseCollation`. Versus the Postgres `listProcedures` detailed payload: `volatility`, `parallelSafety`, `strict`, and `returnType` are intentionally absent (no MySQL/MariaDB analogues for the first three; procedures have no return type for the fourth — the Postgres-side payload also omits all four), `owner` is renamed to `definer` (more accurate for the MySQL `DEFINER` concept), keys are bare names rather than `name(arguments)` (no overloads possible), the four session-context fields (`sqlMode`, `characterSetClient`, `collationConnection`, `databaseCollation`) are MySQL/MariaDB-only additions, and `deterministic` plus `sqlDataAccess` are MySQL/MariaDB-only additions versus the Postgres `listProcedures` detailed payload (which omits both because Postgres procedures have no equivalent attributes).\n</what_it_returns>\n\n<pagination>\nPaginated. Pass the prior response's `nextCursor` as `cursor` to fetch the next page. The `search` filter must stay the same across pages for cursor continuity.\n</pagination>",
     "inputSchema": {
-      "$schema": "https://json-schema.org/draft/2020-12/schema",
-      "description": "Request for the MySQL/MariaDB `listProcedures` tool — supports search + detailed mode.",
       "properties": {
         "cursor": {
           "default": null,
@@ -237,12 +211,18 @@ expression: tools
           ]
         }
       },
-      "title": "ListProceduresRequest",
       "type": "object"
     },
     "outputSchema": {
-      "$defs": {
-        "ListEntries": {
+      "properties": {
+        "nextCursor": {
+          "description": "Opaque cursor pointing to the next page. Absent when this is the final page.",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "procedures": {
           "anyOf": [
             {
               "description": "Brief mode: sorted array of bare entity-name strings.",
@@ -257,28 +237,12 @@ expression: tools
               "type": "object"
             }
           ],
-          "description": "Two-shape listing payload: bare names in brief mode, name-keyed metadata in detailed mode.\n\nShared by [`ListTablesResponse`] and [`ListTriggersResponse`]. Serialises untagged:\nbrief mode → JSON array of strings, detailed mode → JSON object whose keys are\nentity names and whose values are the per-entity metadata."
-        }
-      },
-      "$schema": "https://json-schema.org/draft/2020-12/schema",
-      "description": "Response for the `listProcedures` tool.",
-      "properties": {
-        "nextCursor": {
-          "description": "Opaque cursor pointing to the next page. Absent when this is the final page.",
-          "type": [
-            "string",
-            "null"
-          ]
-        },
-        "procedures": {
-          "$ref": "#/$defs/ListEntries",
           "description": "Page of matching procedures. Shape depends on the request's `detailed` flag."
         }
       },
       "required": [
         "procedures"
       ],
-      "title": "ListProceduresResponse",
       "type": "object"
     },
     "annotations": {
@@ -293,8 +257,6 @@ expression: tools
     "title": "List Tables",
     "description": "List tables in a database, optionally filtered and/or with full metadata.\n\n<usecase>\nUse when:\n- Exploring a database to find relevant tables (brief mode, default).\n- Searching for a table by partial name (pass `search`).\n- Inspecting a table's columns, constraints, indexes, and triggers before writing a query (pass `detailed: true`). This supersedes the legacy `getTableSchema` tool.\n</usecase>\n\n<parameters>\n- `database` — Database to target. Defaults to the active database.\n- `cursor` — Opaque pagination cursor; echo the prior response's `nextCursor`.\n- `search` — Case-insensitive filter on table names via `LIKE`. `%` matches any sequence; `_` matches a single character.\n- `detailed` — When `true`, returns full metadata objects keyed by table name instead of bare name strings. Default `false`.\n</parameters>\n\n<examples>\n✓ \"What tables are in mydb?\" → listTables(database=\"mydb\")\n✓ \"Find the orders table\" → listTables(search=\"order\")\n✓ \"What columns does orders have?\" → listTables(search=\"orders\", detailed=true)\n</examples>\n\n<what_it_returns>\nBrief mode (default): a sorted JSON array of table-name strings, e.g. `[\"customers\", \"orders\"]`.\nDetailed mode: a JSON object keyed by table name; each value carries `schema`, `kind`, `owner`, `comment`, `columns`, `constraints`, `indexes`, and `triggers` (the name is the key and is not repeated inside the value). Keys iterate in the same alphabetical order brief mode uses. Example: `{\"orders\": {\"schema\": \"mydb\", \"kind\": \"TABLE\", …}}`.\n</what_it_returns>\n\n<pagination>\nPaginated. Pass the prior response's `nextCursor` as `cursor` to fetch the next page. The `search` filter must stay the same across pages for cursor continuity.\n</pagination>",
     "inputSchema": {
-      "$schema": "https://json-schema.org/draft/2020-12/schema",
-      "description": "Request for the MySQL/MariaDB `listTables` tool — supports search + detailed mode.",
       "properties": {
         "cursor": {
           "default": null,
@@ -326,12 +288,18 @@ expression: tools
           ]
         }
       },
-      "title": "ListTablesRequest",
       "type": "object"
     },
     "outputSchema": {
-      "$defs": {
-        "ListEntries": {
+      "properties": {
+        "nextCursor": {
+          "description": "Opaque cursor pointing to the next page. Absent when this is the final page.",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "tables": {
           "anyOf": [
             {
               "description": "Brief mode: sorted array of bare entity-name strings.",
@@ -346,28 +314,12 @@ expression: tools
               "type": "object"
             }
           ],
-          "description": "Two-shape listing payload: bare names in brief mode, name-keyed metadata in detailed mode.\n\nShared by [`ListTablesResponse`] and [`ListTriggersResponse`]. Serialises untagged:\nbrief mode → JSON array of strings, detailed mode → JSON object whose keys are\nentity names and whose values are the per-entity metadata."
-        }
-      },
-      "$schema": "https://json-schema.org/draft/2020-12/schema",
-      "description": "Response for the `listTables` tool.",
-      "properties": {
-        "nextCursor": {
-          "description": "Opaque cursor pointing to the next page. Absent when this is the final page.",
-          "type": [
-            "string",
-            "null"
-          ]
-        },
-        "tables": {
-          "$ref": "#/$defs/ListEntries",
           "description": "Page of matching tables. Shape depends on the request's `detailed` flag."
         }
       },
       "required": [
         "tables"
       ],
-      "title": "ListTablesResponse",
       "type": "object"
     },
     "annotations": {
@@ -382,8 +334,6 @@ expression: tools
     "title": "List Triggers",
     "description": "List user-defined triggers in a database, optionally filtered and/or with full metadata.\n\n<usecase>\nUse when:\n- Auditing trigger coverage across a database (brief mode, default).\n- Searching for a trigger by partial name (pass `search`).\n- Inspecting a trigger's timing, event, activation level, full `CREATE TRIGGER` text, and the session context active at trigger-creation time before reasoning about side-effects (pass `detailed: true`). Detailed mode supersedes ad-hoc `readQuery` against `information_schema.TRIGGERS`.\n</usecase>\n\n<parameters>\n- `database` — Database to target. Defaults to the active database.\n- `cursor` — Opaque pagination cursor; echo the prior response's `nextCursor`.\n- `search` — Case-insensitive filter on trigger names via `LIKE`. `%` matches any sequence; `_` matches a single character.\n- `detailed` — When `true`, returns full metadata objects keyed by trigger name instead of bare name strings. Default `false`.\n</parameters>\n\n<examples>\n✓ \"What triggers are in the mydb database?\" → listTriggers(database=\"mydb\")\n✓ \"Find the audit triggers\" → listTriggers(search=\"audit\")\n✓ \"What does orders_audit_after_insert do?\" → listTriggers(search=\"orders_audit_after_insert\", detailed=true)\n✗ \"Show me a trigger's body\" → use detailed mode; the `definition` field carries the full `CREATE TRIGGER` text\n</examples>\n\n<what_it_returns>\nBrief mode (default): a sorted JSON array of trigger-name strings, e.g. `[\"customers_audit_after_insert\", \"orders_audit_after_insert\"]`.\nDetailed mode: a JSON object keyed by trigger name; each value carries `schema`, `table`, `timing` (BEFORE/AFTER), `events` (single-element array — `INSERT`, `UPDATE`, or `DELETE`), `activationLevel` (always `ROW` on MySQL/MariaDB), `definition` (the canonical `CREATE TRIGGER` text including `DEFINER=` in `` `user`@`host` `` form), `sqlMode`, `characterSetClient`, `collationConnection`, and `databaseCollation`. The Postgres-only `status` and `functionName` fields are intentionally absent (no per-trigger enabled/disabled flag and no separate handler-function reference on MySQL/MariaDB); the four session-context fields are MySQL/MariaDB-only additions versus the Postgres detailed payload.\n</what_it_returns>\n\n<pagination>\nPaginated. Pass the prior response's `nextCursor` as `cursor` to fetch the next page. The `search` filter must stay the same across pages for cursor continuity.\n</pagination>",
     "inputSchema": {
-      "$schema": "https://json-schema.org/draft/2020-12/schema",
-      "description": "Request for the `listTriggers` tool.",
       "properties": {
         "cursor": {
           "default": null,
@@ -415,12 +365,18 @@ expression: tools
           ]
         }
       },
-      "title": "ListTriggersRequest",
       "type": "object"
     },
     "outputSchema": {
-      "$defs": {
-        "ListEntries": {
+      "properties": {
+        "nextCursor": {
+          "description": "Opaque cursor pointing to the next page. Absent when this is the final page.",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "triggers": {
           "anyOf": [
             {
               "description": "Brief mode: sorted array of bare entity-name strings.",
@@ -435,28 +391,12 @@ expression: tools
               "type": "object"
             }
           ],
-          "description": "Two-shape listing payload: bare names in brief mode, name-keyed metadata in detailed mode.\n\nShared by [`ListTablesResponse`] and [`ListTriggersResponse`]. Serialises untagged:\nbrief mode → JSON array of strings, detailed mode → JSON object whose keys are\nentity names and whose values are the per-entity metadata."
-        }
-      },
-      "$schema": "https://json-schema.org/draft/2020-12/schema",
-      "description": "Response for the `listTriggers` tool.",
-      "properties": {
-        "nextCursor": {
-          "description": "Opaque cursor pointing to the next page. Absent when this is the final page.",
-          "type": [
-            "string",
-            "null"
-          ]
-        },
-        "triggers": {
-          "$ref": "#/$defs/ListEntries",
           "description": "Page of matching triggers. Shape depends on the request's `detailed` flag."
         }
       },
       "required": [
         "triggers"
       ],
-      "title": "ListTriggersResponse",
       "type": "object"
     },
     "annotations": {
@@ -471,8 +411,6 @@ expression: tools
     "title": "List Views",
     "description": "List user-defined views in a database, optionally filtered and/or with full metadata. Base tables and system-schema views are excluded.\n\n<usecase>\nUse when:\n- Auditing views across a database (brief mode, default).\n- Searching for a view by partial name (pass `search`).\n- Inspecting a view's definer, security mode, check-option level, updatable flag, session character set/collation, and full SELECT body before querying it (pass `detailed: true`). Detailed mode supersedes ad-hoc `readQuery` against `information_schema.VIEWS`.\n</usecase>\n\n<parameters>\n- `database` — Database to target. Defaults to the active database.\n- `cursor` — Opaque pagination cursor; echo the prior response's `nextCursor`.\n- `search` — Case-insensitive filter on view names via `LIKE`. `%` matches any sequence; `_` matches a single character.\n- `detailed` — When `true`, returns full metadata objects keyed by view name instead of bare name strings. Default `false`.\n</parameters>\n\n<examples>\n✓ \"What views are in the mydb database?\" → listViews(database=\"mydb\")\n✓ \"Find the active-users view\" → listViews(search=\"active\")\n✓ \"What does active_users select?\" → listViews(search=\"active_users\", detailed=true)\n✗ \"Show me the columns of a view\" → use listTables with `detailed: true` instead\n✗ \"List materialized views\" → MySQL/MariaDB have no materialized-view concept\n</examples>\n\n<what_it_returns>\nBrief mode (default): a sorted JSON array of view-name strings, e.g. `[\"active_orders\", \"active_users\", \"published_posts\"]`.\nDetailed mode: a JSON object keyed by bare view name; each value carries `schema`, `definer` (`user@host`), `security` (`INVOKER` or `DEFINER`), `checkOption` (`NONE`, `CASCADED`, or `LOCAL`), `updatable` (boolean), `characterSetClient`, `collationConnection`, and `definition` (the SELECT body verbatim from `information_schema.VIEWS.VIEW_DEFINITION`, with no `CREATE VIEW` wrapper). The view name is the map key only — it is not repeated inside the value.\n\nVersus the Postgres `listViews` detailed payload: `description` is intentionally absent (neither MySQL nor MariaDB exposes a user-comment column for views — `CREATE VIEW` syntax has no `COMMENT` clause), `algorithm` is intentionally absent (MariaDB-only column on `information_schema.VIEWS`), `owner` is renamed to `definer` (more accurate for the MySQL `DEFINER` concept), and the five MySQL/MariaDB-only structured fields (`security`, `checkOption`, `updatable`, `characterSetClient`, `collationConnection`) are added. The `definition` field shape is byte-identical to Postgres — raw SELECT body verbatim, no DDL wrapper. When the connected role lacks the `SHOW VIEW` privilege on a particular view, the engine redacts `VIEW_DEFINITION` to the empty string; the row remains in the response with `definition` reflecting that empty value.\n</what_it_returns>\n\n<pagination>\nPaginated. Pass the prior response's `nextCursor` as `cursor` to fetch the next page. The `search` filter must stay the same across pages for cursor continuity. Brief and detailed modes share the same `TABLE_NAME` row order, so a client can switch `detailed` between pages without losing position.\n</pagination>",
     "inputSchema": {
-      "$schema": "https://json-schema.org/draft/2020-12/schema",
-      "description": "Request for the MySQL/MariaDB `listViews` tool — supports search + detailed mode.",
       "properties": {
         "cursor": {
           "default": null,
@@ -504,12 +442,18 @@ expression: tools
           ]
         }
       },
-      "title": "ListViewsRequest",
       "type": "object"
     },
     "outputSchema": {
-      "$defs": {
-        "ListEntries": {
+      "properties": {
+        "nextCursor": {
+          "description": "Opaque cursor pointing to the next page. Absent when this is the final page.",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "views": {
           "anyOf": [
             {
               "description": "Brief mode: sorted array of bare entity-name strings.",
@@ -524,28 +468,12 @@ expression: tools
               "type": "object"
             }
           ],
-          "description": "Two-shape listing payload: bare names in brief mode, name-keyed metadata in detailed mode.\n\nShared by [`ListTablesResponse`] and [`ListTriggersResponse`]. Serialises untagged:\nbrief mode → JSON array of strings, detailed mode → JSON object whose keys are\nentity names and whose values are the per-entity metadata."
-        }
-      },
-      "$schema": "https://json-schema.org/draft/2020-12/schema",
-      "description": "Response for the `listViews` tool.",
-      "properties": {
-        "nextCursor": {
-          "description": "Opaque cursor pointing to the next page. Absent when this is the final page.",
-          "type": [
-            "string",
-            "null"
-          ]
-        },
-        "views": {
-          "$ref": "#/$defs/ListEntries",
           "description": "Page of matching views. Shape depends on the request's `detailed` flag."
         }
       },
       "required": [
         "views"
       ],
-      "title": "ListViewsResponse",
       "type": "object"
     },
     "annotations": {
@@ -560,8 +488,6 @@ expression: tools
     "title": "Read Query",
     "description": "Execute a read-only SQL query. Allowed statements: SELECT, SHOW, DESCRIBE, USE, EXPLAIN.\n\n<usecase>\nUse when:\n- Querying data from tables (SELECT with WHERE, JOIN, GROUP BY, etc.)\n- Aggregations: COUNT, SUM, AVG, GROUP BY, HAVING\n- Listing server variables or status (SHOW)\n- Viewing table structure (DESCRIBE)\n- Switching database context (USE)\n</usecase>\n\n<when_not_to_use>\n- Data changes (INSERT, UPDATE, DELETE) → use writeQuery\n- Query performance analysis → use explainQuery\n- Discovering tables or columns → use listTables (pass detailed=true for column-level metadata)\n</when_not_to_use>\n\n<examples>\n✓ \"SELECT * FROM users WHERE status = 'active'\"\n✓ \"SELECT COUNT(*) FROM orders GROUP BY region\"\n✓ \"SHOW TABLES\" or \"DESCRIBE users\"\n✗ \"INSERT INTO users ...\" → use writeQuery\n✗ \"EXPLAIN SELECT ...\" → use explainQuery for structured analysis\n</examples>\n\n<what_it_returns>\nA JSON array of row objects, each keyed by column name.\n</what_it_returns>\n\n<pagination>\n`SELECT` results are paginated. Pass the prior response's `nextCursor` as `cursor` to fetch the next page. `SHOW`, `DESCRIBE`, `USE`, and `EXPLAIN` return a single page and ignore `cursor`.\n</pagination>",
     "inputSchema": {
-      "$schema": "https://json-schema.org/draft/2020-12/schema",
-      "description": "Request for the `readQuery` tool.",
       "properties": {
         "cursor": {
           "default": null,
@@ -587,12 +513,9 @@ expression: tools
       "required": [
         "query"
       ],
-      "title": "ReadQueryRequest",
       "type": "object"
     },
     "outputSchema": {
-      "$schema": "https://json-schema.org/draft/2020-12/schema",
-      "description": "Response for the `readQuery` tool.",
       "properties": {
         "nextCursor": {
           "description": "Opaque cursor pointing to the next page. Absent when this is the final\npage, when the result fits in one page, or when the statement is a\nnon-`SELECT` kind that does not paginate (e.g. `SHOW`, `EXPLAIN`).",
@@ -610,7 +533,6 @@ expression: tools
       "required": [
         "rows"
       ],
-      "title": "ReadQueryResponse",
       "type": "object"
     },
     "annotations": {

--- a/tests/approval/snapshots/approval_mysql__list_tools_read_write_pinned.snap
+++ b/tests/approval/snapshots/approval_mysql__list_tools_read_write_pinned.snap
@@ -1,6 +1,5 @@
 ---
 source: tests/approval/mysql.rs
-assertion_line: 81
 expression: tools
 ---
 [
@@ -9,8 +8,6 @@ expression: tools
     "title": "Drop Table",
     "description": "Drop a table.\n\n<usecase>\nUse when:\n- Removing a table that is no longer needed\n- Cleaning up test or temporary tables\n</usecase>\n\n<examples>\n✓ \"Drop the temp_logs table\" → dropTable(table=\"temp_logs\")\n✗ \"Delete rows from a table\" → use writeQuery with DELETE\n</examples>\n\n<safety>\nIMPORTANT: This permanently deletes the table and ALL its data. This action cannot be undone.\nIf the table has foreign key dependencies, the drop will fail — resolve dependencies first.\n</safety>\n\n<what_it_returns>\nA confirmation message with the dropped table name.\n</what_it_returns>\n",
     "inputSchema": {
-      "$schema": "https://json-schema.org/draft/2020-12/schema",
-      "description": "Request for the `dropTable` tool.",
       "properties": {
         "table": {
           "description": "Name of the table to drop. Must be non-empty.",
@@ -20,12 +17,9 @@ expression: tools
       "required": [
         "table"
       ],
-      "title": "DropTableRequest",
       "type": "object"
     },
     "outputSchema": {
-      "$schema": "https://json-schema.org/draft/2020-12/schema",
-      "description": "Response for tools with no structured return data.",
       "properties": {
         "message": {
           "description": "Description of the completed operation.",
@@ -35,7 +29,6 @@ expression: tools
       "required": [
         "message"
       ],
-      "title": "MessageResponse",
       "type": "object"
     },
     "annotations": {
@@ -50,8 +43,6 @@ expression: tools
     "title": "Explain Query",
     "description": "Return the execution plan for a SQL query to diagnose performance. Use this tool instead of running EXPLAIN directly through readQuery — it provides structured output.\n\n<usecase>\nUse when:\n- A query runs slowly and you need to understand why\n- Investigating performance bottlenecks\n- Planning index creation to optimize queries\n- Analyzing join methods, table scan strategies, and sort operations\n</usecase>\n\n<when_not_to_use>\n- Running actual queries → use readQuery or writeQuery\n- Checking table structure → use listTables(detailed=true)\n</when_not_to_use>\n\n<examples>\n✓ \"Why is my SELECT on orders slow?\" → explainQuery(query=\"SELECT ...\")\n✓ \"Should I add an index?\" → explainQuery with analyze=true\n✗ \"Run this SELECT\" → use readQuery\n</examples>\n\n<safety>\nSet `analyze` to true for actual execution statistics (EXPLAIN ANALYZE).\nIMPORTANT: EXPLAIN ANALYZE actually executes the query! In read-only mode, only read-only statements are allowed with analyze.\nWhen analyze is false, returns EXPLAIN FORMAT=JSON output without executing.\n</safety>\n\n<what_it_returns>\nA JSON array of execution plan rows showing access methods, join types, row estimates, and costs.\n</what_it_returns>",
     "inputSchema": {
-      "$schema": "https://json-schema.org/draft/2020-12/schema",
-      "description": "Request for the `explainQuery` tool.",
       "properties": {
         "analyze": {
           "default": false,
@@ -66,12 +57,9 @@ expression: tools
       "required": [
         "query"
       ],
-      "title": "ExplainQueryRequest",
       "type": "object"
     },
     "outputSchema": {
-      "$schema": "https://json-schema.org/draft/2020-12/schema",
-      "description": "Response for the `writeQuery` and `explainQuery` tools.",
       "properties": {
         "rows": {
           "description": "Result rows, each a JSON object keyed by a column name.",
@@ -82,7 +70,6 @@ expression: tools
       "required": [
         "rows"
       ],
-      "title": "QueryResponse",
       "type": "object"
     },
     "annotations": {
@@ -97,8 +84,6 @@ expression: tools
     "title": "List Functions",
     "description": "List user-defined SQL functions, optionally filtered and/or with full metadata. Loadable UDFs (`mysql.func`) and stored procedures are excluded.\n\n<usecase>\nUse when:\n- Auditing stored functions across the database (brief mode, default).\n- Searching for a function by partial name (pass `search`).\n- Inspecting a function's language, signature, return type, determinism, SQL-data-access classification, security mode, definer, comment, session context, and full reconstructed `CREATE FUNCTION` text before reasoning about correctness or invocation safety (pass `detailed: true`). Detailed mode supersedes ad-hoc `readQuery` against `information_schema.ROUTINES` / `information_schema.PARAMETERS`.\n</usecase>\n\n<parameters>\n- `cursor` — Opaque pagination cursor; echo the prior response's `nextCursor`.\n- `search` — Case-insensitive filter on function names via `LIKE`. `%` matches any sequence; `_` matches a single character.\n- `detailed` — When `true`, returns full metadata objects keyed by function name instead of bare name strings. Default `false`.\n</parameters>\n\n<examples>\n✓ \"What functions are here?\" → listFunctions()\n✓ \"Find the order-total calculation\" → listFunctions(search=\"order\")\n✓ \"What does calc_order_total do?\" → listFunctions(search=\"calc_order_total\", detailed=true)\n✗ \"List stored procedures\" → use listProcedures instead\n✗ \"List loadable UDFs from mysql.func\" → not supported; only routines in information_schema.ROUTINES are returned\n</examples>\n\n<what_it_returns>\nBrief mode (default): a sorted JSON array of function-name strings, e.g. `[\"calc_order_subtotal\", \"calc_order_total\", \"double_it\"]`.\nDetailed mode: a JSON object keyed by bare function name (MySQL/MariaDB do not allow function overloading, so no signature suffix is needed); each value carries `schema`, `language` (typically `\"SQL\"`; MariaDB external-language functions report the external language name), `arguments` (comma-separated `name type` pairs from `information_schema.PARAMETERS`, empty string for zero-parameter functions), `returnType` (full `DTD_IDENTIFIER` including length/precision/unsigned/enum/set members), `deterministic` (boolean), `sqlDataAccess` (one of `CONTAINS_SQL`, `NO_SQL`, `READS_SQL_DATA`, `MODIFIES_SQL_DATA`), `security` (`INVOKER` or `DEFINER`), `definer` (`user@host`), `description` (the `COMMENT` text or `null` when no comment was set — the empty string MySQL stores is coerced to JSON `null`), `definition` (the canonical reconstructed `CREATE FUNCTION` text including `DEFINER=` in `` `user`@`host` `` form), `sqlMode`, `characterSetClient`, `collationConnection`, and `databaseCollation`. Versus the Postgres detailed payload: `volatility`, `parallelSafety`, and `strict` are intentionally absent (no MySQL/MariaDB analogues), `owner` is renamed to `definer` (more accurate for the MySQL `DEFINER` concept), keys are bare names rather than `name(arguments)` (no overloads possible), and the four session-context fields (`sqlMode`, `characterSetClient`, `collationConnection`, `databaseCollation`) are MySQL/MariaDB-only additions.\n</what_it_returns>\n\n<pagination>\nPaginated. Pass the prior response's `nextCursor` as `cursor` to fetch the next page. The `search` filter must stay the same across pages for cursor continuity.\n</pagination>\n",
     "inputSchema": {
-      "$schema": "https://json-schema.org/draft/2020-12/schema",
-      "description": "Request for the MySQL/MariaDB `listFunctions` tool — supports search + detailed mode.",
       "properties": {
         "cursor": {
           "default": null,
@@ -122,12 +107,11 @@ expression: tools
           ]
         }
       },
-      "title": "ListFunctionsRequest",
       "type": "object"
     },
     "outputSchema": {
-      "$defs": {
-        "ListEntries": {
+      "properties": {
+        "functions": {
           "anyOf": [
             {
               "description": "Brief mode: sorted array of bare entity-name strings.",
@@ -142,14 +126,6 @@ expression: tools
               "type": "object"
             }
           ],
-          "description": "Two-shape listing payload: bare names in brief mode, name-keyed metadata in detailed mode.\n\nShared by [`ListTablesResponse`] and [`ListTriggersResponse`]. Serialises untagged:\nbrief mode → JSON array of strings, detailed mode → JSON object whose keys are\nentity names and whose values are the per-entity metadata."
-        }
-      },
-      "$schema": "https://json-schema.org/draft/2020-12/schema",
-      "description": "Response for the `listFunctions` tool.",
-      "properties": {
-        "functions": {
-          "$ref": "#/$defs/ListEntries",
           "description": "Page of matching functions. Shape depends on the request's `detailed` flag."
         },
         "nextCursor": {
@@ -163,7 +139,6 @@ expression: tools
       "required": [
         "functions"
       ],
-      "title": "ListFunctionsResponse",
       "type": "object"
     },
     "annotations": {
@@ -178,8 +153,6 @@ expression: tools
     "title": "List Procedures",
     "description": "List user-defined stored procedures, optionally filtered and/or with full metadata. Stored functions and loadable UDFs (`mysql.func`) are excluded.\n\n<usecase>\nUse when:\n- Auditing stored procedures across the database (brief mode, default).\n- Searching for a procedure by partial name (pass `search`).\n- Inspecting a procedure's language, parameter list (with `IN`/`OUT`/`INOUT` modes), determinism, SQL-data-access classification, security mode, definer, comment, session context, and full reconstructed `CREATE PROCEDURE` text before reasoning about correctness or invocation safety (pass `detailed: true`). Detailed mode supersedes ad-hoc `readQuery` against `information_schema.ROUTINES` / `information_schema.PARAMETERS`.\n</usecase>\n\n<parameters>\n- `cursor` — Opaque pagination cursor; echo the prior response's `nextCursor`.\n- `search` — Case-insensitive filter on procedure names via `LIKE`. `%` matches any sequence; `_` matches a single character.\n- `detailed` — When `true`, returns full metadata objects keyed by procedure name instead of bare name strings. Default `false`.\n</parameters>\n\n<examples>\n✓ \"What procedures are here?\" → listProcedures()\n✓ \"Find the order archival routine\" → listProcedures(search=\"archive\")\n✓ \"What does archive_order do?\" → listProcedures(search=\"archive_order\", detailed=true)\n✗ \"List functions\" → use listFunctions instead\n✗ \"List loadable UDFs from mysql.func\" → not supported; only routines in information_schema.ROUTINES are returned\n</examples>\n\n<what_it_returns>\nBrief mode (default): a sorted JSON array of procedure-name strings, e.g. `[\"archive_order\", \"archive_order_history\", \"purge_order_archive\", \"touch_post\"]`.\nDetailed mode: a JSON object keyed by bare procedure name (MySQL/MariaDB do not allow procedure overloading, so no signature suffix is needed); each value carries `schema`, `language` (typically `\"SQL\"`; MariaDB external-language procedures report the external language name), `arguments` (comma-separated `MODE name type` triples from `information_schema.PARAMETERS` — `MODE` is one of `IN`, `OUT`, `INOUT`; empty string for zero-parameter procedures), `deterministic` (boolean), `sqlDataAccess` (one of `CONTAINS_SQL`, `NO_SQL`, `READS_SQL_DATA`, `MODIFIES_SQL_DATA`), `security` (`INVOKER` or `DEFINER`), `definer` (`user@host`), `description` (the `COMMENT` text or `null` when no comment was set — the empty string MySQL stores is coerced to JSON `null`), `definition` (the canonical reconstructed `CREATE PROCEDURE` text including `DEFINER=` in `` `user`@`host` `` form; no `RETURNS` clause — procedures have no return type), `sqlMode`, `characterSetClient`, `collationConnection`, and `databaseCollation`. Versus the Postgres `listProcedures` detailed payload: `volatility`, `parallelSafety`, `strict`, and `returnType` are intentionally absent (no MySQL/MariaDB analogues for the first three; procedures have no return type for the fourth — the Postgres-side payload also omits all four), `owner` is renamed to `definer` (more accurate for the MySQL `DEFINER` concept), keys are bare names rather than `name(arguments)` (no overloads possible), the four session-context fields (`sqlMode`, `characterSetClient`, `collationConnection`, `databaseCollation`) are MySQL/MariaDB-only additions, and `deterministic` plus `sqlDataAccess` are MySQL/MariaDB-only additions versus the Postgres `listProcedures` detailed payload (which omits both because Postgres procedures have no equivalent attributes).\n</what_it_returns>\n\n<pagination>\nPaginated. Pass the prior response's `nextCursor` as `cursor` to fetch the next page. The `search` filter must stay the same across pages for cursor continuity.\n</pagination>\n",
     "inputSchema": {
-      "$schema": "https://json-schema.org/draft/2020-12/schema",
-      "description": "Request for the MySQL/MariaDB `listProcedures` tool — supports search + detailed mode.",
       "properties": {
         "cursor": {
           "default": null,
@@ -203,12 +176,18 @@ expression: tools
           ]
         }
       },
-      "title": "ListProceduresRequest",
       "type": "object"
     },
     "outputSchema": {
-      "$defs": {
-        "ListEntries": {
+      "properties": {
+        "nextCursor": {
+          "description": "Opaque cursor pointing to the next page. Absent when this is the final page.",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "procedures": {
           "anyOf": [
             {
               "description": "Brief mode: sorted array of bare entity-name strings.",
@@ -223,28 +202,12 @@ expression: tools
               "type": "object"
             }
           ],
-          "description": "Two-shape listing payload: bare names in brief mode, name-keyed metadata in detailed mode.\n\nShared by [`ListTablesResponse`] and [`ListTriggersResponse`]. Serialises untagged:\nbrief mode → JSON array of strings, detailed mode → JSON object whose keys are\nentity names and whose values are the per-entity metadata."
-        }
-      },
-      "$schema": "https://json-schema.org/draft/2020-12/schema",
-      "description": "Response for the `listProcedures` tool.",
-      "properties": {
-        "nextCursor": {
-          "description": "Opaque cursor pointing to the next page. Absent when this is the final page.",
-          "type": [
-            "string",
-            "null"
-          ]
-        },
-        "procedures": {
-          "$ref": "#/$defs/ListEntries",
           "description": "Page of matching procedures. Shape depends on the request's `detailed` flag."
         }
       },
       "required": [
         "procedures"
       ],
-      "title": "ListProceduresResponse",
       "type": "object"
     },
     "annotations": {
@@ -259,8 +222,6 @@ expression: tools
     "title": "List Tables",
     "description": "List tables, optionally filtered and/or with full metadata.\n\n<usecase>\nUse when:\n- Exploring the database to find relevant tables (brief mode, default).\n- Searching for a table by partial name (pass `search`).\n- Inspecting a table's columns, constraints, indexes, and triggers before writing a query (pass `detailed: true`). This supersedes the legacy `getTableSchema` workflow.\n</usecase>\n\n<parameters>\n- `cursor` — Opaque pagination cursor; echo the prior response's `nextCursor`.\n- `search` — Case-insensitive filter on table names via `LIKE`. `%` matches any sequence; `_` matches a single character.\n- `detailed` — When `true`, returns full metadata objects keyed by table name instead of bare name strings. Default `false`.\n</parameters>\n\n<examples>\n✓ \"What tables are here?\" → listTables()\n✓ \"Find the orders table\" → listTables(search=\"order\")\n✓ \"What columns does orders have?\" → listTables(search=\"orders\", detailed=true)\n</examples>\n\n<what_it_returns>\nBrief mode (default): a sorted JSON array of table-name strings, e.g. `[\"customers\", \"orders\"]`.\nDetailed mode: a JSON object keyed by table name; each value carries `schema`, `kind`, `owner`, `comment`, `columns`, `constraints`, `indexes`, and `triggers` (the name is the key and is not repeated inside the value). Keys iterate in the same alphabetical order brief mode uses. Example: `{\"orders\": {\"schema\": \"mydb\", \"kind\": \"TABLE\", …}}`.\n</what_it_returns>\n\n<pagination>\nPaginated. Pass the prior response's `nextCursor` as `cursor` to fetch the next page. The `search` filter must stay the same across pages for cursor continuity.\n</pagination>\n",
     "inputSchema": {
-      "$schema": "https://json-schema.org/draft/2020-12/schema",
-      "description": "Request for the MySQL/MariaDB `listTables` tool — supports search + detailed mode.",
       "properties": {
         "cursor": {
           "default": null,
@@ -284,12 +245,18 @@ expression: tools
           ]
         }
       },
-      "title": "ListTablesRequest",
       "type": "object"
     },
     "outputSchema": {
-      "$defs": {
-        "ListEntries": {
+      "properties": {
+        "nextCursor": {
+          "description": "Opaque cursor pointing to the next page. Absent when this is the final page.",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "tables": {
           "anyOf": [
             {
               "description": "Brief mode: sorted array of bare entity-name strings.",
@@ -304,28 +271,12 @@ expression: tools
               "type": "object"
             }
           ],
-          "description": "Two-shape listing payload: bare names in brief mode, name-keyed metadata in detailed mode.\n\nShared by [`ListTablesResponse`] and [`ListTriggersResponse`]. Serialises untagged:\nbrief mode → JSON array of strings, detailed mode → JSON object whose keys are\nentity names and whose values are the per-entity metadata."
-        }
-      },
-      "$schema": "https://json-schema.org/draft/2020-12/schema",
-      "description": "Response for the `listTables` tool.",
-      "properties": {
-        "nextCursor": {
-          "description": "Opaque cursor pointing to the next page. Absent when this is the final page.",
-          "type": [
-            "string",
-            "null"
-          ]
-        },
-        "tables": {
-          "$ref": "#/$defs/ListEntries",
           "description": "Page of matching tables. Shape depends on the request's `detailed` flag."
         }
       },
       "required": [
         "tables"
       ],
-      "title": "ListTablesResponse",
       "type": "object"
     },
     "annotations": {
@@ -340,8 +291,6 @@ expression: tools
     "title": "List Triggers",
     "description": "List user-defined triggers, optionally filtered and/or with full metadata.\n\n<usecase>\nUse when:\n- Auditing trigger coverage across the database (brief mode, default).\n- Searching for a trigger by partial name (pass `search`).\n- Inspecting a trigger's timing, event, activation level, full `CREATE TRIGGER` text, and the session context active at trigger-creation time before reasoning about side-effects (pass `detailed: true`). Detailed mode supersedes ad-hoc `readQuery` against `information_schema.TRIGGERS`.\n</usecase>\n\n<parameters>\n- `cursor` — Opaque pagination cursor; echo the prior response's `nextCursor`.\n- `search` — Case-insensitive filter on trigger names via `LIKE`. `%` matches any sequence; `_` matches a single character.\n- `detailed` — When `true`, returns full metadata objects keyed by trigger name instead of bare name strings. Default `false`.\n</parameters>\n\n<examples>\n✓ \"What triggers are here?\" → listTriggers()\n✓ \"Find the audit triggers\" → listTriggers(search=\"audit\")\n✓ \"What does orders_audit_after_insert do?\" → listTriggers(search=\"orders_audit_after_insert\", detailed=true)\n✗ \"Show me a trigger's body\" → use detailed mode; the `definition` field carries the full `CREATE TRIGGER` text\n</examples>\n\n<what_it_returns>\nBrief mode (default): a sorted JSON array of trigger-name strings, e.g. `[\"customers_audit_after_insert\", \"orders_audit_after_insert\"]`.\nDetailed mode: a JSON object keyed by trigger name; each value carries `schema`, `table`, `timing` (BEFORE/AFTER), `events` (single-element array — `INSERT`, `UPDATE`, or `DELETE`), `activationLevel` (always `ROW` on MySQL/MariaDB), `definition` (the canonical `CREATE TRIGGER` text including `DEFINER=` in `` `user`@`host` `` form), `sqlMode`, `characterSetClient`, `collationConnection`, and `databaseCollation`. The Postgres-only `status` and `functionName` fields are intentionally absent (no per-trigger enabled/disabled flag and no separate handler-function reference on MySQL/MariaDB); the four session-context fields are MySQL/MariaDB-only additions versus the Postgres detailed payload.\n</what_it_returns>\n\n<pagination>\nPaginated. Pass the prior response's `nextCursor` as `cursor` to fetch the next page. The `search` filter must stay the same across pages for cursor continuity.\n</pagination>\n",
     "inputSchema": {
-      "$schema": "https://json-schema.org/draft/2020-12/schema",
-      "description": "Request for the `listTriggers` tool.",
       "properties": {
         "cursor": {
           "default": null,
@@ -365,12 +314,18 @@ expression: tools
           ]
         }
       },
-      "title": "ListTriggersRequest",
       "type": "object"
     },
     "outputSchema": {
-      "$defs": {
-        "ListEntries": {
+      "properties": {
+        "nextCursor": {
+          "description": "Opaque cursor pointing to the next page. Absent when this is the final page.",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "triggers": {
           "anyOf": [
             {
               "description": "Brief mode: sorted array of bare entity-name strings.",
@@ -385,28 +340,12 @@ expression: tools
               "type": "object"
             }
           ],
-          "description": "Two-shape listing payload: bare names in brief mode, name-keyed metadata in detailed mode.\n\nShared by [`ListTablesResponse`] and [`ListTriggersResponse`]. Serialises untagged:\nbrief mode → JSON array of strings, detailed mode → JSON object whose keys are\nentity names and whose values are the per-entity metadata."
-        }
-      },
-      "$schema": "https://json-schema.org/draft/2020-12/schema",
-      "description": "Response for the `listTriggers` tool.",
-      "properties": {
-        "nextCursor": {
-          "description": "Opaque cursor pointing to the next page. Absent when this is the final page.",
-          "type": [
-            "string",
-            "null"
-          ]
-        },
-        "triggers": {
-          "$ref": "#/$defs/ListEntries",
           "description": "Page of matching triggers. Shape depends on the request's `detailed` flag."
         }
       },
       "required": [
         "triggers"
       ],
-      "title": "ListTriggersResponse",
       "type": "object"
     },
     "annotations": {
@@ -421,8 +360,6 @@ expression: tools
     "title": "List Views",
     "description": "List user-defined views, optionally filtered and/or with full metadata. Base tables and system-schema views are excluded.\n\n<usecase>\nUse when:\n- Auditing views across the database (brief mode, default).\n- Searching for a view by partial name (pass `search`).\n- Inspecting a view's definer, security mode, check-option level, updatable flag, session character set/collation, and full SELECT body before querying it (pass `detailed: true`). Detailed mode supersedes ad-hoc `readQuery` against `information_schema.VIEWS`.\n</usecase>\n\n<parameters>\n- `cursor` — Opaque pagination cursor; echo the prior response's `nextCursor`.\n- `search` — Case-insensitive filter on view names via `LIKE`. `%` matches any sequence; `_` matches a single character.\n- `detailed` — When `true`, returns full metadata objects keyed by view name instead of bare name strings. Default `false`.\n</parameters>\n\n<examples>\n✓ \"What views are here?\" → listViews()\n✓ \"Find the active-users view\" → listViews(search=\"active\")\n✓ \"What does active_users select?\" → listViews(search=\"active_users\", detailed=true)\n✗ \"Show me the columns of a view\" → use listTables with `detailed: true` instead\n✗ \"List materialized views\" → MySQL/MariaDB have no materialized-view concept\n</examples>\n\n<what_it_returns>\nBrief mode (default): a sorted JSON array of view-name strings, e.g. `[\"active_orders\", \"active_users\", \"published_posts\"]`.\nDetailed mode: a JSON object keyed by bare view name; each value carries `schema`, `definer` (`user@host`), `security` (`INVOKER` or `DEFINER`), `checkOption` (`NONE`, `CASCADED`, or `LOCAL`), `updatable` (boolean), `characterSetClient`, `collationConnection`, and `definition` (the SELECT body verbatim from `information_schema.VIEWS.VIEW_DEFINITION`, with no `CREATE VIEW` wrapper). The view name is the map key only — it is not repeated inside the value.\n\nVersus the Postgres `listViews` detailed payload: `description` is intentionally absent (neither MySQL nor MariaDB exposes a user-comment column for views — `CREATE VIEW` syntax has no `COMMENT` clause), `algorithm` is intentionally absent (MariaDB-only column on `information_schema.VIEWS`), `owner` is renamed to `definer` (more accurate for the MySQL `DEFINER` concept), and the five MySQL/MariaDB-only structured fields (`security`, `checkOption`, `updatable`, `characterSetClient`, `collationConnection`) are added. The `definition` field shape is byte-identical to Postgres — raw SELECT body verbatim, no DDL wrapper. When the connected role lacks the `SHOW VIEW` privilege on a particular view, the engine redacts `VIEW_DEFINITION` to the empty string; the row remains in the response with `definition` reflecting that empty value.\n</what_it_returns>\n\n<pagination>\nPaginated. Pass the prior response's `nextCursor` as `cursor` to fetch the next page. The `search` filter must stay the same across pages for cursor continuity. Brief and detailed modes share the same `TABLE_NAME` row order, so a client can switch `detailed` between pages without losing position.\n</pagination>\n",
     "inputSchema": {
-      "$schema": "https://json-schema.org/draft/2020-12/schema",
-      "description": "Request for the MySQL/MariaDB `listViews` tool — supports search + detailed mode.",
       "properties": {
         "cursor": {
           "default": null,
@@ -446,12 +383,18 @@ expression: tools
           ]
         }
       },
-      "title": "ListViewsRequest",
       "type": "object"
     },
     "outputSchema": {
-      "$defs": {
-        "ListEntries": {
+      "properties": {
+        "nextCursor": {
+          "description": "Opaque cursor pointing to the next page. Absent when this is the final page.",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "views": {
           "anyOf": [
             {
               "description": "Brief mode: sorted array of bare entity-name strings.",
@@ -466,28 +409,12 @@ expression: tools
               "type": "object"
             }
           ],
-          "description": "Two-shape listing payload: bare names in brief mode, name-keyed metadata in detailed mode.\n\nShared by [`ListTablesResponse`] and [`ListTriggersResponse`]. Serialises untagged:\nbrief mode → JSON array of strings, detailed mode → JSON object whose keys are\nentity names and whose values are the per-entity metadata."
-        }
-      },
-      "$schema": "https://json-schema.org/draft/2020-12/schema",
-      "description": "Response for the `listViews` tool.",
-      "properties": {
-        "nextCursor": {
-          "description": "Opaque cursor pointing to the next page. Absent when this is the final page.",
-          "type": [
-            "string",
-            "null"
-          ]
-        },
-        "views": {
-          "$ref": "#/$defs/ListEntries",
           "description": "Page of matching views. Shape depends on the request's `detailed` flag."
         }
       },
       "required": [
         "views"
       ],
-      "title": "ListViewsResponse",
       "type": "object"
     },
     "annotations": {
@@ -502,8 +429,6 @@ expression: tools
     "title": "Read Query",
     "description": "Execute a read-only SQL query. Allowed statements: SELECT, SHOW, DESCRIBE, USE, EXPLAIN.\n\n<usecase>\nUse when:\n- Querying data from tables (SELECT with WHERE, JOIN, GROUP BY, etc.)\n- Aggregations: COUNT, SUM, AVG, GROUP BY, HAVING\n- Listing server variables or status (SHOW)\n- Viewing table structure (DESCRIBE)\n- Switching database context (USE)\n</usecase>\n\n<when_not_to_use>\n- Data changes (INSERT, UPDATE, DELETE) → use writeQuery\n- Query performance analysis → use explainQuery\n- Discovering tables or columns → use listTables (pass detailed=true for column-level metadata)\n</when_not_to_use>\n\n<examples>\n✓ \"SELECT * FROM users WHERE status = 'active'\"\n✓ \"SELECT COUNT(*) FROM orders GROUP BY region\"\n✓ \"SHOW TABLES\" or \"DESCRIBE users\"\n✗ \"INSERT INTO users ...\" → use writeQuery\n✗ \"EXPLAIN SELECT ...\" → use explainQuery for structured analysis\n</examples>\n\n<what_it_returns>\nA JSON array of row objects, each keyed by column name.\n</what_it_returns>\n\n<pagination>\n`SELECT` results are paginated. Pass the prior response's `nextCursor` as `cursor` to fetch the next page. `SHOW`, `DESCRIBE`, `USE`, and `EXPLAIN` return a single page and ignore `cursor`.\n</pagination>",
     "inputSchema": {
-      "$schema": "https://json-schema.org/draft/2020-12/schema",
-      "description": "Request for the `readQuery` tool.",
       "properties": {
         "cursor": {
           "default": null,
@@ -521,12 +446,9 @@ expression: tools
       "required": [
         "query"
       ],
-      "title": "ReadQueryRequest",
       "type": "object"
     },
     "outputSchema": {
-      "$schema": "https://json-schema.org/draft/2020-12/schema",
-      "description": "Response for the `readQuery` tool.",
       "properties": {
         "nextCursor": {
           "description": "Opaque cursor pointing to the next page. Absent when this is the final\npage, when the result fits in one page, or when the statement is a\nnon-`SELECT` kind that does not paginate (e.g. `SHOW`, `EXPLAIN`).",
@@ -544,7 +466,6 @@ expression: tools
       "required": [
         "rows"
       ],
-      "title": "ReadQueryResponse",
       "type": "object"
     },
     "annotations": {
@@ -559,8 +480,6 @@ expression: tools
     "title": "Write Query",
     "description": "Execute a write SQL query (INSERT, UPDATE, DELETE, CREATE, ALTER, DROP).\n\n<usecase>\nUse when:\n- Inserting, updating, or deleting rows\n- Creating or altering tables, indexes, views, or other schema objects\n- Any data modification operation\n</usecase>\n\n<when_not_to_use>\n- Read-only queries (SELECT, SHOW) → use readQuery\n- Query performance analysis → use explainQuery\n- Creating/dropping entire databases → use createDatabase or dropDatabase\n</when_not_to_use>\n\n<examples>\n✓ \"INSERT INTO users (name, email) VALUES ('Alice', 'alice@example.com')\"\n✓ \"UPDATE orders SET status = 'shipped' WHERE id = 42\"\n✓ \"CREATE TABLE logs (id INT PRIMARY KEY, message TEXT)\"\n✗ \"SELECT * FROM users\" → use readQuery\n</examples>\n\n<what_it_returns>\nA JSON array of affected/returning row objects, each keyed by column name.\n</what_it_returns>",
     "inputSchema": {
-      "$schema": "https://json-schema.org/draft/2020-12/schema",
-      "description": "Request for the `writeQuery` tool.",
       "properties": {
         "query": {
           "description": "The SQL query to execute.",
@@ -570,12 +489,9 @@ expression: tools
       "required": [
         "query"
       ],
-      "title": "QueryRequest",
       "type": "object"
     },
     "outputSchema": {
-      "$schema": "https://json-schema.org/draft/2020-12/schema",
-      "description": "Response for the `writeQuery` and `explainQuery` tools.",
       "properties": {
         "rows": {
           "description": "Result rows, each a JSON object keyed by a column name.",
@@ -586,7 +502,6 @@ expression: tools
       "required": [
         "rows"
       ],
-      "title": "QueryResponse",
       "type": "object"
     },
     "annotations": {

--- a/tests/approval/snapshots/approval_mysql__list_tools_read_write_unpinned.snap
+++ b/tests/approval/snapshots/approval_mysql__list_tools_read_write_unpinned.snap
@@ -8,8 +8,6 @@ expression: tools
     "title": "Create Database",
     "description": "Create a new database on the connected server.\n\n<usecase>\nUse when:\n- Setting up a new database for a project or application\n- The user asks to create a database\n</usecase>\n\n<examples>\n✓ \"Create a database called analytics\" → createDatabase(database=\"analytics\")\n✗ \"Create a table\" → use writeQuery with CREATE TABLE\n</examples>\n\n<important>\nDatabase name must be non-empty; backend reserved-character rules apply.\nIf the database already exists, returns a message indicating so without error.\n</important>\n\n<what_it_returns>\nA confirmation message with the created database name.\n</what_it_returns>",
     "inputSchema": {
-      "$schema": "https://json-schema.org/draft/2020-12/schema",
-      "description": "Request for the `createDatabase` tool.",
       "properties": {
         "database": {
           "description": "Name of the database to create. Must be non-empty.",
@@ -19,12 +17,9 @@ expression: tools
       "required": [
         "database"
       ],
-      "title": "CreateDatabaseRequest",
       "type": "object"
     },
     "outputSchema": {
-      "$schema": "https://json-schema.org/draft/2020-12/schema",
-      "description": "Response for tools with no structured return data.",
       "properties": {
         "message": {
           "description": "Description of the completed operation.",
@@ -34,7 +29,6 @@ expression: tools
       "required": [
         "message"
       ],
-      "title": "MessageResponse",
       "type": "object"
     },
     "annotations": {
@@ -49,8 +43,6 @@ expression: tools
     "title": "Drop Database",
     "description": "Drop an existing database from the connected server.\n\n<usecase>\nUse when:\n- Removing a database that is no longer needed\n- Cleaning up test or temporary databases\n</usecase>\n\n<examples>\n✓ \"Drop the test_db database\" → dropDatabase(database=\"test_db\")\n✗ \"Drop a table\" → use dropTable instead\n</examples>\n\n<safety>\nIMPORTANT: This permanently deletes the database and ALL its data. This action cannot be undone.\nCannot drop the database you are currently connected to.\n</safety>\n\n<what_it_returns>\nA confirmation message with the dropped database name.\n</what_it_returns>",
     "inputSchema": {
-      "$schema": "https://json-schema.org/draft/2020-12/schema",
-      "description": "Request for the `dropDatabase` tool.",
       "properties": {
         "database": {
           "description": "Name of the database to drop. Must be non-empty.",
@@ -60,12 +52,9 @@ expression: tools
       "required": [
         "database"
       ],
-      "title": "DropDatabaseRequest",
       "type": "object"
     },
     "outputSchema": {
-      "$schema": "https://json-schema.org/draft/2020-12/schema",
-      "description": "Response for tools with no structured return data.",
       "properties": {
         "message": {
           "description": "Description of the completed operation.",
@@ -75,7 +64,6 @@ expression: tools
       "required": [
         "message"
       ],
-      "title": "MessageResponse",
       "type": "object"
     },
     "annotations": {
@@ -90,8 +78,6 @@ expression: tools
     "title": "Drop Table",
     "description": "Drop a table from a database.\n\n<usecase>\nUse when:\n- Removing a table that is no longer needed\n- Cleaning up test or temporary tables\n</usecase>\n\n<examples>\n✓ \"Drop the temp_logs table from mydb\" → dropTable(database=\"mydb\", table=\"temp_logs\")\n✗ \"Delete rows from a table\" → use writeQuery with DELETE\n✗ \"Drop a database\" → use dropDatabase instead\n</examples>\n\n<safety>\nIMPORTANT: This permanently deletes the table and ALL its data. This action cannot be undone.\nIf the table has foreign key dependencies, the drop will fail — resolve dependencies first.\n</safety>\n\n<what_it_returns>\nA confirmation message with the dropped table name.\n</what_it_returns>",
     "inputSchema": {
-      "$schema": "https://json-schema.org/draft/2020-12/schema",
-      "description": "Request for the `dropTable` tool.",
       "properties": {
         "database": {
           "default": null,
@@ -109,12 +95,9 @@ expression: tools
       "required": [
         "table"
       ],
-      "title": "DropTableRequest",
       "type": "object"
     },
     "outputSchema": {
-      "$schema": "https://json-schema.org/draft/2020-12/schema",
-      "description": "Response for tools with no structured return data.",
       "properties": {
         "message": {
           "description": "Description of the completed operation.",
@@ -124,7 +107,6 @@ expression: tools
       "required": [
         "message"
       ],
-      "title": "MessageResponse",
       "type": "object"
     },
     "annotations": {
@@ -139,8 +121,6 @@ expression: tools
     "title": "Explain Query",
     "description": "Return the execution plan for a SQL query to diagnose performance. Use this tool instead of running EXPLAIN directly through readQuery — it provides structured output.\n\n<usecase>\nUse when:\n- A query runs slowly and you need to understand why\n- Investigating performance bottlenecks\n- Planning index creation to optimize queries\n- Analyzing join methods, table scan strategies, and sort operations\n</usecase>\n\n<when_not_to_use>\n- Running actual queries → use readQuery or writeQuery\n- Checking table structure → use listTables(detailed=true)\n</when_not_to_use>\n\n<examples>\n✓ \"Why is my SELECT on orders slow?\" → explainQuery(query=\"SELECT ...\")\n✓ \"Should I add an index?\" → explainQuery with analyze=true\n✗ \"Run this SELECT\" → use readQuery\n</examples>\n\n<safety>\nSet `analyze` to true for actual execution statistics (EXPLAIN ANALYZE).\nIMPORTANT: EXPLAIN ANALYZE actually executes the query! In read-only mode, only read-only statements are allowed with analyze.\nWhen analyze is false, returns EXPLAIN FORMAT=JSON output without executing.\n</safety>\n\n<what_it_returns>\nA JSON array of execution plan rows showing access methods, join types, row estimates, and costs.\n</what_it_returns>",
     "inputSchema": {
-      "$schema": "https://json-schema.org/draft/2020-12/schema",
-      "description": "Request for the `explainQuery` tool.",
       "properties": {
         "analyze": {
           "default": false,
@@ -163,12 +143,9 @@ expression: tools
       "required": [
         "query"
       ],
-      "title": "ExplainQueryRequest",
       "type": "object"
     },
     "outputSchema": {
-      "$schema": "https://json-schema.org/draft/2020-12/schema",
-      "description": "Response for the `writeQuery` and `explainQuery` tools.",
       "properties": {
         "rows": {
           "description": "Result rows, each a JSON object keyed by a column name.",
@@ -179,7 +156,6 @@ expression: tools
       "required": [
         "rows"
       ],
-      "title": "QueryResponse",
       "type": "object"
     },
     "annotations": {
@@ -194,8 +170,6 @@ expression: tools
     "title": "List Databases",
     "description": "List all accessible databases on the connected server. Use this tool to discover what databases are available before using other tools.\n\n<usecase>\nALWAYS call this tool FIRST when:\n- You need to explore what databases exist on the server\n- You need a database name for listTables or query tools\n- The user asks what data is available\n</usecase>\n\n<examples>\n✓ \"What databases are on this server?\"\n✓ \"Show me what's available\" → call listDatabases first\n</examples>\n\n<what_it_returns>\nA sorted JSON array of database name strings.\n</what_it_returns>\n\n<pagination>\nPaginated. Pass the prior response's `nextCursor` as `cursor` to fetch the next page.\n</pagination>",
     "inputSchema": {
-      "$schema": "https://json-schema.org/draft/2020-12/schema",
-      "description": "Request for the `listDatabases` tool.",
       "properties": {
         "cursor": {
           "default": null,
@@ -206,12 +180,9 @@ expression: tools
           ]
         }
       },
-      "title": "ListDatabasesRequest",
       "type": "object"
     },
     "outputSchema": {
-      "$schema": "https://json-schema.org/draft/2020-12/schema",
-      "description": "Response for the `listDatabases` tool.",
       "properties": {
         "databases": {
           "description": "Sorted list of database names for this page.",
@@ -231,7 +202,6 @@ expression: tools
       "required": [
         "databases"
       ],
-      "title": "ListDatabasesResponse",
       "type": "object"
     },
     "annotations": {
@@ -246,8 +216,6 @@ expression: tools
     "title": "List Functions",
     "description": "List user-defined SQL functions in a database, optionally filtered and/or with full metadata. Loadable UDFs (`mysql.func`) and stored procedures are excluded.\n\n<usecase>\nUse when:\n- Auditing stored functions across a database (brief mode, default).\n- Searching for a function by partial name (pass `search`).\n- Inspecting a function's language, signature, return type, determinism, SQL-data-access classification, security mode, definer, comment, session context, and full reconstructed `CREATE FUNCTION` text before reasoning about correctness or invocation safety (pass `detailed: true`). Detailed mode supersedes ad-hoc `readQuery` against `information_schema.ROUTINES` / `information_schema.PARAMETERS`.\n</usecase>\n\n<parameters>\n- `database` — Database to target. Defaults to the active database.\n- `cursor` — Opaque pagination cursor; echo the prior response's `nextCursor`.\n- `search` — Case-insensitive filter on function names via `LIKE`. `%` matches any sequence; `_` matches a single character.\n- `detailed` — When `true`, returns full metadata objects keyed by function name instead of bare name strings. Default `false`.\n</parameters>\n\n<examples>\n✓ \"What functions are in the mydb database?\" → listFunctions(database=\"mydb\")\n✓ \"Find the order-total calculation\" → listFunctions(search=\"order\")\n✓ \"What does calc_order_total do?\" → listFunctions(search=\"calc_order_total\", detailed=true)\n✗ \"List stored procedures\" → use listProcedures instead\n✗ \"List loadable UDFs from mysql.func\" → not supported; only routines in information_schema.ROUTINES are returned\n</examples>\n\n<what_it_returns>\nBrief mode (default): a sorted JSON array of function-name strings, e.g. `[\"calc_order_subtotal\", \"calc_order_total\", \"double_it\"]`.\nDetailed mode: a JSON object keyed by bare function name (MySQL/MariaDB do not allow function overloading, so no signature suffix is needed); each value carries `schema`, `language` (typically `\"SQL\"`; MariaDB external-language functions report the external language name), `arguments` (comma-separated `name type` pairs from `information_schema.PARAMETERS`, empty string for zero-parameter functions), `returnType` (full `DTD_IDENTIFIER` including length/precision/unsigned/enum/set members), `deterministic` (boolean), `sqlDataAccess` (one of `CONTAINS_SQL`, `NO_SQL`, `READS_SQL_DATA`, `MODIFIES_SQL_DATA`), `security` (`INVOKER` or `DEFINER`), `definer` (`user@host`), `description` (the `COMMENT` text or `null` when no comment was set — the empty string MySQL stores is coerced to JSON `null`), `definition` (the canonical reconstructed `CREATE FUNCTION` text including `DEFINER=` in `` `user`@`host` `` form), `sqlMode`, `characterSetClient`, `collationConnection`, and `databaseCollation`. Versus the Postgres detailed payload: `volatility`, `parallelSafety`, and `strict` are intentionally absent (no MySQL/MariaDB analogues), `owner` is renamed to `definer` (more accurate for the MySQL `DEFINER` concept), keys are bare names rather than `name(arguments)` (no overloads possible), and the four session-context fields (`sqlMode`, `characterSetClient`, `collationConnection`, `databaseCollation`) are MySQL/MariaDB-only additions.\n</what_it_returns>\n\n<pagination>\nPaginated. Pass the prior response's `nextCursor` as `cursor` to fetch the next page. The `search` filter must stay the same across pages for cursor continuity.\n</pagination>",
     "inputSchema": {
-      "$schema": "https://json-schema.org/draft/2020-12/schema",
-      "description": "Request for the MySQL/MariaDB `listFunctions` tool — supports search + detailed mode.",
       "properties": {
         "cursor": {
           "default": null,
@@ -279,12 +247,11 @@ expression: tools
           ]
         }
       },
-      "title": "ListFunctionsRequest",
       "type": "object"
     },
     "outputSchema": {
-      "$defs": {
-        "ListEntries": {
+      "properties": {
+        "functions": {
           "anyOf": [
             {
               "description": "Brief mode: sorted array of bare entity-name strings.",
@@ -299,14 +266,6 @@ expression: tools
               "type": "object"
             }
           ],
-          "description": "Two-shape listing payload: bare names in brief mode, name-keyed metadata in detailed mode.\n\nShared by [`ListTablesResponse`] and [`ListTriggersResponse`]. Serialises untagged:\nbrief mode → JSON array of strings, detailed mode → JSON object whose keys are\nentity names and whose values are the per-entity metadata."
-        }
-      },
-      "$schema": "https://json-schema.org/draft/2020-12/schema",
-      "description": "Response for the `listFunctions` tool.",
-      "properties": {
-        "functions": {
-          "$ref": "#/$defs/ListEntries",
           "description": "Page of matching functions. Shape depends on the request's `detailed` flag."
         },
         "nextCursor": {
@@ -320,7 +279,6 @@ expression: tools
       "required": [
         "functions"
       ],
-      "title": "ListFunctionsResponse",
       "type": "object"
     },
     "annotations": {
@@ -335,8 +293,6 @@ expression: tools
     "title": "List Procedures",
     "description": "List user-defined stored procedures in a database, optionally filtered and/or with full metadata. Stored functions and loadable UDFs (`mysql.func`) are excluded.\n\n<usecase>\nUse when:\n- Auditing stored procedures across a database (brief mode, default).\n- Searching for a procedure by partial name (pass `search`).\n- Inspecting a procedure's language, parameter list (with `IN`/`OUT`/`INOUT` modes), determinism, SQL-data-access classification, security mode, definer, comment, session context, and full reconstructed `CREATE PROCEDURE` text before reasoning about correctness or invocation safety (pass `detailed: true`). Detailed mode supersedes ad-hoc `readQuery` against `information_schema.ROUTINES` / `information_schema.PARAMETERS`.\n</usecase>\n\n<parameters>\n- `database` — Database to target. Defaults to the active database.\n- `cursor` — Opaque pagination cursor; echo the prior response's `nextCursor`.\n- `search` — Case-insensitive filter on procedure names via `LIKE`. `%` matches any sequence; `_` matches a single character.\n- `detailed` — When `true`, returns full metadata objects keyed by procedure name instead of bare name strings. Default `false`.\n</parameters>\n\n<examples>\n✓ \"What procedures are in the mydb database?\" → listProcedures(database=\"mydb\")\n✓ \"Find the order archival routine\" → listProcedures(search=\"archive\")\n✓ \"What does archive_order do?\" → listProcedures(search=\"archive_order\", detailed=true)\n✗ \"List functions\" → use listFunctions instead\n✗ \"List loadable UDFs from mysql.func\" → not supported; only routines in information_schema.ROUTINES are returned\n</examples>\n\n<what_it_returns>\nBrief mode (default): a sorted JSON array of procedure-name strings, e.g. `[\"archive_order\", \"archive_order_history\", \"purge_order_archive\", \"touch_post\"]`.\nDetailed mode: a JSON object keyed by bare procedure name (MySQL/MariaDB do not allow procedure overloading, so no signature suffix is needed); each value carries `schema`, `language` (typically `\"SQL\"`; MariaDB external-language procedures report the external language name), `arguments` (comma-separated `MODE name type` triples from `information_schema.PARAMETERS` — `MODE` is one of `IN`, `OUT`, `INOUT`; empty string for zero-parameter procedures), `deterministic` (boolean), `sqlDataAccess` (one of `CONTAINS_SQL`, `NO_SQL`, `READS_SQL_DATA`, `MODIFIES_SQL_DATA`), `security` (`INVOKER` or `DEFINER`), `definer` (`user@host`), `description` (the `COMMENT` text or `null` when no comment was set — the empty string MySQL stores is coerced to JSON `null`), `definition` (the canonical reconstructed `CREATE PROCEDURE` text including `DEFINER=` in `` `user`@`host` `` form; no `RETURNS` clause — procedures have no return type), `sqlMode`, `characterSetClient`, `collationConnection`, and `databaseCollation`. Versus the Postgres `listProcedures` detailed payload: `volatility`, `parallelSafety`, `strict`, and `returnType` are intentionally absent (no MySQL/MariaDB analogues for the first three; procedures have no return type for the fourth — the Postgres-side payload also omits all four), `owner` is renamed to `definer` (more accurate for the MySQL `DEFINER` concept), keys are bare names rather than `name(arguments)` (no overloads possible), the four session-context fields (`sqlMode`, `characterSetClient`, `collationConnection`, `databaseCollation`) are MySQL/MariaDB-only additions, and `deterministic` plus `sqlDataAccess` are MySQL/MariaDB-only additions versus the Postgres `listProcedures` detailed payload (which omits both because Postgres procedures have no equivalent attributes).\n</what_it_returns>\n\n<pagination>\nPaginated. Pass the prior response's `nextCursor` as `cursor` to fetch the next page. The `search` filter must stay the same across pages for cursor continuity.\n</pagination>",
     "inputSchema": {
-      "$schema": "https://json-schema.org/draft/2020-12/schema",
-      "description": "Request for the MySQL/MariaDB `listProcedures` tool — supports search + detailed mode.",
       "properties": {
         "cursor": {
           "default": null,
@@ -368,12 +324,18 @@ expression: tools
           ]
         }
       },
-      "title": "ListProceduresRequest",
       "type": "object"
     },
     "outputSchema": {
-      "$defs": {
-        "ListEntries": {
+      "properties": {
+        "nextCursor": {
+          "description": "Opaque cursor pointing to the next page. Absent when this is the final page.",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "procedures": {
           "anyOf": [
             {
               "description": "Brief mode: sorted array of bare entity-name strings.",
@@ -388,28 +350,12 @@ expression: tools
               "type": "object"
             }
           ],
-          "description": "Two-shape listing payload: bare names in brief mode, name-keyed metadata in detailed mode.\n\nShared by [`ListTablesResponse`] and [`ListTriggersResponse`]. Serialises untagged:\nbrief mode → JSON array of strings, detailed mode → JSON object whose keys are\nentity names and whose values are the per-entity metadata."
-        }
-      },
-      "$schema": "https://json-schema.org/draft/2020-12/schema",
-      "description": "Response for the `listProcedures` tool.",
-      "properties": {
-        "nextCursor": {
-          "description": "Opaque cursor pointing to the next page. Absent when this is the final page.",
-          "type": [
-            "string",
-            "null"
-          ]
-        },
-        "procedures": {
-          "$ref": "#/$defs/ListEntries",
           "description": "Page of matching procedures. Shape depends on the request's `detailed` flag."
         }
       },
       "required": [
         "procedures"
       ],
-      "title": "ListProceduresResponse",
       "type": "object"
     },
     "annotations": {
@@ -424,8 +370,6 @@ expression: tools
     "title": "List Tables",
     "description": "List tables in a database, optionally filtered and/or with full metadata.\n\n<usecase>\nUse when:\n- Exploring a database to find relevant tables (brief mode, default).\n- Searching for a table by partial name (pass `search`).\n- Inspecting a table's columns, constraints, indexes, and triggers before writing a query (pass `detailed: true`). This supersedes the legacy `getTableSchema` tool.\n</usecase>\n\n<parameters>\n- `database` — Database to target. Defaults to the active database.\n- `cursor` — Opaque pagination cursor; echo the prior response's `nextCursor`.\n- `search` — Case-insensitive filter on table names via `LIKE`. `%` matches any sequence; `_` matches a single character.\n- `detailed` — When `true`, returns full metadata objects keyed by table name instead of bare name strings. Default `false`.\n</parameters>\n\n<examples>\n✓ \"What tables are in mydb?\" → listTables(database=\"mydb\")\n✓ \"Find the orders table\" → listTables(search=\"order\")\n✓ \"What columns does orders have?\" → listTables(search=\"orders\", detailed=true)\n</examples>\n\n<what_it_returns>\nBrief mode (default): a sorted JSON array of table-name strings, e.g. `[\"customers\", \"orders\"]`.\nDetailed mode: a JSON object keyed by table name; each value carries `schema`, `kind`, `owner`, `comment`, `columns`, `constraints`, `indexes`, and `triggers` (the name is the key and is not repeated inside the value). Keys iterate in the same alphabetical order brief mode uses. Example: `{\"orders\": {\"schema\": \"mydb\", \"kind\": \"TABLE\", …}}`.\n</what_it_returns>\n\n<pagination>\nPaginated. Pass the prior response's `nextCursor` as `cursor` to fetch the next page. The `search` filter must stay the same across pages for cursor continuity.\n</pagination>",
     "inputSchema": {
-      "$schema": "https://json-schema.org/draft/2020-12/schema",
-      "description": "Request for the MySQL/MariaDB `listTables` tool — supports search + detailed mode.",
       "properties": {
         "cursor": {
           "default": null,
@@ -457,12 +401,18 @@ expression: tools
           ]
         }
       },
-      "title": "ListTablesRequest",
       "type": "object"
     },
     "outputSchema": {
-      "$defs": {
-        "ListEntries": {
+      "properties": {
+        "nextCursor": {
+          "description": "Opaque cursor pointing to the next page. Absent when this is the final page.",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "tables": {
           "anyOf": [
             {
               "description": "Brief mode: sorted array of bare entity-name strings.",
@@ -477,28 +427,12 @@ expression: tools
               "type": "object"
             }
           ],
-          "description": "Two-shape listing payload: bare names in brief mode, name-keyed metadata in detailed mode.\n\nShared by [`ListTablesResponse`] and [`ListTriggersResponse`]. Serialises untagged:\nbrief mode → JSON array of strings, detailed mode → JSON object whose keys are\nentity names and whose values are the per-entity metadata."
-        }
-      },
-      "$schema": "https://json-schema.org/draft/2020-12/schema",
-      "description": "Response for the `listTables` tool.",
-      "properties": {
-        "nextCursor": {
-          "description": "Opaque cursor pointing to the next page. Absent when this is the final page.",
-          "type": [
-            "string",
-            "null"
-          ]
-        },
-        "tables": {
-          "$ref": "#/$defs/ListEntries",
           "description": "Page of matching tables. Shape depends on the request's `detailed` flag."
         }
       },
       "required": [
         "tables"
       ],
-      "title": "ListTablesResponse",
       "type": "object"
     },
     "annotations": {
@@ -513,8 +447,6 @@ expression: tools
     "title": "List Triggers",
     "description": "List user-defined triggers in a database, optionally filtered and/or with full metadata.\n\n<usecase>\nUse when:\n- Auditing trigger coverage across a database (brief mode, default).\n- Searching for a trigger by partial name (pass `search`).\n- Inspecting a trigger's timing, event, activation level, full `CREATE TRIGGER` text, and the session context active at trigger-creation time before reasoning about side-effects (pass `detailed: true`). Detailed mode supersedes ad-hoc `readQuery` against `information_schema.TRIGGERS`.\n</usecase>\n\n<parameters>\n- `database` — Database to target. Defaults to the active database.\n- `cursor` — Opaque pagination cursor; echo the prior response's `nextCursor`.\n- `search` — Case-insensitive filter on trigger names via `LIKE`. `%` matches any sequence; `_` matches a single character.\n- `detailed` — When `true`, returns full metadata objects keyed by trigger name instead of bare name strings. Default `false`.\n</parameters>\n\n<examples>\n✓ \"What triggers are in the mydb database?\" → listTriggers(database=\"mydb\")\n✓ \"Find the audit triggers\" → listTriggers(search=\"audit\")\n✓ \"What does orders_audit_after_insert do?\" → listTriggers(search=\"orders_audit_after_insert\", detailed=true)\n✗ \"Show me a trigger's body\" → use detailed mode; the `definition` field carries the full `CREATE TRIGGER` text\n</examples>\n\n<what_it_returns>\nBrief mode (default): a sorted JSON array of trigger-name strings, e.g. `[\"customers_audit_after_insert\", \"orders_audit_after_insert\"]`.\nDetailed mode: a JSON object keyed by trigger name; each value carries `schema`, `table`, `timing` (BEFORE/AFTER), `events` (single-element array — `INSERT`, `UPDATE`, or `DELETE`), `activationLevel` (always `ROW` on MySQL/MariaDB), `definition` (the canonical `CREATE TRIGGER` text including `DEFINER=` in `` `user`@`host` `` form), `sqlMode`, `characterSetClient`, `collationConnection`, and `databaseCollation`. The Postgres-only `status` and `functionName` fields are intentionally absent (no per-trigger enabled/disabled flag and no separate handler-function reference on MySQL/MariaDB); the four session-context fields are MySQL/MariaDB-only additions versus the Postgres detailed payload.\n</what_it_returns>\n\n<pagination>\nPaginated. Pass the prior response's `nextCursor` as `cursor` to fetch the next page. The `search` filter must stay the same across pages for cursor continuity.\n</pagination>",
     "inputSchema": {
-      "$schema": "https://json-schema.org/draft/2020-12/schema",
-      "description": "Request for the `listTriggers` tool.",
       "properties": {
         "cursor": {
           "default": null,
@@ -546,12 +478,18 @@ expression: tools
           ]
         }
       },
-      "title": "ListTriggersRequest",
       "type": "object"
     },
     "outputSchema": {
-      "$defs": {
-        "ListEntries": {
+      "properties": {
+        "nextCursor": {
+          "description": "Opaque cursor pointing to the next page. Absent when this is the final page.",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "triggers": {
           "anyOf": [
             {
               "description": "Brief mode: sorted array of bare entity-name strings.",
@@ -566,28 +504,12 @@ expression: tools
               "type": "object"
             }
           ],
-          "description": "Two-shape listing payload: bare names in brief mode, name-keyed metadata in detailed mode.\n\nShared by [`ListTablesResponse`] and [`ListTriggersResponse`]. Serialises untagged:\nbrief mode → JSON array of strings, detailed mode → JSON object whose keys are\nentity names and whose values are the per-entity metadata."
-        }
-      },
-      "$schema": "https://json-schema.org/draft/2020-12/schema",
-      "description": "Response for the `listTriggers` tool.",
-      "properties": {
-        "nextCursor": {
-          "description": "Opaque cursor pointing to the next page. Absent when this is the final page.",
-          "type": [
-            "string",
-            "null"
-          ]
-        },
-        "triggers": {
-          "$ref": "#/$defs/ListEntries",
           "description": "Page of matching triggers. Shape depends on the request's `detailed` flag."
         }
       },
       "required": [
         "triggers"
       ],
-      "title": "ListTriggersResponse",
       "type": "object"
     },
     "annotations": {
@@ -602,8 +524,6 @@ expression: tools
     "title": "List Views",
     "description": "List user-defined views in a database, optionally filtered and/or with full metadata. Base tables and system-schema views are excluded.\n\n<usecase>\nUse when:\n- Auditing views across a database (brief mode, default).\n- Searching for a view by partial name (pass `search`).\n- Inspecting a view's definer, security mode, check-option level, updatable flag, session character set/collation, and full SELECT body before querying it (pass `detailed: true`). Detailed mode supersedes ad-hoc `readQuery` against `information_schema.VIEWS`.\n</usecase>\n\n<parameters>\n- `database` — Database to target. Defaults to the active database.\n- `cursor` — Opaque pagination cursor; echo the prior response's `nextCursor`.\n- `search` — Case-insensitive filter on view names via `LIKE`. `%` matches any sequence; `_` matches a single character.\n- `detailed` — When `true`, returns full metadata objects keyed by view name instead of bare name strings. Default `false`.\n</parameters>\n\n<examples>\n✓ \"What views are in the mydb database?\" → listViews(database=\"mydb\")\n✓ \"Find the active-users view\" → listViews(search=\"active\")\n✓ \"What does active_users select?\" → listViews(search=\"active_users\", detailed=true)\n✗ \"Show me the columns of a view\" → use listTables with `detailed: true` instead\n✗ \"List materialized views\" → MySQL/MariaDB have no materialized-view concept\n</examples>\n\n<what_it_returns>\nBrief mode (default): a sorted JSON array of view-name strings, e.g. `[\"active_orders\", \"active_users\", \"published_posts\"]`.\nDetailed mode: a JSON object keyed by bare view name; each value carries `schema`, `definer` (`user@host`), `security` (`INVOKER` or `DEFINER`), `checkOption` (`NONE`, `CASCADED`, or `LOCAL`), `updatable` (boolean), `characterSetClient`, `collationConnection`, and `definition` (the SELECT body verbatim from `information_schema.VIEWS.VIEW_DEFINITION`, with no `CREATE VIEW` wrapper). The view name is the map key only — it is not repeated inside the value.\n\nVersus the Postgres `listViews` detailed payload: `description` is intentionally absent (neither MySQL nor MariaDB exposes a user-comment column for views — `CREATE VIEW` syntax has no `COMMENT` clause), `algorithm` is intentionally absent (MariaDB-only column on `information_schema.VIEWS`), `owner` is renamed to `definer` (more accurate for the MySQL `DEFINER` concept), and the five MySQL/MariaDB-only structured fields (`security`, `checkOption`, `updatable`, `characterSetClient`, `collationConnection`) are added. The `definition` field shape is byte-identical to Postgres — raw SELECT body verbatim, no DDL wrapper. When the connected role lacks the `SHOW VIEW` privilege on a particular view, the engine redacts `VIEW_DEFINITION` to the empty string; the row remains in the response with `definition` reflecting that empty value.\n</what_it_returns>\n\n<pagination>\nPaginated. Pass the prior response's `nextCursor` as `cursor` to fetch the next page. The `search` filter must stay the same across pages for cursor continuity. Brief and detailed modes share the same `TABLE_NAME` row order, so a client can switch `detailed` between pages without losing position.\n</pagination>",
     "inputSchema": {
-      "$schema": "https://json-schema.org/draft/2020-12/schema",
-      "description": "Request for the MySQL/MariaDB `listViews` tool — supports search + detailed mode.",
       "properties": {
         "cursor": {
           "default": null,
@@ -635,12 +555,18 @@ expression: tools
           ]
         }
       },
-      "title": "ListViewsRequest",
       "type": "object"
     },
     "outputSchema": {
-      "$defs": {
-        "ListEntries": {
+      "properties": {
+        "nextCursor": {
+          "description": "Opaque cursor pointing to the next page. Absent when this is the final page.",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "views": {
           "anyOf": [
             {
               "description": "Brief mode: sorted array of bare entity-name strings.",
@@ -655,28 +581,12 @@ expression: tools
               "type": "object"
             }
           ],
-          "description": "Two-shape listing payload: bare names in brief mode, name-keyed metadata in detailed mode.\n\nShared by [`ListTablesResponse`] and [`ListTriggersResponse`]. Serialises untagged:\nbrief mode → JSON array of strings, detailed mode → JSON object whose keys are\nentity names and whose values are the per-entity metadata."
-        }
-      },
-      "$schema": "https://json-schema.org/draft/2020-12/schema",
-      "description": "Response for the `listViews` tool.",
-      "properties": {
-        "nextCursor": {
-          "description": "Opaque cursor pointing to the next page. Absent when this is the final page.",
-          "type": [
-            "string",
-            "null"
-          ]
-        },
-        "views": {
-          "$ref": "#/$defs/ListEntries",
           "description": "Page of matching views. Shape depends on the request's `detailed` flag."
         }
       },
       "required": [
         "views"
       ],
-      "title": "ListViewsResponse",
       "type": "object"
     },
     "annotations": {
@@ -691,8 +601,6 @@ expression: tools
     "title": "Read Query",
     "description": "Execute a read-only SQL query. Allowed statements: SELECT, SHOW, DESCRIBE, USE, EXPLAIN.\n\n<usecase>\nUse when:\n- Querying data from tables (SELECT with WHERE, JOIN, GROUP BY, etc.)\n- Aggregations: COUNT, SUM, AVG, GROUP BY, HAVING\n- Listing server variables or status (SHOW)\n- Viewing table structure (DESCRIBE)\n- Switching database context (USE)\n</usecase>\n\n<when_not_to_use>\n- Data changes (INSERT, UPDATE, DELETE) → use writeQuery\n- Query performance analysis → use explainQuery\n- Discovering tables or columns → use listTables (pass detailed=true for column-level metadata)\n</when_not_to_use>\n\n<examples>\n✓ \"SELECT * FROM users WHERE status = 'active'\"\n✓ \"SELECT COUNT(*) FROM orders GROUP BY region\"\n✓ \"SHOW TABLES\" or \"DESCRIBE users\"\n✗ \"INSERT INTO users ...\" → use writeQuery\n✗ \"EXPLAIN SELECT ...\" → use explainQuery for structured analysis\n</examples>\n\n<what_it_returns>\nA JSON array of row objects, each keyed by column name.\n</what_it_returns>\n\n<pagination>\n`SELECT` results are paginated. Pass the prior response's `nextCursor` as `cursor` to fetch the next page. `SHOW`, `DESCRIBE`, `USE`, and `EXPLAIN` return a single page and ignore `cursor`.\n</pagination>",
     "inputSchema": {
-      "$schema": "https://json-schema.org/draft/2020-12/schema",
-      "description": "Request for the `readQuery` tool.",
       "properties": {
         "cursor": {
           "default": null,
@@ -718,12 +626,9 @@ expression: tools
       "required": [
         "query"
       ],
-      "title": "ReadQueryRequest",
       "type": "object"
     },
     "outputSchema": {
-      "$schema": "https://json-schema.org/draft/2020-12/schema",
-      "description": "Response for the `readQuery` tool.",
       "properties": {
         "nextCursor": {
           "description": "Opaque cursor pointing to the next page. Absent when this is the final\npage, when the result fits in one page, or when the statement is a\nnon-`SELECT` kind that does not paginate (e.g. `SHOW`, `EXPLAIN`).",
@@ -741,7 +646,6 @@ expression: tools
       "required": [
         "rows"
       ],
-      "title": "ReadQueryResponse",
       "type": "object"
     },
     "annotations": {
@@ -756,8 +660,6 @@ expression: tools
     "title": "Write Query",
     "description": "Execute a write SQL query (INSERT, UPDATE, DELETE, CREATE, ALTER, DROP).\n\n<usecase>\nUse when:\n- Inserting, updating, or deleting rows\n- Creating or altering tables, indexes, views, or other schema objects\n- Any data modification operation\n</usecase>\n\n<when_not_to_use>\n- Read-only queries (SELECT, SHOW) → use readQuery\n- Query performance analysis → use explainQuery\n- Creating/dropping entire databases → use createDatabase or dropDatabase\n</when_not_to_use>\n\n<examples>\n✓ \"INSERT INTO users (name, email) VALUES ('Alice', 'alice@example.com')\"\n✓ \"UPDATE orders SET status = 'shipped' WHERE id = 42\"\n✓ \"CREATE TABLE logs (id INT PRIMARY KEY, message TEXT)\"\n✗ \"SELECT * FROM users\" → use readQuery\n</examples>\n\n<what_it_returns>\nA JSON array of affected/returning row objects, each keyed by column name.\n</what_it_returns>",
     "inputSchema": {
-      "$schema": "https://json-schema.org/draft/2020-12/schema",
-      "description": "Request for the `writeQuery` tool.",
       "properties": {
         "database": {
           "default": null,
@@ -775,12 +677,9 @@ expression: tools
       "required": [
         "query"
       ],
-      "title": "QueryRequest",
       "type": "object"
     },
     "outputSchema": {
-      "$schema": "https://json-schema.org/draft/2020-12/schema",
-      "description": "Response for the `writeQuery` and `explainQuery` tools.",
       "properties": {
         "rows": {
           "description": "Result rows, each a JSON object keyed by a column name.",
@@ -791,7 +690,6 @@ expression: tools
       "required": [
         "rows"
       ],
-      "title": "QueryResponse",
       "type": "object"
     },
     "annotations": {

--- a/tests/approval/snapshots/approval_postgres__list_tools_read_only_pinned.snap
+++ b/tests/approval/snapshots/approval_postgres__list_tools_read_only_pinned.snap
@@ -1,6 +1,5 @@
 ---
 source: tests/approval/postgres.rs
-assertion_line: 100
 expression: tools
 ---
 [
@@ -9,8 +8,6 @@ expression: tools
     "title": "Explain Query",
     "description": "Return the execution plan for a SQL query to diagnose performance. Use this tool instead of running EXPLAIN directly through readQuery — it provides structured JSON output.\n\n<usecase>\nUse when:\n- A query runs slowly and you need to understand why\n- Investigating performance bottlenecks\n- Planning index creation to optimize queries\n- Analyzing join methods, table scan strategies, and sort operations\n</usecase>\n\n<when_not_to_use>\n- Running actual queries → use readQuery or writeQuery\n- Checking table structure → use listTables(detailed=true)\n</when_not_to_use>\n\n<examples>\n✓ \"Why is my SELECT on orders slow?\" → explainQuery(query=\"SELECT ...\")\n✓ \"Should I add an index?\" → explainQuery with analyze=true\n✗ \"Run this SELECT\" → use readQuery\n</examples>\n\n<safety>\nSet `analyze` to true for actual execution statistics (EXPLAIN ANALYZE).\nIMPORTANT: EXPLAIN ANALYZE actually executes the query! In read-only mode, only read-only statements are allowed with analyze.\nWhen analyze is false, returns EXPLAIN (FORMAT JSON) output without executing.\n</safety>\n\n<what_it_returns>\nA JSON array of execution plan rows showing access methods, join types, row estimates, and costs.\n</what_it_returns>",
     "inputSchema": {
-      "$schema": "https://json-schema.org/draft/2020-12/schema",
-      "description": "Request for the `explainQuery` tool.",
       "properties": {
         "analyze": {
           "default": false,
@@ -25,12 +22,9 @@ expression: tools
       "required": [
         "query"
       ],
-      "title": "ExplainQueryRequest",
       "type": "object"
     },
     "outputSchema": {
-      "$schema": "https://json-schema.org/draft/2020-12/schema",
-      "description": "Response for the `writeQuery` and `explainQuery` tools.",
       "properties": {
         "rows": {
           "description": "Result rows, each a JSON object keyed by a column name.",
@@ -41,7 +35,6 @@ expression: tools
       "required": [
         "rows"
       ],
-      "title": "QueryResponse",
       "type": "object"
     },
     "annotations": {
@@ -56,8 +49,6 @@ expression: tools
     "title": "List Functions",
     "description": "List user-defined functions in the `public` schema, optionally filtered and/or with full metadata. Aggregates, window functions, and procedures are excluded.\n\n<usecase>\nUse when:\n- Auditing functions across the database (brief mode, default).\n- Searching for a function by partial name (pass `search`).\n- Inspecting a function's language, signature, return type, volatility, strictness, security mode, parallel-safety, owner, comment, and full `CREATE FUNCTION` text before reasoning about correctness or invocation safety (pass `detailed: true`). Detailed mode supersedes ad-hoc `readQuery` against `pg_proc` / `information_schema.routines`.\n</usecase>\n\n<parameters>\n- `cursor` — Opaque pagination cursor; echo the prior response's `nextCursor`.\n- `search` — Case-insensitive filter on function names via `ILIKE`. `%` matches any sequence; `_` matches a single character.\n- `detailed` — When `true`, returns full metadata objects keyed by `name(arguments)` instead of bare name strings. Default `false`.\n</parameters>\n\n<examples>\n✓ \"What functions are here?\" → listFunctions()\n✓ \"Find the order-total calculation\" → listFunctions(search=\"order\")\n✓ \"What does calc_order_total do?\" → listFunctions(search=\"calc_order_total\", detailed=true)\n✗ \"List stored procedures\" → use listProcedures instead\n✗ \"List aggregates\" → not supported; aggregates are excluded\n</examples>\n\n<what_it_returns>\nBrief mode (default): a sorted JSON array of function-name strings, e.g. `[\"audit_user_login\", \"calc_order_subtotal\", \"calc_order_total\", \"calc_order_total\"]`. Overloaded functions appear as one entry per overload (duplicate name strings allowed).\nDetailed mode: a JSON object keyed by function signature `name(arguments)`; each value carries `schema`, `name`, `language`, `arguments`, `returnType`, `volatility` (IMMUTABLE/STABLE/VOLATILE), `strict` (boolean), `security` (INVOKER/DEFINER), `parallelSafety` (SAFE/RESTRICTED/UNSAFE), `owner`, `description` (or null when no `COMMENT ON FUNCTION`), and `definition` (the full `CREATE OR REPLACE FUNCTION` text). Overloads occupy distinct keys (e.g. `calc_total(integer)` vs `calc_total(integer, numeric)`).\n</what_it_returns>\n\n<pagination>\nPaginated. Pass the prior response's `nextCursor` as `cursor` to fetch the next page. The `search` filter must stay the same across pages for cursor continuity. Brief and detailed modes share the same `(proname, oid)` row order, so a client can switch `detailed` between pages without losing position.\n</pagination>\n",
     "inputSchema": {
-      "$schema": "https://json-schema.org/draft/2020-12/schema",
-      "description": "Request for the Postgres `listFunctions` tool — extends the shared shape with `search` and `detailed`.",
       "properties": {
         "cursor": {
           "default": null,
@@ -81,12 +72,11 @@ expression: tools
           ]
         }
       },
-      "title": "ListFunctionsRequest",
       "type": "object"
     },
     "outputSchema": {
-      "$defs": {
-        "ListEntries": {
+      "properties": {
+        "functions": {
           "anyOf": [
             {
               "description": "Brief mode: sorted array of bare entity-name strings.",
@@ -101,14 +91,6 @@ expression: tools
               "type": "object"
             }
           ],
-          "description": "Two-shape listing payload: bare names in brief mode, name-keyed metadata in detailed mode.\n\nShared by [`ListTablesResponse`] and [`ListTriggersResponse`]. Serialises untagged:\nbrief mode → JSON array of strings, detailed mode → JSON object whose keys are\nentity names and whose values are the per-entity metadata."
-        }
-      },
-      "$schema": "https://json-schema.org/draft/2020-12/schema",
-      "description": "Response for the `listFunctions` tool.",
-      "properties": {
-        "functions": {
-          "$ref": "#/$defs/ListEntries",
           "description": "Page of matching functions. Shape depends on the request's `detailed` flag."
         },
         "nextCursor": {
@@ -122,7 +104,6 @@ expression: tools
       "required": [
         "functions"
       ],
-      "title": "ListFunctionsResponse",
       "type": "object"
     },
     "annotations": {
@@ -137,8 +118,6 @@ expression: tools
     "title": "List Materialized Views",
     "description": "List materialized views in the `public` schema, optionally filtered and/or with full metadata. Unlike regular views, materialized views store their results physically and must be refreshed explicitly. Regular views and system-schema matviews are excluded.\n\n<usecase>\nUse when:\n- Auditing materialized views across the database (brief mode, default).\n- Searching for a matview by partial name (pass `search`).\n- Inspecting a matview's owner, comment, full SELECT body, populated state, and index presence before querying or refreshing it (pass `detailed: true`). Detailed mode supersedes ad-hoc `readQuery` against `pg_matviews` / `pg_class`.\n</usecase>\n\n<parameters>\n- `cursor` — Opaque pagination cursor; echo the prior response's `nextCursor`.\n- `search` — Case-insensitive filter on matview names via `ILIKE`. `%` matches any sequence; `_` matches a single character.\n- `detailed` — When `true`, returns full metadata objects keyed by bare matview name instead of bare name strings. Default `false`.\n</parameters>\n\n<examples>\n✓ \"What materialized views are here?\" → listMaterializedViews()\n✓ \"Find the recent-orders matview\" → listMaterializedViews(search=\"orders\")\n✓ \"What does mv_orders_by_region compute?\" → listMaterializedViews(search=\"mv_orders_by_region\", detailed=true)\n✓ \"Has the cache matview ever been refreshed?\" → listMaterializedViews(search=\"cache\", detailed=true) — read `populated`\n✓ \"Which matviews can I refresh concurrently?\" → listMaterializedViews(detailed=true) — read `indexed` (CONCURRENTLY additionally needs a unique index)\n✗ \"List regular views\" → use listViews instead\n</examples>\n\n<what_it_returns>\nBrief mode (default): a sorted JSON array of matview-name strings, e.g. `[\"mv_archived_orders\", \"mv_recent_orders\"]`. Matview names are unique per schema, so no duplicates appear.\nDetailed mode: a JSON object keyed by bare matview name; each value carries:\n- `schema` — schema name (always `\"public\"` in this build).\n- `owner` — owning role's name from `pg_matviews.matviewowner`.\n- `description` — `COMMENT ON MATERIALIZED VIEW` text, or `null` when no comment.\n- `definition` — the SELECT body verbatim from `pg_matviews.definition`, with no `CREATE MATERIALIZED VIEW` wrapper.\n- `populated` — `true` once the matview has been refreshed at least once. `false` for matviews created `WITH NO DATA` and never refreshed; querying such a matview returns zero rows until `REFRESH MATERIALIZED VIEW` runs.\n- `indexed` — `true` when at least one index exists on the matview. `REFRESH MATERIALIZED VIEW CONCURRENTLY` additionally requires a unique index; this tool reports the broader has-any-index signal.\n\nThe matview name is the map key only — it is not repeated inside the value. Detailed mode deliberately omits column metadata (`columns`), `tablespace`, storage parameters, and unique-index detection. Column shape is recoverable from the `definition` text or via `listTables(detailed=true)` since Postgres exposes matviews in `pg_class`.\n</what_it_returns>\n\n<pagination>\nPaginated. Pass the prior response's `nextCursor` as `cursor` to fetch the next page. The `search` filter must stay the same across pages for cursor continuity. Brief and detailed modes share the same `matviewname` row order, so a client can switch `detailed` between pages without losing position.\n</pagination>\n",
     "inputSchema": {
-      "$schema": "https://json-schema.org/draft/2020-12/schema",
-      "description": "Request for the Postgres `listMaterializedViews` tool — extends the shared shape with `search` and `detailed`.",
       "properties": {
         "cursor": {
           "default": null,
@@ -162,12 +141,11 @@ expression: tools
           ]
         }
       },
-      "title": "ListMaterializedViewsRequest",
       "type": "object"
     },
     "outputSchema": {
-      "$defs": {
-        "ListEntries": {
+      "properties": {
+        "materializedViews": {
           "anyOf": [
             {
               "description": "Brief mode: sorted array of bare entity-name strings.",
@@ -182,14 +160,6 @@ expression: tools
               "type": "object"
             }
           ],
-          "description": "Two-shape listing payload: bare names in brief mode, name-keyed metadata in detailed mode.\n\nShared by [`ListTablesResponse`] and [`ListTriggersResponse`]. Serialises untagged:\nbrief mode → JSON array of strings, detailed mode → JSON object whose keys are\nentity names and whose values are the per-entity metadata."
-        }
-      },
-      "$schema": "https://json-schema.org/draft/2020-12/schema",
-      "description": "Response for the `listMaterializedViews` tool.",
-      "properties": {
-        "materializedViews": {
-          "$ref": "#/$defs/ListEntries",
           "description": "Page of matching materialized views. Shape depends on the request's `detailed` flag."
         },
         "nextCursor": {
@@ -203,7 +173,6 @@ expression: tools
       "required": [
         "materializedViews"
       ],
-      "title": "ListMaterializedViewsResponse",
       "type": "object"
     },
     "annotations": {
@@ -218,8 +187,6 @@ expression: tools
     "title": "List Procedures",
     "description": "List user-defined procedures in the `public` schema, optionally filtered and/or with full metadata. Functions, aggregates, and window functions are excluded.\n\n<usecase>\nUse when:\n- Auditing procedures across the database (brief mode, default).\n- Searching for a procedure by partial name (pass `search`).\n- Inspecting a procedure's language, signature, security mode, owner, comment, and full `CREATE PROCEDURE` text before reasoning about correctness or invocation safety (pass `detailed: true`). Detailed mode supersedes ad-hoc `readQuery` against `pg_proc` / `information_schema.routines`.\n</usecase>\n\n<parameters>\n- `cursor` — Opaque pagination cursor; echo the prior response's `nextCursor`.\n- `search` — Case-insensitive filter on procedure names via `ILIKE`. `%` matches any sequence; `_` matches a single character.\n- `detailed` — When `true`, returns full metadata objects keyed by `name(arguments)` instead of bare name strings. Default `false`.\n</parameters>\n\n<examples>\n✓ \"What procedures are here?\" → listProcedures()\n✓ \"Find the order archival routine\" → listProcedures(search=\"archive\")\n✓ \"What does archive_order do?\" → listProcedures(search=\"archive_order\", detailed=true)\n✗ \"List functions\" → use listFunctions instead\n✗ \"List aggregates\" → not supported; aggregates are excluded\n</examples>\n\n<what_it_returns>\nBrief mode (default): a sorted JSON array of procedure-name strings, e.g. `[\"archive_order\", \"archive_order_history\", \"archive_order_history\"]`. Overloaded procedures appear as one entry per overload (duplicate name strings allowed).\nDetailed mode: a JSON object keyed by procedure signature `name(arguments)`; each value carries `schema`, `name`, `language`, `arguments`, `security` (INVOKER/DEFINER), `owner`, `description` (or null when no `COMMENT ON PROCEDURE`), and `definition` (the full `CREATE OR REPLACE PROCEDURE` text). Overloads occupy distinct keys (e.g. `archive_order_history(integer)` vs `archive_order_history(integer, boolean)`). Zero-arg procedures key as `name()` — the parens are always present so the key shape stays uniform.\n\nDetailed mode deliberately omits the `listFunctions`-only fields `returnType`, `volatility`, `strict`, and `parallelSafety`: procedures don't return a value, `pg_proc.provolatile` / `proisstrict` are not user-settable for procedures, and `proparallel` carries no procedure-level guarantee in PostgreSQL.\n</what_it_returns>\n\n<pagination>\nPaginated. Pass the prior response's `nextCursor` as `cursor` to fetch the next page. The `search` filter must stay the same across pages for cursor continuity. Brief and detailed modes share the same `(proname, oid)` row order, so a client can switch `detailed` between pages without losing position.\n</pagination>\n",
     "inputSchema": {
-      "$schema": "https://json-schema.org/draft/2020-12/schema",
-      "description": "Request for the Postgres `listProcedures` tool — extends the shared shape with `search` and `detailed`.",
       "properties": {
         "cursor": {
           "default": null,
@@ -243,12 +210,18 @@ expression: tools
           ]
         }
       },
-      "title": "ListProceduresRequest",
       "type": "object"
     },
     "outputSchema": {
-      "$defs": {
-        "ListEntries": {
+      "properties": {
+        "nextCursor": {
+          "description": "Opaque cursor pointing to the next page. Absent when this is the final page.",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "procedures": {
           "anyOf": [
             {
               "description": "Brief mode: sorted array of bare entity-name strings.",
@@ -263,28 +236,12 @@ expression: tools
               "type": "object"
             }
           ],
-          "description": "Two-shape listing payload: bare names in brief mode, name-keyed metadata in detailed mode.\n\nShared by [`ListTablesResponse`] and [`ListTriggersResponse`]. Serialises untagged:\nbrief mode → JSON array of strings, detailed mode → JSON object whose keys are\nentity names and whose values are the per-entity metadata."
-        }
-      },
-      "$schema": "https://json-schema.org/draft/2020-12/schema",
-      "description": "Response for the `listProcedures` tool.",
-      "properties": {
-        "nextCursor": {
-          "description": "Opaque cursor pointing to the next page. Absent when this is the final page.",
-          "type": [
-            "string",
-            "null"
-          ]
-        },
-        "procedures": {
-          "$ref": "#/$defs/ListEntries",
           "description": "Page of matching procedures. Shape depends on the request's `detailed` flag."
         }
       },
       "required": [
         "procedures"
       ],
-      "title": "ListProceduresResponse",
       "type": "object"
     },
     "annotations": {
@@ -299,8 +256,6 @@ expression: tools
     "title": "List Tables",
     "description": "List tables, optionally filtered and/or with full metadata.\n\n<usecase>\nUse when:\n- Exploring the database to find relevant tables (brief mode, default).\n- Searching for a table by partial name (pass `search`).\n- Inspecting a table's columns, constraints, indexes, and triggers before writing a query (pass `detailed: true`). This supersedes the legacy `getTableSchema` tool.\n</usecase>\n\n<parameters>\n- `cursor` — Opaque pagination cursor; echo the prior response's `nextCursor`.\n- `search` — Case-insensitive filter on table names via `ILIKE`. `%` matches any sequence; `_` matches a single character.\n- `detailed` — When `true`, returns full metadata objects keyed by table name instead of bare name strings. Default `false`.\n</parameters>\n\n<examples>\n✓ \"What tables are here?\" → listTables()\n✓ \"Find the orders table\" → listTables(search=\"order\")\n✓ \"What columns does orders have?\" → listTables(search=\"orders\", detailed=true)\n</examples>\n\n<what_it_returns>\nBrief mode (default): a sorted JSON array of table-name strings, e.g. `[\"customers\", \"orders\"]`.\nDetailed mode: a JSON object keyed by table name; each value carries `schema`, `kind`, `owner`, `comment`, `columns`, `constraints`, `indexes`, and `triggers` (the name is the key and is not repeated inside the value). Keys iterate in the same alphabetical order brief mode uses. Example: `{\"orders\": {\"schema\": \"public\", \"kind\": \"TABLE\", …}}`.\n</what_it_returns>\n\n<pagination>\nPaginated. Pass the prior response's `nextCursor` as `cursor` to fetch the next page. The `search` filter must stay the same across pages for cursor continuity.\n</pagination>\n",
     "inputSchema": {
-      "$schema": "https://json-schema.org/draft/2020-12/schema",
-      "description": "Request for the Postgres `listTables` tool — extends the shared shape with `search` and `detailed`.",
       "properties": {
         "cursor": {
           "default": null,
@@ -324,12 +279,18 @@ expression: tools
           ]
         }
       },
-      "title": "ListTablesRequest",
       "type": "object"
     },
     "outputSchema": {
-      "$defs": {
-        "ListEntries": {
+      "properties": {
+        "nextCursor": {
+          "description": "Opaque cursor pointing to the next page. Absent when this is the final page.",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "tables": {
           "anyOf": [
             {
               "description": "Brief mode: sorted array of bare entity-name strings.",
@@ -344,28 +305,12 @@ expression: tools
               "type": "object"
             }
           ],
-          "description": "Two-shape listing payload: bare names in brief mode, name-keyed metadata in detailed mode.\n\nShared by [`ListTablesResponse`] and [`ListTriggersResponse`]. Serialises untagged:\nbrief mode → JSON array of strings, detailed mode → JSON object whose keys are\nentity names and whose values are the per-entity metadata."
-        }
-      },
-      "$schema": "https://json-schema.org/draft/2020-12/schema",
-      "description": "Response for the `listTables` tool.",
-      "properties": {
-        "nextCursor": {
-          "description": "Opaque cursor pointing to the next page. Absent when this is the final page.",
-          "type": [
-            "string",
-            "null"
-          ]
-        },
-        "tables": {
-          "$ref": "#/$defs/ListEntries",
           "description": "Page of matching tables. Shape depends on the request's `detailed` flag."
         }
       },
       "required": [
         "tables"
       ],
-      "title": "ListTablesResponse",
       "type": "object"
     },
     "annotations": {
@@ -380,8 +325,6 @@ expression: tools
     "title": "List Triggers",
     "description": "List user-defined triggers in the `public` schema, optionally filtered and/or with full metadata.\n\n<usecase>\nUse when:\n- Auditing triggers across the database (brief mode, default).\n- Searching for a trigger by partial name (pass `search`).\n- Inspecting a trigger's timing, events, activation level, handler function, status, and full `CREATE TRIGGER` text before reasoning about side-effects (pass `detailed: true`). Detailed mode supersedes ad-hoc `readQuery` against `pg_trigger` / `information_schema.triggers`.\n</usecase>\n\n<parameters>\n- `cursor` — Opaque pagination cursor; echo the prior response's `nextCursor`.\n- `search` — Case-insensitive filter on trigger names via `ILIKE`. `%` matches any sequence; `_` matches a single character.\n- `detailed` — When `true`, returns full metadata objects keyed by trigger name instead of bare name strings. Default `false`.\n</parameters>\n\n<examples>\n✓ \"What triggers are here?\" → listTriggers()\n✓ \"Find the audit triggers\" → listTriggers(search=\"audit\")\n✓ \"What does orders_audit_after_iu do?\" → listTriggers(search=\"orders_audit_after_iu\", detailed=true)\n✗ \"Show me a trigger's body\" → use detailed mode; the `definition` field carries the full `CREATE TRIGGER` text\n</examples>\n\n<what_it_returns>\nBrief mode (default): a sorted JSON array of trigger-name strings, e.g. `[\"customers_audit_after_insert\", \"orders_audit_after_insert\"]`.\nDetailed mode: a JSON object keyed by trigger name; each value carries `schema`, `table`, `status` (ENABLED/DISABLED/REPLICA/ALWAYS), `timing` (BEFORE/AFTER/INSTEAD OF), `events` (array of strings drawn from INSERT/UPDATE/DELETE/TRUNCATE in that fixed order), `activationLevel` (ROW/STATEMENT), `functionName`, and `definition` (the full `CREATE TRIGGER` text). Internal triggers (FK enforcement etc.) are excluded.\n</what_it_returns>\n\n<pagination>\nPaginated. Pass the prior response's `nextCursor` as `cursor` to fetch the next page. The `search` filter must stay the same across pages for cursor continuity.\n</pagination>\n",
     "inputSchema": {
-      "$schema": "https://json-schema.org/draft/2020-12/schema",
-      "description": "Request for the `listTriggers` tool.",
       "properties": {
         "cursor": {
           "default": null,
@@ -405,12 +348,18 @@ expression: tools
           ]
         }
       },
-      "title": "ListTriggersRequest",
       "type": "object"
     },
     "outputSchema": {
-      "$defs": {
-        "ListEntries": {
+      "properties": {
+        "nextCursor": {
+          "description": "Opaque cursor pointing to the next page. Absent when this is the final page.",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "triggers": {
           "anyOf": [
             {
               "description": "Brief mode: sorted array of bare entity-name strings.",
@@ -425,28 +374,12 @@ expression: tools
               "type": "object"
             }
           ],
-          "description": "Two-shape listing payload: bare names in brief mode, name-keyed metadata in detailed mode.\n\nShared by [`ListTablesResponse`] and [`ListTriggersResponse`]. Serialises untagged:\nbrief mode → JSON array of strings, detailed mode → JSON object whose keys are\nentity names and whose values are the per-entity metadata."
-        }
-      },
-      "$schema": "https://json-schema.org/draft/2020-12/schema",
-      "description": "Response for the `listTriggers` tool.",
-      "properties": {
-        "nextCursor": {
-          "description": "Opaque cursor pointing to the next page. Absent when this is the final page.",
-          "type": [
-            "string",
-            "null"
-          ]
-        },
-        "triggers": {
-          "$ref": "#/$defs/ListEntries",
           "description": "Page of matching triggers. Shape depends on the request's `detailed` flag."
         }
       },
       "required": [
         "triggers"
       ],
-      "title": "ListTriggersResponse",
       "type": "object"
     },
     "annotations": {
@@ -461,8 +394,6 @@ expression: tools
     "title": "List Views",
     "description": "List user-defined views in the `public` schema, optionally filtered and/or with full metadata. Materialized views and system-schema views are excluded.\n\n<usecase>\nUse when:\n- Auditing views across the database (brief mode, default).\n- Searching for a view by partial name (pass `search`).\n- Inspecting a view's owner, comment, and full SELECT body before querying it (pass `detailed: true`). Detailed mode supersedes ad-hoc `readQuery` against `pg_views` / `pg_class`.\n</usecase>\n\n<parameters>\n- `cursor` — Opaque pagination cursor; echo the prior response's `nextCursor`.\n- `search` — Case-insensitive filter on view names via `ILIKE`. `%` matches any sequence; `_` matches a single character.\n- `detailed` — When `true`, returns full metadata objects keyed by bare view name instead of bare name strings. Default `false`.\n</parameters>\n\n<examples>\n✓ \"What views are here?\" → listViews()\n✓ \"Find the active-users view\" → listViews(search=\"active\")\n✓ \"What does active_users select?\" → listViews(search=\"active_users\", detailed=true)\n✗ \"Show me the columns of a view\" → use listTables with `detailed: true` instead\n✗ \"List materialized views\" → use listMaterializedViews\n</examples>\n\n<what_it_returns>\nBrief mode (default): a sorted JSON array of view-name strings, e.g. `[\"active_orders\", \"active_users\"]`. View names are unique per schema, so no duplicates appear.\nDetailed mode: a JSON object keyed by bare view name; each value carries `schema`, `owner`, `description` (or null when no `COMMENT ON VIEW`), and `definition` (the SELECT body verbatim from `pg_views.definition`, with no `CREATE VIEW` wrapper). The view name is the map key only — it is not repeated inside the value.\n\nDetailed mode deliberately omits column metadata (`columns`), the `name` field (already the key), and view-level options (`security_barrier`, `security_invoker`, `WITH CHECK OPTION`). Column shape is recoverable from the `definition` text or via `listTables(detailed=true)` since Postgres exposes views in `pg_class`.\n</what_it_returns>\n\n<pagination>\nPaginated. Pass the prior response's `nextCursor` as `cursor` to fetch the next page. The `search` filter must stay the same across pages for cursor continuity. Brief and detailed modes share the same `viewname` row order, so a client can switch `detailed` between pages without losing position.\n</pagination>\n",
     "inputSchema": {
-      "$schema": "https://json-schema.org/draft/2020-12/schema",
-      "description": "Request for the Postgres `listViews` tool — extends the shared shape with `search` and `detailed`.",
       "properties": {
         "cursor": {
           "default": null,
@@ -486,12 +417,18 @@ expression: tools
           ]
         }
       },
-      "title": "ListViewsRequest",
       "type": "object"
     },
     "outputSchema": {
-      "$defs": {
-        "ListEntries": {
+      "properties": {
+        "nextCursor": {
+          "description": "Opaque cursor pointing to the next page. Absent when this is the final page.",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "views": {
           "anyOf": [
             {
               "description": "Brief mode: sorted array of bare entity-name strings.",
@@ -506,28 +443,12 @@ expression: tools
               "type": "object"
             }
           ],
-          "description": "Two-shape listing payload: bare names in brief mode, name-keyed metadata in detailed mode.\n\nShared by [`ListTablesResponse`] and [`ListTriggersResponse`]. Serialises untagged:\nbrief mode → JSON array of strings, detailed mode → JSON object whose keys are\nentity names and whose values are the per-entity metadata."
-        }
-      },
-      "$schema": "https://json-schema.org/draft/2020-12/schema",
-      "description": "Response for the `listViews` tool.",
-      "properties": {
-        "nextCursor": {
-          "description": "Opaque cursor pointing to the next page. Absent when this is the final page.",
-          "type": [
-            "string",
-            "null"
-          ]
-        },
-        "views": {
-          "$ref": "#/$defs/ListEntries",
           "description": "Page of matching views. Shape depends on the request's `detailed` flag."
         }
       },
       "required": [
         "views"
       ],
-      "title": "ListViewsResponse",
       "type": "object"
     },
     "annotations": {
@@ -542,8 +463,6 @@ expression: tools
     "title": "Read Query",
     "description": "Execute a read-only SQL query. Allowed statements: SELECT, SHOW, EXPLAIN.\n\n<usecase>\nUse when:\n- Querying data from tables (SELECT with WHERE, JOIN, GROUP BY, etc.)\n- Aggregations: COUNT, SUM, AVG, GROUP BY, HAVING\n- Listing server configuration parameters (SHOW)\n</usecase>\n\n<when_not_to_use>\n- Data changes (INSERT, UPDATE, DELETE) → use writeQuery\n- Query performance analysis → use explainQuery\n- Discovering tables or columns → use listTables (pass `detailed: true` to get columns, keys, and indexes)\n</when_not_to_use>\n\n<examples>\n✓ \"SELECT * FROM users WHERE status = 'active'\"\n✓ \"SELECT COUNT(*) FROM orders GROUP BY region\"\n✓ \"SHOW server_version\"\n✗ \"INSERT INTO users ...\" → use writeQuery\n✗ \"EXPLAIN SELECT ...\" → use explainQuery for structured analysis\n</examples>\n\n<what_it_returns>\nA JSON array of row objects, each keyed by column name.\n</what_it_returns>\n\n<pagination>\n`SELECT` results are paginated. Pass the prior response's `nextCursor` as `cursor` to fetch the next page. `SHOW` and `EXPLAIN` return a single page and ignore `cursor`.\n</pagination>",
     "inputSchema": {
-      "$schema": "https://json-schema.org/draft/2020-12/schema",
-      "description": "Request for the `readQuery` tool.",
       "properties": {
         "cursor": {
           "default": null,
@@ -561,12 +480,9 @@ expression: tools
       "required": [
         "query"
       ],
-      "title": "ReadQueryRequest",
       "type": "object"
     },
     "outputSchema": {
-      "$schema": "https://json-schema.org/draft/2020-12/schema",
-      "description": "Response for the `readQuery` tool.",
       "properties": {
         "nextCursor": {
           "description": "Opaque cursor pointing to the next page. Absent when this is the final\npage, when the result fits in one page, or when the statement is a\nnon-`SELECT` kind that does not paginate (e.g. `SHOW`, `EXPLAIN`).",
@@ -584,7 +500,6 @@ expression: tools
       "required": [
         "rows"
       ],
-      "title": "ReadQueryResponse",
       "type": "object"
     },
     "annotations": {

--- a/tests/approval/snapshots/approval_postgres__list_tools_read_only_unpinned.snap
+++ b/tests/approval/snapshots/approval_postgres__list_tools_read_only_unpinned.snap
@@ -8,8 +8,6 @@ expression: tools
     "title": "Explain Query",
     "description": "Return the execution plan for a SQL query to diagnose performance. Use this tool instead of running EXPLAIN directly through readQuery — it provides structured JSON output.\n\n<usecase>\nUse when:\n- A query runs slowly and you need to understand why\n- Investigating performance bottlenecks\n- Planning index creation to optimize queries\n- Analyzing join methods, table scan strategies, and sort operations\n</usecase>\n\n<when_not_to_use>\n- Running actual queries → use readQuery or writeQuery\n- Checking table structure → use listTables(detailed=true)\n</when_not_to_use>\n\n<examples>\n✓ \"Why is my SELECT on orders slow?\" → explainQuery(query=\"SELECT ...\")\n✓ \"Should I add an index?\" → explainQuery with analyze=true\n✗ \"Run this SELECT\" → use readQuery\n</examples>\n\n<safety>\nSet `analyze` to true for actual execution statistics (EXPLAIN ANALYZE).\nIMPORTANT: EXPLAIN ANALYZE actually executes the query! In read-only mode, only read-only statements are allowed with analyze.\nWhen analyze is false, returns EXPLAIN (FORMAT JSON) output without executing.\n</safety>\n\n<what_it_returns>\nA JSON array of execution plan rows showing access methods, join types, row estimates, and costs.\n</what_it_returns>",
     "inputSchema": {
-      "$schema": "https://json-schema.org/draft/2020-12/schema",
-      "description": "Request for the `explainQuery` tool.",
       "properties": {
         "analyze": {
           "default": false,
@@ -32,12 +30,9 @@ expression: tools
       "required": [
         "query"
       ],
-      "title": "ExplainQueryRequest",
       "type": "object"
     },
     "outputSchema": {
-      "$schema": "https://json-schema.org/draft/2020-12/schema",
-      "description": "Response for the `writeQuery` and `explainQuery` tools.",
       "properties": {
         "rows": {
           "description": "Result rows, each a JSON object keyed by a column name.",
@@ -48,7 +43,6 @@ expression: tools
       "required": [
         "rows"
       ],
-      "title": "QueryResponse",
       "type": "object"
     },
     "annotations": {
@@ -63,8 +57,6 @@ expression: tools
     "title": "List Databases",
     "description": "List all accessible databases on the connected server. Use this tool to discover what databases are available before using other tools.\n\n<usecase>\nALWAYS call this tool FIRST when:\n- You need to explore what databases exist on the server\n- You need a database name for listTables or query tools\n- The user asks what data is available\n</usecase>\n\n<examples>\n✓ \"What databases are on this server?\"\n✓ \"Show me what's available\" → call listDatabases first\n</examples>\n\n<what_it_returns>\nA sorted JSON array of database name strings.\n</what_it_returns>\n\n<pagination>\nPaginated. Pass the prior response's `nextCursor` as `cursor` to fetch the next page.\n</pagination>",
     "inputSchema": {
-      "$schema": "https://json-schema.org/draft/2020-12/schema",
-      "description": "Request for the `listDatabases` tool.",
       "properties": {
         "cursor": {
           "default": null,
@@ -75,12 +67,9 @@ expression: tools
           ]
         }
       },
-      "title": "ListDatabasesRequest",
       "type": "object"
     },
     "outputSchema": {
-      "$schema": "https://json-schema.org/draft/2020-12/schema",
-      "description": "Response for the `listDatabases` tool.",
       "properties": {
         "databases": {
           "description": "Sorted list of database names for this page.",
@@ -100,7 +89,6 @@ expression: tools
       "required": [
         "databases"
       ],
-      "title": "ListDatabasesResponse",
       "type": "object"
     },
     "annotations": {
@@ -115,8 +103,6 @@ expression: tools
     "title": "List Functions",
     "description": "List user-defined functions in the `public` schema, optionally filtered and/or with full metadata. Aggregates, window functions, and procedures are excluded.\n\n<usecase>\nUse when:\n- Auditing functions across a database (brief mode, default).\n- Searching for a function by partial name (pass `search`).\n- Inspecting a function's language, signature, return type, volatility, strictness, security mode, parallel-safety, owner, comment, and full `CREATE FUNCTION` text before reasoning about correctness or invocation safety (pass `detailed: true`). Detailed mode supersedes ad-hoc `readQuery` against `pg_proc` / `information_schema.routines`.\n</usecase>\n\n<parameters>\n- `database` — Database to target. Defaults to the active database.\n- `cursor` — Opaque pagination cursor; echo the prior response's `nextCursor`.\n- `search` — Case-insensitive filter on function names via `ILIKE`. `%` matches any sequence; `_` matches a single character.\n- `detailed` — When `true`, returns full metadata objects keyed by `name(arguments)` instead of bare name strings. Default `false`.\n</parameters>\n\n<examples>\n✓ \"What functions are in mydb?\" → listFunctions(database=\"mydb\")\n✓ \"Find the order-total calculation\" → listFunctions(search=\"order\")\n✓ \"What does calc_order_total do?\" → listFunctions(search=\"calc_order_total\", detailed=true)\n✗ \"List stored procedures\" → use listProcedures instead\n✗ \"List aggregates\" → not supported; aggregates are excluded\n</examples>\n\n<what_it_returns>\nBrief mode (default): a sorted JSON array of function-name strings, e.g. `[\"audit_user_login\", \"calc_order_subtotal\", \"calc_order_total\", \"calc_order_total\"]`. Overloaded functions appear as one entry per overload (duplicate name strings allowed).\nDetailed mode: a JSON object keyed by function signature `name(arguments)`; each value carries `schema`, `name`, `language`, `arguments`, `returnType`, `volatility` (IMMUTABLE/STABLE/VOLATILE), `strict` (boolean), `security` (INVOKER/DEFINER), `parallelSafety` (SAFE/RESTRICTED/UNSAFE), `owner`, `description` (or null when no `COMMENT ON FUNCTION`), and `definition` (the full `CREATE OR REPLACE FUNCTION` text). Overloads occupy distinct keys (e.g. `calc_total(integer)` vs `calc_total(integer, numeric)`).\n</what_it_returns>\n\n<pagination>\nPaginated. Pass the prior response's `nextCursor` as `cursor` to fetch the next page. The `search` filter must stay the same across pages for cursor continuity. Brief and detailed modes share the same `(proname, oid)` row order, so a client can switch `detailed` between pages without losing position.\n</pagination>",
     "inputSchema": {
-      "$schema": "https://json-schema.org/draft/2020-12/schema",
-      "description": "Request for the Postgres `listFunctions` tool — extends the shared shape with `search` and `detailed`.",
       "properties": {
         "cursor": {
           "default": null,
@@ -148,12 +134,11 @@ expression: tools
           ]
         }
       },
-      "title": "ListFunctionsRequest",
       "type": "object"
     },
     "outputSchema": {
-      "$defs": {
-        "ListEntries": {
+      "properties": {
+        "functions": {
           "anyOf": [
             {
               "description": "Brief mode: sorted array of bare entity-name strings.",
@@ -168,14 +153,6 @@ expression: tools
               "type": "object"
             }
           ],
-          "description": "Two-shape listing payload: bare names in brief mode, name-keyed metadata in detailed mode.\n\nShared by [`ListTablesResponse`] and [`ListTriggersResponse`]. Serialises untagged:\nbrief mode → JSON array of strings, detailed mode → JSON object whose keys are\nentity names and whose values are the per-entity metadata."
-        }
-      },
-      "$schema": "https://json-schema.org/draft/2020-12/schema",
-      "description": "Response for the `listFunctions` tool.",
-      "properties": {
-        "functions": {
-          "$ref": "#/$defs/ListEntries",
           "description": "Page of matching functions. Shape depends on the request's `detailed` flag."
         },
         "nextCursor": {
@@ -189,7 +166,6 @@ expression: tools
       "required": [
         "functions"
       ],
-      "title": "ListFunctionsResponse",
       "type": "object"
     },
     "annotations": {
@@ -204,8 +180,6 @@ expression: tools
     "title": "List Materialized Views",
     "description": "List materialized views in the `public` schema, optionally filtered and/or with full metadata. Unlike regular views, materialized views store their results physically and must be refreshed explicitly. Regular views and system-schema matviews are excluded.\n\n<usecase>\nUse when:\n- Auditing materialized views across a database (brief mode, default).\n- Searching for a matview by partial name (pass `search`).\n- Inspecting a matview's owner, comment, full SELECT body, populated state, and index presence before querying or refreshing it (pass `detailed: true`). Detailed mode supersedes ad-hoc `readQuery` against `pg_matviews` / `pg_class`.\n</usecase>\n\n<parameters>\n- `database` — Database to target. Defaults to the active database.\n- `cursor` — Opaque pagination cursor; echo the prior response's `nextCursor`.\n- `search` — Case-insensitive filter on matview names via `ILIKE`. `%` matches any sequence; `_` matches a single character.\n- `detailed` — When `true`, returns full metadata objects keyed by bare matview name instead of bare name strings. Default `false`.\n</parameters>\n\n<examples>\n✓ \"What materialized views are in mydb?\" → listMaterializedViews(database=\"mydb\")\n✓ \"Find the recent-orders matview\" → listMaterializedViews(search=\"orders\")\n✓ \"What does mv_orders_by_region compute?\" → listMaterializedViews(search=\"mv_orders_by_region\", detailed=true)\n✓ \"Has the cache matview ever been refreshed?\" → listMaterializedViews(search=\"cache\", detailed=true) — read `populated`\n✓ \"Which matviews can I refresh concurrently?\" → listMaterializedViews(detailed=true) — read `indexed` (CONCURRENTLY additionally needs a unique index)\n✗ \"List regular views\" → use listViews instead\n</examples>\n\n<what_it_returns>\nBrief mode (default): a sorted JSON array of matview-name strings, e.g. `[\"mv_archived_orders\", \"mv_recent_orders\"]`. Matview names are unique per schema, so no duplicates appear.\nDetailed mode: a JSON object keyed by bare matview name; each value carries:\n- `schema` — schema name (always `\"public\"` in this build).\n- `owner` — owning role's name from `pg_matviews.matviewowner`.\n- `description` — `COMMENT ON MATERIALIZED VIEW` text, or `null` when no comment.\n- `definition` — the SELECT body verbatim from `pg_matviews.definition`, with no `CREATE MATERIALIZED VIEW` wrapper.\n- `populated` — `true` once the matview has been refreshed at least once. `false` for matviews created `WITH NO DATA` and never refreshed; querying such a matview returns zero rows until `REFRESH MATERIALIZED VIEW` runs.\n- `indexed` — `true` when at least one index exists on the matview. `REFRESH MATERIALIZED VIEW CONCURRENTLY` additionally requires a unique index; this tool reports the broader has-any-index signal.\n\nThe matview name is the map key only — it is not repeated inside the value. Detailed mode deliberately omits column metadata (`columns`), `tablespace`, storage parameters, and unique-index detection. Column shape is recoverable from the `definition` text or via `listTables(detailed=true)` since Postgres exposes matviews in `pg_class`.\n</what_it_returns>\n\n<pagination>\nPaginated. Pass the prior response's `nextCursor` as `cursor` to fetch the next page. The `search` filter must stay the same across pages for cursor continuity. Brief and detailed modes share the same `matviewname` row order, so a client can switch `detailed` between pages without losing position.\n</pagination>",
     "inputSchema": {
-      "$schema": "https://json-schema.org/draft/2020-12/schema",
-      "description": "Request for the Postgres `listMaterializedViews` tool — extends the shared shape with `search` and `detailed`.",
       "properties": {
         "cursor": {
           "default": null,
@@ -237,12 +211,11 @@ expression: tools
           ]
         }
       },
-      "title": "ListMaterializedViewsRequest",
       "type": "object"
     },
     "outputSchema": {
-      "$defs": {
-        "ListEntries": {
+      "properties": {
+        "materializedViews": {
           "anyOf": [
             {
               "description": "Brief mode: sorted array of bare entity-name strings.",
@@ -257,14 +230,6 @@ expression: tools
               "type": "object"
             }
           ],
-          "description": "Two-shape listing payload: bare names in brief mode, name-keyed metadata in detailed mode.\n\nShared by [`ListTablesResponse`] and [`ListTriggersResponse`]. Serialises untagged:\nbrief mode → JSON array of strings, detailed mode → JSON object whose keys are\nentity names and whose values are the per-entity metadata."
-        }
-      },
-      "$schema": "https://json-schema.org/draft/2020-12/schema",
-      "description": "Response for the `listMaterializedViews` tool.",
-      "properties": {
-        "materializedViews": {
-          "$ref": "#/$defs/ListEntries",
           "description": "Page of matching materialized views. Shape depends on the request's `detailed` flag."
         },
         "nextCursor": {
@@ -278,7 +243,6 @@ expression: tools
       "required": [
         "materializedViews"
       ],
-      "title": "ListMaterializedViewsResponse",
       "type": "object"
     },
     "annotations": {
@@ -293,8 +257,6 @@ expression: tools
     "title": "List Procedures",
     "description": "List user-defined procedures in the `public` schema, optionally filtered and/or with full metadata. Functions, aggregates, and window functions are excluded.\n\n<usecase>\nUse when:\n- Auditing procedures across a database (brief mode, default).\n- Searching for a procedure by partial name (pass `search`).\n- Inspecting a procedure's language, signature, security mode, owner, comment, and full `CREATE PROCEDURE` text before reasoning about correctness or invocation safety (pass `detailed: true`). Detailed mode supersedes ad-hoc `readQuery` against `pg_proc` / `information_schema.routines`.\n</usecase>\n\n<parameters>\n- `database` — Database to target. Defaults to the active database.\n- `cursor` — Opaque pagination cursor; echo the prior response's `nextCursor`.\n- `search` — Case-insensitive filter on procedure names via `ILIKE`. `%` matches any sequence; `_` matches a single character.\n- `detailed` — When `true`, returns full metadata objects keyed by `name(arguments)` instead of bare name strings. Default `false`.\n</parameters>\n\n<examples>\n✓ \"What procedures are in mydb?\" → listProcedures(database=\"mydb\")\n✓ \"Find the order archival routine\" → listProcedures(search=\"archive\")\n✓ \"What does archive_order do?\" → listProcedures(search=\"archive_order\", detailed=true)\n✗ \"List functions\" → use listFunctions instead\n✗ \"List aggregates\" → not supported; aggregates are excluded\n</examples>\n\n<what_it_returns>\nBrief mode (default): a sorted JSON array of procedure-name strings, e.g. `[\"archive_order\", \"archive_order_history\", \"archive_order_history\"]`. Overloaded procedures appear as one entry per overload (duplicate name strings allowed).\nDetailed mode: a JSON object keyed by procedure signature `name(arguments)`; each value carries `schema`, `name`, `language`, `arguments`, `security` (INVOKER/DEFINER), `owner`, `description` (or null when no `COMMENT ON PROCEDURE`), and `definition` (the full `CREATE OR REPLACE PROCEDURE` text). Overloads occupy distinct keys (e.g. `archive_order_history(integer)` vs `archive_order_history(integer, boolean)`). Zero-arg procedures key as `name()` — the parens are always present so the key shape stays uniform.\n\nDetailed mode deliberately omits the `listFunctions`-only fields `returnType`, `volatility`, `strict`, and `parallelSafety`: procedures don't return a value, `pg_proc.provolatile` / `proisstrict` are not user-settable for procedures, and `proparallel` carries no procedure-level guarantee in PostgreSQL.\n</what_it_returns>\n\n<pagination>\nPaginated. Pass the prior response's `nextCursor` as `cursor` to fetch the next page. The `search` filter must stay the same across pages for cursor continuity. Brief and detailed modes share the same `(proname, oid)` row order, so a client can switch `detailed` between pages without losing position.\n</pagination>",
     "inputSchema": {
-      "$schema": "https://json-schema.org/draft/2020-12/schema",
-      "description": "Request for the Postgres `listProcedures` tool — extends the shared shape with `search` and `detailed`.",
       "properties": {
         "cursor": {
           "default": null,
@@ -326,12 +288,18 @@ expression: tools
           ]
         }
       },
-      "title": "ListProceduresRequest",
       "type": "object"
     },
     "outputSchema": {
-      "$defs": {
-        "ListEntries": {
+      "properties": {
+        "nextCursor": {
+          "description": "Opaque cursor pointing to the next page. Absent when this is the final page.",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "procedures": {
           "anyOf": [
             {
               "description": "Brief mode: sorted array of bare entity-name strings.",
@@ -346,28 +314,12 @@ expression: tools
               "type": "object"
             }
           ],
-          "description": "Two-shape listing payload: bare names in brief mode, name-keyed metadata in detailed mode.\n\nShared by [`ListTablesResponse`] and [`ListTriggersResponse`]. Serialises untagged:\nbrief mode → JSON array of strings, detailed mode → JSON object whose keys are\nentity names and whose values are the per-entity metadata."
-        }
-      },
-      "$schema": "https://json-schema.org/draft/2020-12/schema",
-      "description": "Response for the `listProcedures` tool.",
-      "properties": {
-        "nextCursor": {
-          "description": "Opaque cursor pointing to the next page. Absent when this is the final page.",
-          "type": [
-            "string",
-            "null"
-          ]
-        },
-        "procedures": {
-          "$ref": "#/$defs/ListEntries",
           "description": "Page of matching procedures. Shape depends on the request's `detailed` flag."
         }
       },
       "required": [
         "procedures"
       ],
-      "title": "ListProceduresResponse",
       "type": "object"
     },
     "annotations": {
@@ -382,8 +334,6 @@ expression: tools
     "title": "List Tables",
     "description": "List tables in a database, optionally filtered and/or with full metadata.\n\n<usecase>\nUse when:\n- Exploring a database to find relevant tables (brief mode, default).\n- Searching for a table by partial name (pass `search`).\n- Inspecting a table's columns, constraints, indexes, and triggers before writing a query (pass `detailed: true`). This supersedes the legacy `getTableSchema` tool.\n</usecase>\n\n<parameters>\n- `database` — Database to target. Defaults to the active database.\n- `cursor` — Opaque pagination cursor; echo the prior response's `nextCursor`.\n- `search` — Case-insensitive filter on table names via `ILIKE`. `%` matches any sequence; `_` matches a single character.\n- `detailed` — When `true`, returns full metadata objects keyed by table name instead of bare name strings. Default `false`.\n</parameters>\n\n<examples>\n✓ \"What tables are in mydb?\" → listTables(database=\"mydb\")\n✓ \"Find the orders table\" → listTables(search=\"order\")\n✓ \"What columns does orders have?\" → listTables(search=\"orders\", detailed=true)\n</examples>\n\n<what_it_returns>\nBrief mode (default): a sorted JSON array of table-name strings, e.g. `[\"customers\", \"orders\"]`.\nDetailed mode: a JSON object keyed by table name; each value carries `schema`, `kind`, `owner`, `comment`, `columns`, `constraints`, `indexes`, and `triggers` (the name is the key and is not repeated inside the value). Keys iterate in the same alphabetical order brief mode uses. Example: `{\"orders\": {\"schema\": \"public\", \"kind\": \"TABLE\", …}}`.\n</what_it_returns>\n\n<pagination>\nPaginated. Pass the prior response's `nextCursor` as `cursor` to fetch the next page. The `search` filter must stay the same across pages for cursor continuity.\n</pagination>",
     "inputSchema": {
-      "$schema": "https://json-schema.org/draft/2020-12/schema",
-      "description": "Request for the Postgres `listTables` tool — extends the shared shape with `search` and `detailed`.",
       "properties": {
         "cursor": {
           "default": null,
@@ -415,12 +365,18 @@ expression: tools
           ]
         }
       },
-      "title": "ListTablesRequest",
       "type": "object"
     },
     "outputSchema": {
-      "$defs": {
-        "ListEntries": {
+      "properties": {
+        "nextCursor": {
+          "description": "Opaque cursor pointing to the next page. Absent when this is the final page.",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "tables": {
           "anyOf": [
             {
               "description": "Brief mode: sorted array of bare entity-name strings.",
@@ -435,28 +391,12 @@ expression: tools
               "type": "object"
             }
           ],
-          "description": "Two-shape listing payload: bare names in brief mode, name-keyed metadata in detailed mode.\n\nShared by [`ListTablesResponse`] and [`ListTriggersResponse`]. Serialises untagged:\nbrief mode → JSON array of strings, detailed mode → JSON object whose keys are\nentity names and whose values are the per-entity metadata."
-        }
-      },
-      "$schema": "https://json-schema.org/draft/2020-12/schema",
-      "description": "Response for the `listTables` tool.",
-      "properties": {
-        "nextCursor": {
-          "description": "Opaque cursor pointing to the next page. Absent when this is the final page.",
-          "type": [
-            "string",
-            "null"
-          ]
-        },
-        "tables": {
-          "$ref": "#/$defs/ListEntries",
           "description": "Page of matching tables. Shape depends on the request's `detailed` flag."
         }
       },
       "required": [
         "tables"
       ],
-      "title": "ListTablesResponse",
       "type": "object"
     },
     "annotations": {
@@ -471,8 +411,6 @@ expression: tools
     "title": "List Triggers",
     "description": "List user-defined triggers in the `public` schema, optionally filtered and/or with full metadata.\n\n<usecase>\nUse when:\n- Auditing triggers across a database (brief mode, default).\n- Searching for a trigger by partial name (pass `search`).\n- Inspecting a trigger's timing, events, activation level, handler function, status, and full `CREATE TRIGGER` text before reasoning about side-effects (pass `detailed: true`). Detailed mode supersedes ad-hoc `readQuery` against `pg_trigger` / `information_schema.triggers`.\n</usecase>\n\n<parameters>\n- `database` — Database to target. Defaults to the active database.\n- `cursor` — Opaque pagination cursor; echo the prior response's `nextCursor`.\n- `search` — Case-insensitive filter on trigger names via `ILIKE`. `%` matches any sequence; `_` matches a single character.\n- `detailed` — When `true`, returns full metadata objects keyed by trigger name instead of bare name strings. Default `false`.\n</parameters>\n\n<examples>\n✓ \"What triggers are in the mydb database?\" → listTriggers(database=\"mydb\")\n✓ \"Find the audit triggers\" → listTriggers(search=\"audit\")\n✓ \"What does orders_audit_after_iu do?\" → listTriggers(search=\"orders_audit_after_iu\", detailed=true)\n✗ \"Show me a trigger's body\" → use detailed mode; the `definition` field carries the full `CREATE TRIGGER` text\n</examples>\n\n<what_it_returns>\nBrief mode (default): a sorted JSON array of trigger-name strings, e.g. `[\"customers_audit_after_insert\", \"orders_audit_after_insert\"]`.\nDetailed mode: a JSON object keyed by trigger name; each value carries `schema`, `table`, `status` (ENABLED/DISABLED/REPLICA/ALWAYS), `timing` (BEFORE/AFTER/INSTEAD OF), `events` (array of strings drawn from INSERT/UPDATE/DELETE/TRUNCATE in that fixed order), `activationLevel` (ROW/STATEMENT), `functionName`, and `definition` (the full `CREATE TRIGGER` text). Internal triggers (FK enforcement etc.) are excluded.\n</what_it_returns>\n\n<pagination>\nPaginated. Pass the prior response's `nextCursor` as `cursor` to fetch the next page. The `search` filter must stay the same across pages for cursor continuity.\n</pagination>",
     "inputSchema": {
-      "$schema": "https://json-schema.org/draft/2020-12/schema",
-      "description": "Request for the `listTriggers` tool.",
       "properties": {
         "cursor": {
           "default": null,
@@ -504,12 +442,18 @@ expression: tools
           ]
         }
       },
-      "title": "ListTriggersRequest",
       "type": "object"
     },
     "outputSchema": {
-      "$defs": {
-        "ListEntries": {
+      "properties": {
+        "nextCursor": {
+          "description": "Opaque cursor pointing to the next page. Absent when this is the final page.",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "triggers": {
           "anyOf": [
             {
               "description": "Brief mode: sorted array of bare entity-name strings.",
@@ -524,28 +468,12 @@ expression: tools
               "type": "object"
             }
           ],
-          "description": "Two-shape listing payload: bare names in brief mode, name-keyed metadata in detailed mode.\n\nShared by [`ListTablesResponse`] and [`ListTriggersResponse`]. Serialises untagged:\nbrief mode → JSON array of strings, detailed mode → JSON object whose keys are\nentity names and whose values are the per-entity metadata."
-        }
-      },
-      "$schema": "https://json-schema.org/draft/2020-12/schema",
-      "description": "Response for the `listTriggers` tool.",
-      "properties": {
-        "nextCursor": {
-          "description": "Opaque cursor pointing to the next page. Absent when this is the final page.",
-          "type": [
-            "string",
-            "null"
-          ]
-        },
-        "triggers": {
-          "$ref": "#/$defs/ListEntries",
           "description": "Page of matching triggers. Shape depends on the request's `detailed` flag."
         }
       },
       "required": [
         "triggers"
       ],
-      "title": "ListTriggersResponse",
       "type": "object"
     },
     "annotations": {
@@ -560,8 +488,6 @@ expression: tools
     "title": "List Views",
     "description": "List user-defined views in the `public` schema, optionally filtered and/or with full metadata. Materialized views and system-schema views are excluded.\n\n<usecase>\nUse when:\n- Auditing views across a database (brief mode, default).\n- Searching for a view by partial name (pass `search`).\n- Inspecting a view's owner, comment, and full SELECT body before querying it (pass `detailed: true`). Detailed mode supersedes ad-hoc `readQuery` against `pg_views` / `pg_class`.\n</usecase>\n\n<parameters>\n- `database` — Database to target. Defaults to the active database.\n- `cursor` — Opaque pagination cursor; echo the prior response's `nextCursor`.\n- `search` — Case-insensitive filter on view names via `ILIKE`. `%` matches any sequence; `_` matches a single character.\n- `detailed` — When `true`, returns full metadata objects keyed by bare view name instead of bare name strings. Default `false`.\n</parameters>\n\n<examples>\n✓ \"What views are in mydb?\" → listViews(database=\"mydb\")\n✓ \"Find the active-users view\" → listViews(search=\"active\")\n✓ \"What does active_users select?\" → listViews(search=\"active_users\", detailed=true)\n✗ \"Show me the columns of a view\" → use listTables with `detailed: true` instead\n✗ \"List materialized views\" → use listMaterializedViews\n</examples>\n\n<what_it_returns>\nBrief mode (default): a sorted JSON array of view-name strings, e.g. `[\"active_orders\", \"active_users\"]`. View names are unique per schema, so no duplicates appear.\nDetailed mode: a JSON object keyed by bare view name; each value carries `schema`, `owner`, `description` (or null when no `COMMENT ON VIEW`), and `definition` (the SELECT body verbatim from `pg_views.definition`, with no `CREATE VIEW` wrapper). The view name is the map key only — it is not repeated inside the value.\n\nDetailed mode deliberately omits column metadata (`columns`), the `name` field (already the key), and view-level options (`security_barrier`, `security_invoker`, `WITH CHECK OPTION`). Column shape is recoverable from the `definition` text or via `listTables(detailed=true)` since Postgres exposes views in `pg_class`.\n</what_it_returns>\n\n<pagination>\nPaginated. Pass the prior response's `nextCursor` as `cursor` to fetch the next page. The `search` filter must stay the same across pages for cursor continuity. Brief and detailed modes share the same `viewname` row order, so a client can switch `detailed` between pages without losing position.\n</pagination>",
     "inputSchema": {
-      "$schema": "https://json-schema.org/draft/2020-12/schema",
-      "description": "Request for the Postgres `listViews` tool — extends the shared shape with `search` and `detailed`.",
       "properties": {
         "cursor": {
           "default": null,
@@ -593,12 +519,18 @@ expression: tools
           ]
         }
       },
-      "title": "ListViewsRequest",
       "type": "object"
     },
     "outputSchema": {
-      "$defs": {
-        "ListEntries": {
+      "properties": {
+        "nextCursor": {
+          "description": "Opaque cursor pointing to the next page. Absent when this is the final page.",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "views": {
           "anyOf": [
             {
               "description": "Brief mode: sorted array of bare entity-name strings.",
@@ -613,28 +545,12 @@ expression: tools
               "type": "object"
             }
           ],
-          "description": "Two-shape listing payload: bare names in brief mode, name-keyed metadata in detailed mode.\n\nShared by [`ListTablesResponse`] and [`ListTriggersResponse`]. Serialises untagged:\nbrief mode → JSON array of strings, detailed mode → JSON object whose keys are\nentity names and whose values are the per-entity metadata."
-        }
-      },
-      "$schema": "https://json-schema.org/draft/2020-12/schema",
-      "description": "Response for the `listViews` tool.",
-      "properties": {
-        "nextCursor": {
-          "description": "Opaque cursor pointing to the next page. Absent when this is the final page.",
-          "type": [
-            "string",
-            "null"
-          ]
-        },
-        "views": {
-          "$ref": "#/$defs/ListEntries",
           "description": "Page of matching views. Shape depends on the request's `detailed` flag."
         }
       },
       "required": [
         "views"
       ],
-      "title": "ListViewsResponse",
       "type": "object"
     },
     "annotations": {
@@ -649,8 +565,6 @@ expression: tools
     "title": "Read Query",
     "description": "Execute a read-only SQL query. Allowed statements: SELECT, SHOW, EXPLAIN.\n\n<usecase>\nUse when:\n- Querying data from tables (SELECT with WHERE, JOIN, GROUP BY, etc.)\n- Aggregations: COUNT, SUM, AVG, GROUP BY, HAVING\n- Listing server configuration parameters (SHOW)\n</usecase>\n\n<when_not_to_use>\n- Data changes (INSERT, UPDATE, DELETE) → use writeQuery\n- Query performance analysis → use explainQuery\n- Discovering tables or columns → use listTables (pass `detailed: true` to get columns, keys, and indexes)\n</when_not_to_use>\n\n<examples>\n✓ \"SELECT * FROM users WHERE status = 'active'\"\n✓ \"SELECT COUNT(*) FROM orders GROUP BY region\"\n✓ \"SHOW server_version\"\n✗ \"INSERT INTO users ...\" → use writeQuery\n✗ \"EXPLAIN SELECT ...\" → use explainQuery for structured analysis\n</examples>\n\n<what_it_returns>\nA JSON array of row objects, each keyed by column name.\n</what_it_returns>\n\n<pagination>\n`SELECT` results are paginated. Pass the prior response's `nextCursor` as `cursor` to fetch the next page. `SHOW` and `EXPLAIN` return a single page and ignore `cursor`.\n</pagination>",
     "inputSchema": {
-      "$schema": "https://json-schema.org/draft/2020-12/schema",
-      "description": "Request for the `readQuery` tool.",
       "properties": {
         "cursor": {
           "default": null,
@@ -676,12 +590,9 @@ expression: tools
       "required": [
         "query"
       ],
-      "title": "ReadQueryRequest",
       "type": "object"
     },
     "outputSchema": {
-      "$schema": "https://json-schema.org/draft/2020-12/schema",
-      "description": "Response for the `readQuery` tool.",
       "properties": {
         "nextCursor": {
           "description": "Opaque cursor pointing to the next page. Absent when this is the final\npage, when the result fits in one page, or when the statement is a\nnon-`SELECT` kind that does not paginate (e.g. `SHOW`, `EXPLAIN`).",
@@ -699,7 +610,6 @@ expression: tools
       "required": [
         "rows"
       ],
-      "title": "ReadQueryResponse",
       "type": "object"
     },
     "annotations": {

--- a/tests/approval/snapshots/approval_postgres__list_tools_read_write_pinned.snap
+++ b/tests/approval/snapshots/approval_postgres__list_tools_read_write_pinned.snap
@@ -1,6 +1,5 @@
 ---
 source: tests/approval/postgres.rs
-assertion_line: 82
 expression: tools
 ---
 [
@@ -9,8 +8,6 @@ expression: tools
     "title": "Drop Table",
     "description": "Drop a table. Checks for foreign key dependencies via the database engine.\n\n<usecase>\nUse when:\n- Removing a table that is no longer needed\n- Cleaning up test or temporary tables\n</usecase>\n\n<examples>\n✓ \"Drop the temp_logs table\" → dropTable(table=\"temp_logs\")\n✓ \"Force drop with dependencies\" → dropTable(table=\"temp_logs\", cascade=true)\n✗ \"Delete rows from a table\" → use writeQuery with DELETE\n✗ \"Drop a database\" → use dropDatabase instead\n</examples>\n\n<safety>\nIMPORTANT: This permanently deletes the table and ALL its data. This action cannot be undone.\nSet `cascade` to true to also drop dependent foreign key constraints.\nWithout cascade, the drop will fail if other tables reference this one.\n</safety>\n\n<what_it_returns>\nA confirmation message with the dropped table name.\n</what_it_returns>\n",
     "inputSchema": {
-      "$schema": "https://json-schema.org/draft/2020-12/schema",
-      "description": "Request for the `dropTable` tool.",
       "properties": {
         "cascade": {
           "default": false,
@@ -25,12 +22,9 @@ expression: tools
       "required": [
         "table"
       ],
-      "title": "DropTableRequest",
       "type": "object"
     },
     "outputSchema": {
-      "$schema": "https://json-schema.org/draft/2020-12/schema",
-      "description": "Response for tools with no structured return data.",
       "properties": {
         "message": {
           "description": "Description of the completed operation.",
@@ -40,7 +34,6 @@ expression: tools
       "required": [
         "message"
       ],
-      "title": "MessageResponse",
       "type": "object"
     },
     "annotations": {
@@ -55,8 +48,6 @@ expression: tools
     "title": "Explain Query",
     "description": "Return the execution plan for a SQL query to diagnose performance. Use this tool instead of running EXPLAIN directly through readQuery — it provides structured JSON output.\n\n<usecase>\nUse when:\n- A query runs slowly and you need to understand why\n- Investigating performance bottlenecks\n- Planning index creation to optimize queries\n- Analyzing join methods, table scan strategies, and sort operations\n</usecase>\n\n<when_not_to_use>\n- Running actual queries → use readQuery or writeQuery\n- Checking table structure → use listTables(detailed=true)\n</when_not_to_use>\n\n<examples>\n✓ \"Why is my SELECT on orders slow?\" → explainQuery(query=\"SELECT ...\")\n✓ \"Should I add an index?\" → explainQuery with analyze=true\n✗ \"Run this SELECT\" → use readQuery\n</examples>\n\n<safety>\nSet `analyze` to true for actual execution statistics (EXPLAIN ANALYZE).\nIMPORTANT: EXPLAIN ANALYZE actually executes the query! In read-only mode, only read-only statements are allowed with analyze.\nWhen analyze is false, returns EXPLAIN (FORMAT JSON) output without executing.\n</safety>\n\n<what_it_returns>\nA JSON array of execution plan rows showing access methods, join types, row estimates, and costs.\n</what_it_returns>",
     "inputSchema": {
-      "$schema": "https://json-schema.org/draft/2020-12/schema",
-      "description": "Request for the `explainQuery` tool.",
       "properties": {
         "analyze": {
           "default": false,
@@ -71,12 +62,9 @@ expression: tools
       "required": [
         "query"
       ],
-      "title": "ExplainQueryRequest",
       "type": "object"
     },
     "outputSchema": {
-      "$schema": "https://json-schema.org/draft/2020-12/schema",
-      "description": "Response for the `writeQuery` and `explainQuery` tools.",
       "properties": {
         "rows": {
           "description": "Result rows, each a JSON object keyed by a column name.",
@@ -87,7 +75,6 @@ expression: tools
       "required": [
         "rows"
       ],
-      "title": "QueryResponse",
       "type": "object"
     },
     "annotations": {
@@ -102,8 +89,6 @@ expression: tools
     "title": "List Functions",
     "description": "List user-defined functions in the `public` schema, optionally filtered and/or with full metadata. Aggregates, window functions, and procedures are excluded.\n\n<usecase>\nUse when:\n- Auditing functions across the database (brief mode, default).\n- Searching for a function by partial name (pass `search`).\n- Inspecting a function's language, signature, return type, volatility, strictness, security mode, parallel-safety, owner, comment, and full `CREATE FUNCTION` text before reasoning about correctness or invocation safety (pass `detailed: true`). Detailed mode supersedes ad-hoc `readQuery` against `pg_proc` / `information_schema.routines`.\n</usecase>\n\n<parameters>\n- `cursor` — Opaque pagination cursor; echo the prior response's `nextCursor`.\n- `search` — Case-insensitive filter on function names via `ILIKE`. `%` matches any sequence; `_` matches a single character.\n- `detailed` — When `true`, returns full metadata objects keyed by `name(arguments)` instead of bare name strings. Default `false`.\n</parameters>\n\n<examples>\n✓ \"What functions are here?\" → listFunctions()\n✓ \"Find the order-total calculation\" → listFunctions(search=\"order\")\n✓ \"What does calc_order_total do?\" → listFunctions(search=\"calc_order_total\", detailed=true)\n✗ \"List stored procedures\" → use listProcedures instead\n✗ \"List aggregates\" → not supported; aggregates are excluded\n</examples>\n\n<what_it_returns>\nBrief mode (default): a sorted JSON array of function-name strings, e.g. `[\"audit_user_login\", \"calc_order_subtotal\", \"calc_order_total\", \"calc_order_total\"]`. Overloaded functions appear as one entry per overload (duplicate name strings allowed).\nDetailed mode: a JSON object keyed by function signature `name(arguments)`; each value carries `schema`, `name`, `language`, `arguments`, `returnType`, `volatility` (IMMUTABLE/STABLE/VOLATILE), `strict` (boolean), `security` (INVOKER/DEFINER), `parallelSafety` (SAFE/RESTRICTED/UNSAFE), `owner`, `description` (or null when no `COMMENT ON FUNCTION`), and `definition` (the full `CREATE OR REPLACE FUNCTION` text). Overloads occupy distinct keys (e.g. `calc_total(integer)` vs `calc_total(integer, numeric)`).\n</what_it_returns>\n\n<pagination>\nPaginated. Pass the prior response's `nextCursor` as `cursor` to fetch the next page. The `search` filter must stay the same across pages for cursor continuity. Brief and detailed modes share the same `(proname, oid)` row order, so a client can switch `detailed` between pages without losing position.\n</pagination>\n",
     "inputSchema": {
-      "$schema": "https://json-schema.org/draft/2020-12/schema",
-      "description": "Request for the Postgres `listFunctions` tool — extends the shared shape with `search` and `detailed`.",
       "properties": {
         "cursor": {
           "default": null,
@@ -127,12 +112,11 @@ expression: tools
           ]
         }
       },
-      "title": "ListFunctionsRequest",
       "type": "object"
     },
     "outputSchema": {
-      "$defs": {
-        "ListEntries": {
+      "properties": {
+        "functions": {
           "anyOf": [
             {
               "description": "Brief mode: sorted array of bare entity-name strings.",
@@ -147,14 +131,6 @@ expression: tools
               "type": "object"
             }
           ],
-          "description": "Two-shape listing payload: bare names in brief mode, name-keyed metadata in detailed mode.\n\nShared by [`ListTablesResponse`] and [`ListTriggersResponse`]. Serialises untagged:\nbrief mode → JSON array of strings, detailed mode → JSON object whose keys are\nentity names and whose values are the per-entity metadata."
-        }
-      },
-      "$schema": "https://json-schema.org/draft/2020-12/schema",
-      "description": "Response for the `listFunctions` tool.",
-      "properties": {
-        "functions": {
-          "$ref": "#/$defs/ListEntries",
           "description": "Page of matching functions. Shape depends on the request's `detailed` flag."
         },
         "nextCursor": {
@@ -168,7 +144,6 @@ expression: tools
       "required": [
         "functions"
       ],
-      "title": "ListFunctionsResponse",
       "type": "object"
     },
     "annotations": {
@@ -183,8 +158,6 @@ expression: tools
     "title": "List Materialized Views",
     "description": "List materialized views in the `public` schema, optionally filtered and/or with full metadata. Unlike regular views, materialized views store their results physically and must be refreshed explicitly. Regular views and system-schema matviews are excluded.\n\n<usecase>\nUse when:\n- Auditing materialized views across the database (brief mode, default).\n- Searching for a matview by partial name (pass `search`).\n- Inspecting a matview's owner, comment, full SELECT body, populated state, and index presence before querying or refreshing it (pass `detailed: true`). Detailed mode supersedes ad-hoc `readQuery` against `pg_matviews` / `pg_class`.\n</usecase>\n\n<parameters>\n- `cursor` — Opaque pagination cursor; echo the prior response's `nextCursor`.\n- `search` — Case-insensitive filter on matview names via `ILIKE`. `%` matches any sequence; `_` matches a single character.\n- `detailed` — When `true`, returns full metadata objects keyed by bare matview name instead of bare name strings. Default `false`.\n</parameters>\n\n<examples>\n✓ \"What materialized views are here?\" → listMaterializedViews()\n✓ \"Find the recent-orders matview\" → listMaterializedViews(search=\"orders\")\n✓ \"What does mv_orders_by_region compute?\" → listMaterializedViews(search=\"mv_orders_by_region\", detailed=true)\n✓ \"Has the cache matview ever been refreshed?\" → listMaterializedViews(search=\"cache\", detailed=true) — read `populated`\n✓ \"Which matviews can I refresh concurrently?\" → listMaterializedViews(detailed=true) — read `indexed` (CONCURRENTLY additionally needs a unique index)\n✗ \"List regular views\" → use listViews instead\n</examples>\n\n<what_it_returns>\nBrief mode (default): a sorted JSON array of matview-name strings, e.g. `[\"mv_archived_orders\", \"mv_recent_orders\"]`. Matview names are unique per schema, so no duplicates appear.\nDetailed mode: a JSON object keyed by bare matview name; each value carries:\n- `schema` — schema name (always `\"public\"` in this build).\n- `owner` — owning role's name from `pg_matviews.matviewowner`.\n- `description` — `COMMENT ON MATERIALIZED VIEW` text, or `null` when no comment.\n- `definition` — the SELECT body verbatim from `pg_matviews.definition`, with no `CREATE MATERIALIZED VIEW` wrapper.\n- `populated` — `true` once the matview has been refreshed at least once. `false` for matviews created `WITH NO DATA` and never refreshed; querying such a matview returns zero rows until `REFRESH MATERIALIZED VIEW` runs.\n- `indexed` — `true` when at least one index exists on the matview. `REFRESH MATERIALIZED VIEW CONCURRENTLY` additionally requires a unique index; this tool reports the broader has-any-index signal.\n\nThe matview name is the map key only — it is not repeated inside the value. Detailed mode deliberately omits column metadata (`columns`), `tablespace`, storage parameters, and unique-index detection. Column shape is recoverable from the `definition` text or via `listTables(detailed=true)` since Postgres exposes matviews in `pg_class`.\n</what_it_returns>\n\n<pagination>\nPaginated. Pass the prior response's `nextCursor` as `cursor` to fetch the next page. The `search` filter must stay the same across pages for cursor continuity. Brief and detailed modes share the same `matviewname` row order, so a client can switch `detailed` between pages without losing position.\n</pagination>\n",
     "inputSchema": {
-      "$schema": "https://json-schema.org/draft/2020-12/schema",
-      "description": "Request for the Postgres `listMaterializedViews` tool — extends the shared shape with `search` and `detailed`.",
       "properties": {
         "cursor": {
           "default": null,
@@ -208,12 +181,11 @@ expression: tools
           ]
         }
       },
-      "title": "ListMaterializedViewsRequest",
       "type": "object"
     },
     "outputSchema": {
-      "$defs": {
-        "ListEntries": {
+      "properties": {
+        "materializedViews": {
           "anyOf": [
             {
               "description": "Brief mode: sorted array of bare entity-name strings.",
@@ -228,14 +200,6 @@ expression: tools
               "type": "object"
             }
           ],
-          "description": "Two-shape listing payload: bare names in brief mode, name-keyed metadata in detailed mode.\n\nShared by [`ListTablesResponse`] and [`ListTriggersResponse`]. Serialises untagged:\nbrief mode → JSON array of strings, detailed mode → JSON object whose keys are\nentity names and whose values are the per-entity metadata."
-        }
-      },
-      "$schema": "https://json-schema.org/draft/2020-12/schema",
-      "description": "Response for the `listMaterializedViews` tool.",
-      "properties": {
-        "materializedViews": {
-          "$ref": "#/$defs/ListEntries",
           "description": "Page of matching materialized views. Shape depends on the request's `detailed` flag."
         },
         "nextCursor": {
@@ -249,7 +213,6 @@ expression: tools
       "required": [
         "materializedViews"
       ],
-      "title": "ListMaterializedViewsResponse",
       "type": "object"
     },
     "annotations": {
@@ -264,8 +227,6 @@ expression: tools
     "title": "List Procedures",
     "description": "List user-defined procedures in the `public` schema, optionally filtered and/or with full metadata. Functions, aggregates, and window functions are excluded.\n\n<usecase>\nUse when:\n- Auditing procedures across the database (brief mode, default).\n- Searching for a procedure by partial name (pass `search`).\n- Inspecting a procedure's language, signature, security mode, owner, comment, and full `CREATE PROCEDURE` text before reasoning about correctness or invocation safety (pass `detailed: true`). Detailed mode supersedes ad-hoc `readQuery` against `pg_proc` / `information_schema.routines`.\n</usecase>\n\n<parameters>\n- `cursor` — Opaque pagination cursor; echo the prior response's `nextCursor`.\n- `search` — Case-insensitive filter on procedure names via `ILIKE`. `%` matches any sequence; `_` matches a single character.\n- `detailed` — When `true`, returns full metadata objects keyed by `name(arguments)` instead of bare name strings. Default `false`.\n</parameters>\n\n<examples>\n✓ \"What procedures are here?\" → listProcedures()\n✓ \"Find the order archival routine\" → listProcedures(search=\"archive\")\n✓ \"What does archive_order do?\" → listProcedures(search=\"archive_order\", detailed=true)\n✗ \"List functions\" → use listFunctions instead\n✗ \"List aggregates\" → not supported; aggregates are excluded\n</examples>\n\n<what_it_returns>\nBrief mode (default): a sorted JSON array of procedure-name strings, e.g. `[\"archive_order\", \"archive_order_history\", \"archive_order_history\"]`. Overloaded procedures appear as one entry per overload (duplicate name strings allowed).\nDetailed mode: a JSON object keyed by procedure signature `name(arguments)`; each value carries `schema`, `name`, `language`, `arguments`, `security` (INVOKER/DEFINER), `owner`, `description` (or null when no `COMMENT ON PROCEDURE`), and `definition` (the full `CREATE OR REPLACE PROCEDURE` text). Overloads occupy distinct keys (e.g. `archive_order_history(integer)` vs `archive_order_history(integer, boolean)`). Zero-arg procedures key as `name()` — the parens are always present so the key shape stays uniform.\n\nDetailed mode deliberately omits the `listFunctions`-only fields `returnType`, `volatility`, `strict`, and `parallelSafety`: procedures don't return a value, `pg_proc.provolatile` / `proisstrict` are not user-settable for procedures, and `proparallel` carries no procedure-level guarantee in PostgreSQL.\n</what_it_returns>\n\n<pagination>\nPaginated. Pass the prior response's `nextCursor` as `cursor` to fetch the next page. The `search` filter must stay the same across pages for cursor continuity. Brief and detailed modes share the same `(proname, oid)` row order, so a client can switch `detailed` between pages without losing position.\n</pagination>\n",
     "inputSchema": {
-      "$schema": "https://json-schema.org/draft/2020-12/schema",
-      "description": "Request for the Postgres `listProcedures` tool — extends the shared shape with `search` and `detailed`.",
       "properties": {
         "cursor": {
           "default": null,
@@ -289,12 +250,18 @@ expression: tools
           ]
         }
       },
-      "title": "ListProceduresRequest",
       "type": "object"
     },
     "outputSchema": {
-      "$defs": {
-        "ListEntries": {
+      "properties": {
+        "nextCursor": {
+          "description": "Opaque cursor pointing to the next page. Absent when this is the final page.",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "procedures": {
           "anyOf": [
             {
               "description": "Brief mode: sorted array of bare entity-name strings.",
@@ -309,28 +276,12 @@ expression: tools
               "type": "object"
             }
           ],
-          "description": "Two-shape listing payload: bare names in brief mode, name-keyed metadata in detailed mode.\n\nShared by [`ListTablesResponse`] and [`ListTriggersResponse`]. Serialises untagged:\nbrief mode → JSON array of strings, detailed mode → JSON object whose keys are\nentity names and whose values are the per-entity metadata."
-        }
-      },
-      "$schema": "https://json-schema.org/draft/2020-12/schema",
-      "description": "Response for the `listProcedures` tool.",
-      "properties": {
-        "nextCursor": {
-          "description": "Opaque cursor pointing to the next page. Absent when this is the final page.",
-          "type": [
-            "string",
-            "null"
-          ]
-        },
-        "procedures": {
-          "$ref": "#/$defs/ListEntries",
           "description": "Page of matching procedures. Shape depends on the request's `detailed` flag."
         }
       },
       "required": [
         "procedures"
       ],
-      "title": "ListProceduresResponse",
       "type": "object"
     },
     "annotations": {
@@ -345,8 +296,6 @@ expression: tools
     "title": "List Tables",
     "description": "List tables, optionally filtered and/or with full metadata.\n\n<usecase>\nUse when:\n- Exploring the database to find relevant tables (brief mode, default).\n- Searching for a table by partial name (pass `search`).\n- Inspecting a table's columns, constraints, indexes, and triggers before writing a query (pass `detailed: true`). This supersedes the legacy `getTableSchema` tool.\n</usecase>\n\n<parameters>\n- `cursor` — Opaque pagination cursor; echo the prior response's `nextCursor`.\n- `search` — Case-insensitive filter on table names via `ILIKE`. `%` matches any sequence; `_` matches a single character.\n- `detailed` — When `true`, returns full metadata objects keyed by table name instead of bare name strings. Default `false`.\n</parameters>\n\n<examples>\n✓ \"What tables are here?\" → listTables()\n✓ \"Find the orders table\" → listTables(search=\"order\")\n✓ \"What columns does orders have?\" → listTables(search=\"orders\", detailed=true)\n</examples>\n\n<what_it_returns>\nBrief mode (default): a sorted JSON array of table-name strings, e.g. `[\"customers\", \"orders\"]`.\nDetailed mode: a JSON object keyed by table name; each value carries `schema`, `kind`, `owner`, `comment`, `columns`, `constraints`, `indexes`, and `triggers` (the name is the key and is not repeated inside the value). Keys iterate in the same alphabetical order brief mode uses. Example: `{\"orders\": {\"schema\": \"public\", \"kind\": \"TABLE\", …}}`.\n</what_it_returns>\n\n<pagination>\nPaginated. Pass the prior response's `nextCursor` as `cursor` to fetch the next page. The `search` filter must stay the same across pages for cursor continuity.\n</pagination>\n",
     "inputSchema": {
-      "$schema": "https://json-schema.org/draft/2020-12/schema",
-      "description": "Request for the Postgres `listTables` tool — extends the shared shape with `search` and `detailed`.",
       "properties": {
         "cursor": {
           "default": null,
@@ -370,12 +319,18 @@ expression: tools
           ]
         }
       },
-      "title": "ListTablesRequest",
       "type": "object"
     },
     "outputSchema": {
-      "$defs": {
-        "ListEntries": {
+      "properties": {
+        "nextCursor": {
+          "description": "Opaque cursor pointing to the next page. Absent when this is the final page.",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "tables": {
           "anyOf": [
             {
               "description": "Brief mode: sorted array of bare entity-name strings.",
@@ -390,28 +345,12 @@ expression: tools
               "type": "object"
             }
           ],
-          "description": "Two-shape listing payload: bare names in brief mode, name-keyed metadata in detailed mode.\n\nShared by [`ListTablesResponse`] and [`ListTriggersResponse`]. Serialises untagged:\nbrief mode → JSON array of strings, detailed mode → JSON object whose keys are\nentity names and whose values are the per-entity metadata."
-        }
-      },
-      "$schema": "https://json-schema.org/draft/2020-12/schema",
-      "description": "Response for the `listTables` tool.",
-      "properties": {
-        "nextCursor": {
-          "description": "Opaque cursor pointing to the next page. Absent when this is the final page.",
-          "type": [
-            "string",
-            "null"
-          ]
-        },
-        "tables": {
-          "$ref": "#/$defs/ListEntries",
           "description": "Page of matching tables. Shape depends on the request's `detailed` flag."
         }
       },
       "required": [
         "tables"
       ],
-      "title": "ListTablesResponse",
       "type": "object"
     },
     "annotations": {
@@ -426,8 +365,6 @@ expression: tools
     "title": "List Triggers",
     "description": "List user-defined triggers in the `public` schema, optionally filtered and/or with full metadata.\n\n<usecase>\nUse when:\n- Auditing triggers across the database (brief mode, default).\n- Searching for a trigger by partial name (pass `search`).\n- Inspecting a trigger's timing, events, activation level, handler function, status, and full `CREATE TRIGGER` text before reasoning about side-effects (pass `detailed: true`). Detailed mode supersedes ad-hoc `readQuery` against `pg_trigger` / `information_schema.triggers`.\n</usecase>\n\n<parameters>\n- `cursor` — Opaque pagination cursor; echo the prior response's `nextCursor`.\n- `search` — Case-insensitive filter on trigger names via `ILIKE`. `%` matches any sequence; `_` matches a single character.\n- `detailed` — When `true`, returns full metadata objects keyed by trigger name instead of bare name strings. Default `false`.\n</parameters>\n\n<examples>\n✓ \"What triggers are here?\" → listTriggers()\n✓ \"Find the audit triggers\" → listTriggers(search=\"audit\")\n✓ \"What does orders_audit_after_iu do?\" → listTriggers(search=\"orders_audit_after_iu\", detailed=true)\n✗ \"Show me a trigger's body\" → use detailed mode; the `definition` field carries the full `CREATE TRIGGER` text\n</examples>\n\n<what_it_returns>\nBrief mode (default): a sorted JSON array of trigger-name strings, e.g. `[\"customers_audit_after_insert\", \"orders_audit_after_insert\"]`.\nDetailed mode: a JSON object keyed by trigger name; each value carries `schema`, `table`, `status` (ENABLED/DISABLED/REPLICA/ALWAYS), `timing` (BEFORE/AFTER/INSTEAD OF), `events` (array of strings drawn from INSERT/UPDATE/DELETE/TRUNCATE in that fixed order), `activationLevel` (ROW/STATEMENT), `functionName`, and `definition` (the full `CREATE TRIGGER` text). Internal triggers (FK enforcement etc.) are excluded.\n</what_it_returns>\n\n<pagination>\nPaginated. Pass the prior response's `nextCursor` as `cursor` to fetch the next page. The `search` filter must stay the same across pages for cursor continuity.\n</pagination>\n",
     "inputSchema": {
-      "$schema": "https://json-schema.org/draft/2020-12/schema",
-      "description": "Request for the `listTriggers` tool.",
       "properties": {
         "cursor": {
           "default": null,
@@ -451,12 +388,18 @@ expression: tools
           ]
         }
       },
-      "title": "ListTriggersRequest",
       "type": "object"
     },
     "outputSchema": {
-      "$defs": {
-        "ListEntries": {
+      "properties": {
+        "nextCursor": {
+          "description": "Opaque cursor pointing to the next page. Absent when this is the final page.",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "triggers": {
           "anyOf": [
             {
               "description": "Brief mode: sorted array of bare entity-name strings.",
@@ -471,28 +414,12 @@ expression: tools
               "type": "object"
             }
           ],
-          "description": "Two-shape listing payload: bare names in brief mode, name-keyed metadata in detailed mode.\n\nShared by [`ListTablesResponse`] and [`ListTriggersResponse`]. Serialises untagged:\nbrief mode → JSON array of strings, detailed mode → JSON object whose keys are\nentity names and whose values are the per-entity metadata."
-        }
-      },
-      "$schema": "https://json-schema.org/draft/2020-12/schema",
-      "description": "Response for the `listTriggers` tool.",
-      "properties": {
-        "nextCursor": {
-          "description": "Opaque cursor pointing to the next page. Absent when this is the final page.",
-          "type": [
-            "string",
-            "null"
-          ]
-        },
-        "triggers": {
-          "$ref": "#/$defs/ListEntries",
           "description": "Page of matching triggers. Shape depends on the request's `detailed` flag."
         }
       },
       "required": [
         "triggers"
       ],
-      "title": "ListTriggersResponse",
       "type": "object"
     },
     "annotations": {
@@ -507,8 +434,6 @@ expression: tools
     "title": "List Views",
     "description": "List user-defined views in the `public` schema, optionally filtered and/or with full metadata. Materialized views and system-schema views are excluded.\n\n<usecase>\nUse when:\n- Auditing views across the database (brief mode, default).\n- Searching for a view by partial name (pass `search`).\n- Inspecting a view's owner, comment, and full SELECT body before querying it (pass `detailed: true`). Detailed mode supersedes ad-hoc `readQuery` against `pg_views` / `pg_class`.\n</usecase>\n\n<parameters>\n- `cursor` — Opaque pagination cursor; echo the prior response's `nextCursor`.\n- `search` — Case-insensitive filter on view names via `ILIKE`. `%` matches any sequence; `_` matches a single character.\n- `detailed` — When `true`, returns full metadata objects keyed by bare view name instead of bare name strings. Default `false`.\n</parameters>\n\n<examples>\n✓ \"What views are here?\" → listViews()\n✓ \"Find the active-users view\" → listViews(search=\"active\")\n✓ \"What does active_users select?\" → listViews(search=\"active_users\", detailed=true)\n✗ \"Show me the columns of a view\" → use listTables with `detailed: true` instead\n✗ \"List materialized views\" → use listMaterializedViews\n</examples>\n\n<what_it_returns>\nBrief mode (default): a sorted JSON array of view-name strings, e.g. `[\"active_orders\", \"active_users\"]`. View names are unique per schema, so no duplicates appear.\nDetailed mode: a JSON object keyed by bare view name; each value carries `schema`, `owner`, `description` (or null when no `COMMENT ON VIEW`), and `definition` (the SELECT body verbatim from `pg_views.definition`, with no `CREATE VIEW` wrapper). The view name is the map key only — it is not repeated inside the value.\n\nDetailed mode deliberately omits column metadata (`columns`), the `name` field (already the key), and view-level options (`security_barrier`, `security_invoker`, `WITH CHECK OPTION`). Column shape is recoverable from the `definition` text or via `listTables(detailed=true)` since Postgres exposes views in `pg_class`.\n</what_it_returns>\n\n<pagination>\nPaginated. Pass the prior response's `nextCursor` as `cursor` to fetch the next page. The `search` filter must stay the same across pages for cursor continuity. Brief and detailed modes share the same `viewname` row order, so a client can switch `detailed` between pages without losing position.\n</pagination>\n",
     "inputSchema": {
-      "$schema": "https://json-schema.org/draft/2020-12/schema",
-      "description": "Request for the Postgres `listViews` tool — extends the shared shape with `search` and `detailed`.",
       "properties": {
         "cursor": {
           "default": null,
@@ -532,12 +457,18 @@ expression: tools
           ]
         }
       },
-      "title": "ListViewsRequest",
       "type": "object"
     },
     "outputSchema": {
-      "$defs": {
-        "ListEntries": {
+      "properties": {
+        "nextCursor": {
+          "description": "Opaque cursor pointing to the next page. Absent when this is the final page.",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "views": {
           "anyOf": [
             {
               "description": "Brief mode: sorted array of bare entity-name strings.",
@@ -552,28 +483,12 @@ expression: tools
               "type": "object"
             }
           ],
-          "description": "Two-shape listing payload: bare names in brief mode, name-keyed metadata in detailed mode.\n\nShared by [`ListTablesResponse`] and [`ListTriggersResponse`]. Serialises untagged:\nbrief mode → JSON array of strings, detailed mode → JSON object whose keys are\nentity names and whose values are the per-entity metadata."
-        }
-      },
-      "$schema": "https://json-schema.org/draft/2020-12/schema",
-      "description": "Response for the `listViews` tool.",
-      "properties": {
-        "nextCursor": {
-          "description": "Opaque cursor pointing to the next page. Absent when this is the final page.",
-          "type": [
-            "string",
-            "null"
-          ]
-        },
-        "views": {
-          "$ref": "#/$defs/ListEntries",
           "description": "Page of matching views. Shape depends on the request's `detailed` flag."
         }
       },
       "required": [
         "views"
       ],
-      "title": "ListViewsResponse",
       "type": "object"
     },
     "annotations": {
@@ -588,8 +503,6 @@ expression: tools
     "title": "Read Query",
     "description": "Execute a read-only SQL query. Allowed statements: SELECT, SHOW, EXPLAIN.\n\n<usecase>\nUse when:\n- Querying data from tables (SELECT with WHERE, JOIN, GROUP BY, etc.)\n- Aggregations: COUNT, SUM, AVG, GROUP BY, HAVING\n- Listing server configuration parameters (SHOW)\n</usecase>\n\n<when_not_to_use>\n- Data changes (INSERT, UPDATE, DELETE) → use writeQuery\n- Query performance analysis → use explainQuery\n- Discovering tables or columns → use listTables (pass `detailed: true` to get columns, keys, and indexes)\n</when_not_to_use>\n\n<examples>\n✓ \"SELECT * FROM users WHERE status = 'active'\"\n✓ \"SELECT COUNT(*) FROM orders GROUP BY region\"\n✓ \"SHOW server_version\"\n✗ \"INSERT INTO users ...\" → use writeQuery\n✗ \"EXPLAIN SELECT ...\" → use explainQuery for structured analysis\n</examples>\n\n<what_it_returns>\nA JSON array of row objects, each keyed by column name.\n</what_it_returns>\n\n<pagination>\n`SELECT` results are paginated. Pass the prior response's `nextCursor` as `cursor` to fetch the next page. `SHOW` and `EXPLAIN` return a single page and ignore `cursor`.\n</pagination>",
     "inputSchema": {
-      "$schema": "https://json-schema.org/draft/2020-12/schema",
-      "description": "Request for the `readQuery` tool.",
       "properties": {
         "cursor": {
           "default": null,
@@ -607,12 +520,9 @@ expression: tools
       "required": [
         "query"
       ],
-      "title": "ReadQueryRequest",
       "type": "object"
     },
     "outputSchema": {
-      "$schema": "https://json-schema.org/draft/2020-12/schema",
-      "description": "Response for the `readQuery` tool.",
       "properties": {
         "nextCursor": {
           "description": "Opaque cursor pointing to the next page. Absent when this is the final\npage, when the result fits in one page, or when the statement is a\nnon-`SELECT` kind that does not paginate (e.g. `SHOW`, `EXPLAIN`).",
@@ -630,7 +540,6 @@ expression: tools
       "required": [
         "rows"
       ],
-      "title": "ReadQueryResponse",
       "type": "object"
     },
     "annotations": {
@@ -645,8 +554,6 @@ expression: tools
     "title": "Write Query",
     "description": "Execute a write SQL query (INSERT, UPDATE, DELETE, CREATE, ALTER, DROP).\n\n<usecase>\nUse when:\n- Inserting, updating, or deleting rows\n- Creating or altering tables, indexes, views, or other schema objects\n- Any data modification operation\n</usecase>\n\n<when_not_to_use>\n- Read-only queries (SELECT, SHOW) → use readQuery\n- Query performance analysis → use explainQuery\n- Creating/dropping entire databases → use createDatabase or dropDatabase\n</when_not_to_use>\n\n<examples>\n✓ \"INSERT INTO users (name, email) VALUES ('Alice', 'alice@example.com')\"\n✓ \"UPDATE orders SET status = 'shipped' WHERE id = 42\"\n✓ \"CREATE TABLE logs (id SERIAL PRIMARY KEY, message TEXT)\"\n✗ \"SELECT * FROM users\" → use readQuery\n</examples>\n\n<what_it_returns>\nA JSON array of affected/returning row objects, each keyed by column name.\n</what_it_returns>",
     "inputSchema": {
-      "$schema": "https://json-schema.org/draft/2020-12/schema",
-      "description": "Request for the `writeQuery` tool.",
       "properties": {
         "query": {
           "description": "The SQL query to execute.",
@@ -656,12 +563,9 @@ expression: tools
       "required": [
         "query"
       ],
-      "title": "QueryRequest",
       "type": "object"
     },
     "outputSchema": {
-      "$schema": "https://json-schema.org/draft/2020-12/schema",
-      "description": "Response for the `writeQuery` and `explainQuery` tools.",
       "properties": {
         "rows": {
           "description": "Result rows, each a JSON object keyed by a column name.",
@@ -672,7 +576,6 @@ expression: tools
       "required": [
         "rows"
       ],
-      "title": "QueryResponse",
       "type": "object"
     },
     "annotations": {

--- a/tests/approval/snapshots/approval_postgres__list_tools_read_write_unpinned.snap
+++ b/tests/approval/snapshots/approval_postgres__list_tools_read_write_unpinned.snap
@@ -8,8 +8,6 @@ expression: tools
     "title": "Create Database",
     "description": "Create a new database on the connected server.\n\n<usecase>\nUse when:\n- Setting up a new database for a project or application\n- The user asks to create a database\n</usecase>\n\n<examples>\n✓ \"Create a database called analytics\" → createDatabase(database=\"analytics\")\n✗ \"Create a table\" → use writeQuery with CREATE TABLE\n</examples>\n\n<important>\nDatabase name must be non-empty; backend reserved-character rules apply.\n</important>\n\n<what_it_returns>\nA confirmation message with the created database name.\n</what_it_returns>",
     "inputSchema": {
-      "$schema": "https://json-schema.org/draft/2020-12/schema",
-      "description": "Request for the `createDatabase` tool.",
       "properties": {
         "database": {
           "description": "Name of the database to create. Must be non-empty.",
@@ -19,12 +17,9 @@ expression: tools
       "required": [
         "database"
       ],
-      "title": "CreateDatabaseRequest",
       "type": "object"
     },
     "outputSchema": {
-      "$schema": "https://json-schema.org/draft/2020-12/schema",
-      "description": "Response for tools with no structured return data.",
       "properties": {
         "message": {
           "description": "Description of the completed operation.",
@@ -34,7 +29,6 @@ expression: tools
       "required": [
         "message"
       ],
-      "title": "MessageResponse",
       "type": "object"
     },
     "annotations": {
@@ -49,8 +43,6 @@ expression: tools
     "title": "Drop Database",
     "description": "Drop an existing database from the connected server.\n\n<usecase>\nUse when:\n- Removing a database that is no longer needed\n- Cleaning up test or temporary databases\n</usecase>\n\n<examples>\n✓ \"Drop the test_db database\" → dropDatabase(database=\"test_db\")\n✗ \"Drop a table\" → use dropTable instead\n</examples>\n\n<safety>\nIMPORTANT: This permanently deletes the database and ALL its data. This action cannot be undone.\nCannot drop the database you are currently connected to.\n</safety>\n\n<what_it_returns>\nA confirmation message with the dropped database name.\n</what_it_returns>",
     "inputSchema": {
-      "$schema": "https://json-schema.org/draft/2020-12/schema",
-      "description": "Request for the `dropDatabase` tool.",
       "properties": {
         "database": {
           "description": "Name of the database to drop. Must be non-empty.",
@@ -60,12 +52,9 @@ expression: tools
       "required": [
         "database"
       ],
-      "title": "DropDatabaseRequest",
       "type": "object"
     },
     "outputSchema": {
-      "$schema": "https://json-schema.org/draft/2020-12/schema",
-      "description": "Response for tools with no structured return data.",
       "properties": {
         "message": {
           "description": "Description of the completed operation.",
@@ -75,7 +64,6 @@ expression: tools
       "required": [
         "message"
       ],
-      "title": "MessageResponse",
       "type": "object"
     },
     "annotations": {
@@ -90,8 +78,6 @@ expression: tools
     "title": "Drop Table",
     "description": "Drop a table from a database. Checks for foreign key dependencies via the database engine.\n\n<usecase>\nUse when:\n- Removing a table that is no longer needed\n- Cleaning up test or temporary tables\n</usecase>\n\n<examples>\n✓ \"Drop the temp_logs table\" → dropTable(database=\"mydb\", table=\"temp_logs\")\n✓ \"Force drop with dependencies\" → dropTable(..., cascade=true)\n✗ \"Delete rows from a table\" → use writeQuery with DELETE\n✗ \"Drop a database\" → use dropDatabase instead\n</examples>\n\n<safety>\nIMPORTANT: This permanently deletes the table and ALL its data. This action cannot be undone.\nSet `cascade` to true to also drop dependent foreign key constraints.\nWithout cascade, the drop will fail if other tables reference this one.\n</safety>\n\n<what_it_returns>\nA confirmation message with the dropped table name.\n</what_it_returns>",
     "inputSchema": {
-      "$schema": "https://json-schema.org/draft/2020-12/schema",
-      "description": "Request for the `dropTable` tool.",
       "properties": {
         "cascade": {
           "default": false,
@@ -114,12 +100,9 @@ expression: tools
       "required": [
         "table"
       ],
-      "title": "DropTableRequest",
       "type": "object"
     },
     "outputSchema": {
-      "$schema": "https://json-schema.org/draft/2020-12/schema",
-      "description": "Response for tools with no structured return data.",
       "properties": {
         "message": {
           "description": "Description of the completed operation.",
@@ -129,7 +112,6 @@ expression: tools
       "required": [
         "message"
       ],
-      "title": "MessageResponse",
       "type": "object"
     },
     "annotations": {
@@ -144,8 +126,6 @@ expression: tools
     "title": "Explain Query",
     "description": "Return the execution plan for a SQL query to diagnose performance. Use this tool instead of running EXPLAIN directly through readQuery — it provides structured JSON output.\n\n<usecase>\nUse when:\n- A query runs slowly and you need to understand why\n- Investigating performance bottlenecks\n- Planning index creation to optimize queries\n- Analyzing join methods, table scan strategies, and sort operations\n</usecase>\n\n<when_not_to_use>\n- Running actual queries → use readQuery or writeQuery\n- Checking table structure → use listTables(detailed=true)\n</when_not_to_use>\n\n<examples>\n✓ \"Why is my SELECT on orders slow?\" → explainQuery(query=\"SELECT ...\")\n✓ \"Should I add an index?\" → explainQuery with analyze=true\n✗ \"Run this SELECT\" → use readQuery\n</examples>\n\n<safety>\nSet `analyze` to true for actual execution statistics (EXPLAIN ANALYZE).\nIMPORTANT: EXPLAIN ANALYZE actually executes the query! In read-only mode, only read-only statements are allowed with analyze.\nWhen analyze is false, returns EXPLAIN (FORMAT JSON) output without executing.\n</safety>\n\n<what_it_returns>\nA JSON array of execution plan rows showing access methods, join types, row estimates, and costs.\n</what_it_returns>",
     "inputSchema": {
-      "$schema": "https://json-schema.org/draft/2020-12/schema",
-      "description": "Request for the `explainQuery` tool.",
       "properties": {
         "analyze": {
           "default": false,
@@ -168,12 +148,9 @@ expression: tools
       "required": [
         "query"
       ],
-      "title": "ExplainQueryRequest",
       "type": "object"
     },
     "outputSchema": {
-      "$schema": "https://json-schema.org/draft/2020-12/schema",
-      "description": "Response for the `writeQuery` and `explainQuery` tools.",
       "properties": {
         "rows": {
           "description": "Result rows, each a JSON object keyed by a column name.",
@@ -184,7 +161,6 @@ expression: tools
       "required": [
         "rows"
       ],
-      "title": "QueryResponse",
       "type": "object"
     },
     "annotations": {
@@ -199,8 +175,6 @@ expression: tools
     "title": "List Databases",
     "description": "List all accessible databases on the connected server. Use this tool to discover what databases are available before using other tools.\n\n<usecase>\nALWAYS call this tool FIRST when:\n- You need to explore what databases exist on the server\n- You need a database name for listTables or query tools\n- The user asks what data is available\n</usecase>\n\n<examples>\n✓ \"What databases are on this server?\"\n✓ \"Show me what's available\" → call listDatabases first\n</examples>\n\n<what_it_returns>\nA sorted JSON array of database name strings.\n</what_it_returns>\n\n<pagination>\nPaginated. Pass the prior response's `nextCursor` as `cursor` to fetch the next page.\n</pagination>",
     "inputSchema": {
-      "$schema": "https://json-schema.org/draft/2020-12/schema",
-      "description": "Request for the `listDatabases` tool.",
       "properties": {
         "cursor": {
           "default": null,
@@ -211,12 +185,9 @@ expression: tools
           ]
         }
       },
-      "title": "ListDatabasesRequest",
       "type": "object"
     },
     "outputSchema": {
-      "$schema": "https://json-schema.org/draft/2020-12/schema",
-      "description": "Response for the `listDatabases` tool.",
       "properties": {
         "databases": {
           "description": "Sorted list of database names for this page.",
@@ -236,7 +207,6 @@ expression: tools
       "required": [
         "databases"
       ],
-      "title": "ListDatabasesResponse",
       "type": "object"
     },
     "annotations": {
@@ -251,8 +221,6 @@ expression: tools
     "title": "List Functions",
     "description": "List user-defined functions in the `public` schema, optionally filtered and/or with full metadata. Aggregates, window functions, and procedures are excluded.\n\n<usecase>\nUse when:\n- Auditing functions across a database (brief mode, default).\n- Searching for a function by partial name (pass `search`).\n- Inspecting a function's language, signature, return type, volatility, strictness, security mode, parallel-safety, owner, comment, and full `CREATE FUNCTION` text before reasoning about correctness or invocation safety (pass `detailed: true`). Detailed mode supersedes ad-hoc `readQuery` against `pg_proc` / `information_schema.routines`.\n</usecase>\n\n<parameters>\n- `database` — Database to target. Defaults to the active database.\n- `cursor` — Opaque pagination cursor; echo the prior response's `nextCursor`.\n- `search` — Case-insensitive filter on function names via `ILIKE`. `%` matches any sequence; `_` matches a single character.\n- `detailed` — When `true`, returns full metadata objects keyed by `name(arguments)` instead of bare name strings. Default `false`.\n</parameters>\n\n<examples>\n✓ \"What functions are in mydb?\" → listFunctions(database=\"mydb\")\n✓ \"Find the order-total calculation\" → listFunctions(search=\"order\")\n✓ \"What does calc_order_total do?\" → listFunctions(search=\"calc_order_total\", detailed=true)\n✗ \"List stored procedures\" → use listProcedures instead\n✗ \"List aggregates\" → not supported; aggregates are excluded\n</examples>\n\n<what_it_returns>\nBrief mode (default): a sorted JSON array of function-name strings, e.g. `[\"audit_user_login\", \"calc_order_subtotal\", \"calc_order_total\", \"calc_order_total\"]`. Overloaded functions appear as one entry per overload (duplicate name strings allowed).\nDetailed mode: a JSON object keyed by function signature `name(arguments)`; each value carries `schema`, `name`, `language`, `arguments`, `returnType`, `volatility` (IMMUTABLE/STABLE/VOLATILE), `strict` (boolean), `security` (INVOKER/DEFINER), `parallelSafety` (SAFE/RESTRICTED/UNSAFE), `owner`, `description` (or null when no `COMMENT ON FUNCTION`), and `definition` (the full `CREATE OR REPLACE FUNCTION` text). Overloads occupy distinct keys (e.g. `calc_total(integer)` vs `calc_total(integer, numeric)`).\n</what_it_returns>\n\n<pagination>\nPaginated. Pass the prior response's `nextCursor` as `cursor` to fetch the next page. The `search` filter must stay the same across pages for cursor continuity. Brief and detailed modes share the same `(proname, oid)` row order, so a client can switch `detailed` between pages without losing position.\n</pagination>",
     "inputSchema": {
-      "$schema": "https://json-schema.org/draft/2020-12/schema",
-      "description": "Request for the Postgres `listFunctions` tool — extends the shared shape with `search` and `detailed`.",
       "properties": {
         "cursor": {
           "default": null,
@@ -284,12 +252,11 @@ expression: tools
           ]
         }
       },
-      "title": "ListFunctionsRequest",
       "type": "object"
     },
     "outputSchema": {
-      "$defs": {
-        "ListEntries": {
+      "properties": {
+        "functions": {
           "anyOf": [
             {
               "description": "Brief mode: sorted array of bare entity-name strings.",
@@ -304,14 +271,6 @@ expression: tools
               "type": "object"
             }
           ],
-          "description": "Two-shape listing payload: bare names in brief mode, name-keyed metadata in detailed mode.\n\nShared by [`ListTablesResponse`] and [`ListTriggersResponse`]. Serialises untagged:\nbrief mode → JSON array of strings, detailed mode → JSON object whose keys are\nentity names and whose values are the per-entity metadata."
-        }
-      },
-      "$schema": "https://json-schema.org/draft/2020-12/schema",
-      "description": "Response for the `listFunctions` tool.",
-      "properties": {
-        "functions": {
-          "$ref": "#/$defs/ListEntries",
           "description": "Page of matching functions. Shape depends on the request's `detailed` flag."
         },
         "nextCursor": {
@@ -325,7 +284,6 @@ expression: tools
       "required": [
         "functions"
       ],
-      "title": "ListFunctionsResponse",
       "type": "object"
     },
     "annotations": {
@@ -340,8 +298,6 @@ expression: tools
     "title": "List Materialized Views",
     "description": "List materialized views in the `public` schema, optionally filtered and/or with full metadata. Unlike regular views, materialized views store their results physically and must be refreshed explicitly. Regular views and system-schema matviews are excluded.\n\n<usecase>\nUse when:\n- Auditing materialized views across a database (brief mode, default).\n- Searching for a matview by partial name (pass `search`).\n- Inspecting a matview's owner, comment, full SELECT body, populated state, and index presence before querying or refreshing it (pass `detailed: true`). Detailed mode supersedes ad-hoc `readQuery` against `pg_matviews` / `pg_class`.\n</usecase>\n\n<parameters>\n- `database` — Database to target. Defaults to the active database.\n- `cursor` — Opaque pagination cursor; echo the prior response's `nextCursor`.\n- `search` — Case-insensitive filter on matview names via `ILIKE`. `%` matches any sequence; `_` matches a single character.\n- `detailed` — When `true`, returns full metadata objects keyed by bare matview name instead of bare name strings. Default `false`.\n</parameters>\n\n<examples>\n✓ \"What materialized views are in mydb?\" → listMaterializedViews(database=\"mydb\")\n✓ \"Find the recent-orders matview\" → listMaterializedViews(search=\"orders\")\n✓ \"What does mv_orders_by_region compute?\" → listMaterializedViews(search=\"mv_orders_by_region\", detailed=true)\n✓ \"Has the cache matview ever been refreshed?\" → listMaterializedViews(search=\"cache\", detailed=true) — read `populated`\n✓ \"Which matviews can I refresh concurrently?\" → listMaterializedViews(detailed=true) — read `indexed` (CONCURRENTLY additionally needs a unique index)\n✗ \"List regular views\" → use listViews instead\n</examples>\n\n<what_it_returns>\nBrief mode (default): a sorted JSON array of matview-name strings, e.g. `[\"mv_archived_orders\", \"mv_recent_orders\"]`. Matview names are unique per schema, so no duplicates appear.\nDetailed mode: a JSON object keyed by bare matview name; each value carries:\n- `schema` — schema name (always `\"public\"` in this build).\n- `owner` — owning role's name from `pg_matviews.matviewowner`.\n- `description` — `COMMENT ON MATERIALIZED VIEW` text, or `null` when no comment.\n- `definition` — the SELECT body verbatim from `pg_matviews.definition`, with no `CREATE MATERIALIZED VIEW` wrapper.\n- `populated` — `true` once the matview has been refreshed at least once. `false` for matviews created `WITH NO DATA` and never refreshed; querying such a matview returns zero rows until `REFRESH MATERIALIZED VIEW` runs.\n- `indexed` — `true` when at least one index exists on the matview. `REFRESH MATERIALIZED VIEW CONCURRENTLY` additionally requires a unique index; this tool reports the broader has-any-index signal.\n\nThe matview name is the map key only — it is not repeated inside the value. Detailed mode deliberately omits column metadata (`columns`), `tablespace`, storage parameters, and unique-index detection. Column shape is recoverable from the `definition` text or via `listTables(detailed=true)` since Postgres exposes matviews in `pg_class`.\n</what_it_returns>\n\n<pagination>\nPaginated. Pass the prior response's `nextCursor` as `cursor` to fetch the next page. The `search` filter must stay the same across pages for cursor continuity. Brief and detailed modes share the same `matviewname` row order, so a client can switch `detailed` between pages without losing position.\n</pagination>",
     "inputSchema": {
-      "$schema": "https://json-schema.org/draft/2020-12/schema",
-      "description": "Request for the Postgres `listMaterializedViews` tool — extends the shared shape with `search` and `detailed`.",
       "properties": {
         "cursor": {
           "default": null,
@@ -373,12 +329,11 @@ expression: tools
           ]
         }
       },
-      "title": "ListMaterializedViewsRequest",
       "type": "object"
     },
     "outputSchema": {
-      "$defs": {
-        "ListEntries": {
+      "properties": {
+        "materializedViews": {
           "anyOf": [
             {
               "description": "Brief mode: sorted array of bare entity-name strings.",
@@ -393,14 +348,6 @@ expression: tools
               "type": "object"
             }
           ],
-          "description": "Two-shape listing payload: bare names in brief mode, name-keyed metadata in detailed mode.\n\nShared by [`ListTablesResponse`] and [`ListTriggersResponse`]. Serialises untagged:\nbrief mode → JSON array of strings, detailed mode → JSON object whose keys are\nentity names and whose values are the per-entity metadata."
-        }
-      },
-      "$schema": "https://json-schema.org/draft/2020-12/schema",
-      "description": "Response for the `listMaterializedViews` tool.",
-      "properties": {
-        "materializedViews": {
-          "$ref": "#/$defs/ListEntries",
           "description": "Page of matching materialized views. Shape depends on the request's `detailed` flag."
         },
         "nextCursor": {
@@ -414,7 +361,6 @@ expression: tools
       "required": [
         "materializedViews"
       ],
-      "title": "ListMaterializedViewsResponse",
       "type": "object"
     },
     "annotations": {
@@ -429,8 +375,6 @@ expression: tools
     "title": "List Procedures",
     "description": "List user-defined procedures in the `public` schema, optionally filtered and/or with full metadata. Functions, aggregates, and window functions are excluded.\n\n<usecase>\nUse when:\n- Auditing procedures across a database (brief mode, default).\n- Searching for a procedure by partial name (pass `search`).\n- Inspecting a procedure's language, signature, security mode, owner, comment, and full `CREATE PROCEDURE` text before reasoning about correctness or invocation safety (pass `detailed: true`). Detailed mode supersedes ad-hoc `readQuery` against `pg_proc` / `information_schema.routines`.\n</usecase>\n\n<parameters>\n- `database` — Database to target. Defaults to the active database.\n- `cursor` — Opaque pagination cursor; echo the prior response's `nextCursor`.\n- `search` — Case-insensitive filter on procedure names via `ILIKE`. `%` matches any sequence; `_` matches a single character.\n- `detailed` — When `true`, returns full metadata objects keyed by `name(arguments)` instead of bare name strings. Default `false`.\n</parameters>\n\n<examples>\n✓ \"What procedures are in mydb?\" → listProcedures(database=\"mydb\")\n✓ \"Find the order archival routine\" → listProcedures(search=\"archive\")\n✓ \"What does archive_order do?\" → listProcedures(search=\"archive_order\", detailed=true)\n✗ \"List functions\" → use listFunctions instead\n✗ \"List aggregates\" → not supported; aggregates are excluded\n</examples>\n\n<what_it_returns>\nBrief mode (default): a sorted JSON array of procedure-name strings, e.g. `[\"archive_order\", \"archive_order_history\", \"archive_order_history\"]`. Overloaded procedures appear as one entry per overload (duplicate name strings allowed).\nDetailed mode: a JSON object keyed by procedure signature `name(arguments)`; each value carries `schema`, `name`, `language`, `arguments`, `security` (INVOKER/DEFINER), `owner`, `description` (or null when no `COMMENT ON PROCEDURE`), and `definition` (the full `CREATE OR REPLACE PROCEDURE` text). Overloads occupy distinct keys (e.g. `archive_order_history(integer)` vs `archive_order_history(integer, boolean)`). Zero-arg procedures key as `name()` — the parens are always present so the key shape stays uniform.\n\nDetailed mode deliberately omits the `listFunctions`-only fields `returnType`, `volatility`, `strict`, and `parallelSafety`: procedures don't return a value, `pg_proc.provolatile` / `proisstrict` are not user-settable for procedures, and `proparallel` carries no procedure-level guarantee in PostgreSQL.\n</what_it_returns>\n\n<pagination>\nPaginated. Pass the prior response's `nextCursor` as `cursor` to fetch the next page. The `search` filter must stay the same across pages for cursor continuity. Brief and detailed modes share the same `(proname, oid)` row order, so a client can switch `detailed` between pages without losing position.\n</pagination>",
     "inputSchema": {
-      "$schema": "https://json-schema.org/draft/2020-12/schema",
-      "description": "Request for the Postgres `listProcedures` tool — extends the shared shape with `search` and `detailed`.",
       "properties": {
         "cursor": {
           "default": null,
@@ -462,12 +406,18 @@ expression: tools
           ]
         }
       },
-      "title": "ListProceduresRequest",
       "type": "object"
     },
     "outputSchema": {
-      "$defs": {
-        "ListEntries": {
+      "properties": {
+        "nextCursor": {
+          "description": "Opaque cursor pointing to the next page. Absent when this is the final page.",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "procedures": {
           "anyOf": [
             {
               "description": "Brief mode: sorted array of bare entity-name strings.",
@@ -482,28 +432,12 @@ expression: tools
               "type": "object"
             }
           ],
-          "description": "Two-shape listing payload: bare names in brief mode, name-keyed metadata in detailed mode.\n\nShared by [`ListTablesResponse`] and [`ListTriggersResponse`]. Serialises untagged:\nbrief mode → JSON array of strings, detailed mode → JSON object whose keys are\nentity names and whose values are the per-entity metadata."
-        }
-      },
-      "$schema": "https://json-schema.org/draft/2020-12/schema",
-      "description": "Response for the `listProcedures` tool.",
-      "properties": {
-        "nextCursor": {
-          "description": "Opaque cursor pointing to the next page. Absent when this is the final page.",
-          "type": [
-            "string",
-            "null"
-          ]
-        },
-        "procedures": {
-          "$ref": "#/$defs/ListEntries",
           "description": "Page of matching procedures. Shape depends on the request's `detailed` flag."
         }
       },
       "required": [
         "procedures"
       ],
-      "title": "ListProceduresResponse",
       "type": "object"
     },
     "annotations": {
@@ -518,8 +452,6 @@ expression: tools
     "title": "List Tables",
     "description": "List tables in a database, optionally filtered and/or with full metadata.\n\n<usecase>\nUse when:\n- Exploring a database to find relevant tables (brief mode, default).\n- Searching for a table by partial name (pass `search`).\n- Inspecting a table's columns, constraints, indexes, and triggers before writing a query (pass `detailed: true`). This supersedes the legacy `getTableSchema` tool.\n</usecase>\n\n<parameters>\n- `database` — Database to target. Defaults to the active database.\n- `cursor` — Opaque pagination cursor; echo the prior response's `nextCursor`.\n- `search` — Case-insensitive filter on table names via `ILIKE`. `%` matches any sequence; `_` matches a single character.\n- `detailed` — When `true`, returns full metadata objects keyed by table name instead of bare name strings. Default `false`.\n</parameters>\n\n<examples>\n✓ \"What tables are in mydb?\" → listTables(database=\"mydb\")\n✓ \"Find the orders table\" → listTables(search=\"order\")\n✓ \"What columns does orders have?\" → listTables(search=\"orders\", detailed=true)\n</examples>\n\n<what_it_returns>\nBrief mode (default): a sorted JSON array of table-name strings, e.g. `[\"customers\", \"orders\"]`.\nDetailed mode: a JSON object keyed by table name; each value carries `schema`, `kind`, `owner`, `comment`, `columns`, `constraints`, `indexes`, and `triggers` (the name is the key and is not repeated inside the value). Keys iterate in the same alphabetical order brief mode uses. Example: `{\"orders\": {\"schema\": \"public\", \"kind\": \"TABLE\", …}}`.\n</what_it_returns>\n\n<pagination>\nPaginated. Pass the prior response's `nextCursor` as `cursor` to fetch the next page. The `search` filter must stay the same across pages for cursor continuity.\n</pagination>",
     "inputSchema": {
-      "$schema": "https://json-schema.org/draft/2020-12/schema",
-      "description": "Request for the Postgres `listTables` tool — extends the shared shape with `search` and `detailed`.",
       "properties": {
         "cursor": {
           "default": null,
@@ -551,12 +483,18 @@ expression: tools
           ]
         }
       },
-      "title": "ListTablesRequest",
       "type": "object"
     },
     "outputSchema": {
-      "$defs": {
-        "ListEntries": {
+      "properties": {
+        "nextCursor": {
+          "description": "Opaque cursor pointing to the next page. Absent when this is the final page.",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "tables": {
           "anyOf": [
             {
               "description": "Brief mode: sorted array of bare entity-name strings.",
@@ -571,28 +509,12 @@ expression: tools
               "type": "object"
             }
           ],
-          "description": "Two-shape listing payload: bare names in brief mode, name-keyed metadata in detailed mode.\n\nShared by [`ListTablesResponse`] and [`ListTriggersResponse`]. Serialises untagged:\nbrief mode → JSON array of strings, detailed mode → JSON object whose keys are\nentity names and whose values are the per-entity metadata."
-        }
-      },
-      "$schema": "https://json-schema.org/draft/2020-12/schema",
-      "description": "Response for the `listTables` tool.",
-      "properties": {
-        "nextCursor": {
-          "description": "Opaque cursor pointing to the next page. Absent when this is the final page.",
-          "type": [
-            "string",
-            "null"
-          ]
-        },
-        "tables": {
-          "$ref": "#/$defs/ListEntries",
           "description": "Page of matching tables. Shape depends on the request's `detailed` flag."
         }
       },
       "required": [
         "tables"
       ],
-      "title": "ListTablesResponse",
       "type": "object"
     },
     "annotations": {
@@ -607,8 +529,6 @@ expression: tools
     "title": "List Triggers",
     "description": "List user-defined triggers in the `public` schema, optionally filtered and/or with full metadata.\n\n<usecase>\nUse when:\n- Auditing triggers across a database (brief mode, default).\n- Searching for a trigger by partial name (pass `search`).\n- Inspecting a trigger's timing, events, activation level, handler function, status, and full `CREATE TRIGGER` text before reasoning about side-effects (pass `detailed: true`). Detailed mode supersedes ad-hoc `readQuery` against `pg_trigger` / `information_schema.triggers`.\n</usecase>\n\n<parameters>\n- `database` — Database to target. Defaults to the active database.\n- `cursor` — Opaque pagination cursor; echo the prior response's `nextCursor`.\n- `search` — Case-insensitive filter on trigger names via `ILIKE`. `%` matches any sequence; `_` matches a single character.\n- `detailed` — When `true`, returns full metadata objects keyed by trigger name instead of bare name strings. Default `false`.\n</parameters>\n\n<examples>\n✓ \"What triggers are in the mydb database?\" → listTriggers(database=\"mydb\")\n✓ \"Find the audit triggers\" → listTriggers(search=\"audit\")\n✓ \"What does orders_audit_after_iu do?\" → listTriggers(search=\"orders_audit_after_iu\", detailed=true)\n✗ \"Show me a trigger's body\" → use detailed mode; the `definition` field carries the full `CREATE TRIGGER` text\n</examples>\n\n<what_it_returns>\nBrief mode (default): a sorted JSON array of trigger-name strings, e.g. `[\"customers_audit_after_insert\", \"orders_audit_after_insert\"]`.\nDetailed mode: a JSON object keyed by trigger name; each value carries `schema`, `table`, `status` (ENABLED/DISABLED/REPLICA/ALWAYS), `timing` (BEFORE/AFTER/INSTEAD OF), `events` (array of strings drawn from INSERT/UPDATE/DELETE/TRUNCATE in that fixed order), `activationLevel` (ROW/STATEMENT), `functionName`, and `definition` (the full `CREATE TRIGGER` text). Internal triggers (FK enforcement etc.) are excluded.\n</what_it_returns>\n\n<pagination>\nPaginated. Pass the prior response's `nextCursor` as `cursor` to fetch the next page. The `search` filter must stay the same across pages for cursor continuity.\n</pagination>",
     "inputSchema": {
-      "$schema": "https://json-schema.org/draft/2020-12/schema",
-      "description": "Request for the `listTriggers` tool.",
       "properties": {
         "cursor": {
           "default": null,
@@ -640,12 +560,18 @@ expression: tools
           ]
         }
       },
-      "title": "ListTriggersRequest",
       "type": "object"
     },
     "outputSchema": {
-      "$defs": {
-        "ListEntries": {
+      "properties": {
+        "nextCursor": {
+          "description": "Opaque cursor pointing to the next page. Absent when this is the final page.",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "triggers": {
           "anyOf": [
             {
               "description": "Brief mode: sorted array of bare entity-name strings.",
@@ -660,28 +586,12 @@ expression: tools
               "type": "object"
             }
           ],
-          "description": "Two-shape listing payload: bare names in brief mode, name-keyed metadata in detailed mode.\n\nShared by [`ListTablesResponse`] and [`ListTriggersResponse`]. Serialises untagged:\nbrief mode → JSON array of strings, detailed mode → JSON object whose keys are\nentity names and whose values are the per-entity metadata."
-        }
-      },
-      "$schema": "https://json-schema.org/draft/2020-12/schema",
-      "description": "Response for the `listTriggers` tool.",
-      "properties": {
-        "nextCursor": {
-          "description": "Opaque cursor pointing to the next page. Absent when this is the final page.",
-          "type": [
-            "string",
-            "null"
-          ]
-        },
-        "triggers": {
-          "$ref": "#/$defs/ListEntries",
           "description": "Page of matching triggers. Shape depends on the request's `detailed` flag."
         }
       },
       "required": [
         "triggers"
       ],
-      "title": "ListTriggersResponse",
       "type": "object"
     },
     "annotations": {
@@ -696,8 +606,6 @@ expression: tools
     "title": "List Views",
     "description": "List user-defined views in the `public` schema, optionally filtered and/or with full metadata. Materialized views and system-schema views are excluded.\n\n<usecase>\nUse when:\n- Auditing views across a database (brief mode, default).\n- Searching for a view by partial name (pass `search`).\n- Inspecting a view's owner, comment, and full SELECT body before querying it (pass `detailed: true`). Detailed mode supersedes ad-hoc `readQuery` against `pg_views` / `pg_class`.\n</usecase>\n\n<parameters>\n- `database` — Database to target. Defaults to the active database.\n- `cursor` — Opaque pagination cursor; echo the prior response's `nextCursor`.\n- `search` — Case-insensitive filter on view names via `ILIKE`. `%` matches any sequence; `_` matches a single character.\n- `detailed` — When `true`, returns full metadata objects keyed by bare view name instead of bare name strings. Default `false`.\n</parameters>\n\n<examples>\n✓ \"What views are in mydb?\" → listViews(database=\"mydb\")\n✓ \"Find the active-users view\" → listViews(search=\"active\")\n✓ \"What does active_users select?\" → listViews(search=\"active_users\", detailed=true)\n✗ \"Show me the columns of a view\" → use listTables with `detailed: true` instead\n✗ \"List materialized views\" → use listMaterializedViews\n</examples>\n\n<what_it_returns>\nBrief mode (default): a sorted JSON array of view-name strings, e.g. `[\"active_orders\", \"active_users\"]`. View names are unique per schema, so no duplicates appear.\nDetailed mode: a JSON object keyed by bare view name; each value carries `schema`, `owner`, `description` (or null when no `COMMENT ON VIEW`), and `definition` (the SELECT body verbatim from `pg_views.definition`, with no `CREATE VIEW` wrapper). The view name is the map key only — it is not repeated inside the value.\n\nDetailed mode deliberately omits column metadata (`columns`), the `name` field (already the key), and view-level options (`security_barrier`, `security_invoker`, `WITH CHECK OPTION`). Column shape is recoverable from the `definition` text or via `listTables(detailed=true)` since Postgres exposes views in `pg_class`.\n</what_it_returns>\n\n<pagination>\nPaginated. Pass the prior response's `nextCursor` as `cursor` to fetch the next page. The `search` filter must stay the same across pages for cursor continuity. Brief and detailed modes share the same `viewname` row order, so a client can switch `detailed` between pages without losing position.\n</pagination>",
     "inputSchema": {
-      "$schema": "https://json-schema.org/draft/2020-12/schema",
-      "description": "Request for the Postgres `listViews` tool — extends the shared shape with `search` and `detailed`.",
       "properties": {
         "cursor": {
           "default": null,
@@ -729,12 +637,18 @@ expression: tools
           ]
         }
       },
-      "title": "ListViewsRequest",
       "type": "object"
     },
     "outputSchema": {
-      "$defs": {
-        "ListEntries": {
+      "properties": {
+        "nextCursor": {
+          "description": "Opaque cursor pointing to the next page. Absent when this is the final page.",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "views": {
           "anyOf": [
             {
               "description": "Brief mode: sorted array of bare entity-name strings.",
@@ -749,28 +663,12 @@ expression: tools
               "type": "object"
             }
           ],
-          "description": "Two-shape listing payload: bare names in brief mode, name-keyed metadata in detailed mode.\n\nShared by [`ListTablesResponse`] and [`ListTriggersResponse`]. Serialises untagged:\nbrief mode → JSON array of strings, detailed mode → JSON object whose keys are\nentity names and whose values are the per-entity metadata."
-        }
-      },
-      "$schema": "https://json-schema.org/draft/2020-12/schema",
-      "description": "Response for the `listViews` tool.",
-      "properties": {
-        "nextCursor": {
-          "description": "Opaque cursor pointing to the next page. Absent when this is the final page.",
-          "type": [
-            "string",
-            "null"
-          ]
-        },
-        "views": {
-          "$ref": "#/$defs/ListEntries",
           "description": "Page of matching views. Shape depends on the request's `detailed` flag."
         }
       },
       "required": [
         "views"
       ],
-      "title": "ListViewsResponse",
       "type": "object"
     },
     "annotations": {
@@ -785,8 +683,6 @@ expression: tools
     "title": "Read Query",
     "description": "Execute a read-only SQL query. Allowed statements: SELECT, SHOW, EXPLAIN.\n\n<usecase>\nUse when:\n- Querying data from tables (SELECT with WHERE, JOIN, GROUP BY, etc.)\n- Aggregations: COUNT, SUM, AVG, GROUP BY, HAVING\n- Listing server configuration parameters (SHOW)\n</usecase>\n\n<when_not_to_use>\n- Data changes (INSERT, UPDATE, DELETE) → use writeQuery\n- Query performance analysis → use explainQuery\n- Discovering tables or columns → use listTables (pass `detailed: true` to get columns, keys, and indexes)\n</when_not_to_use>\n\n<examples>\n✓ \"SELECT * FROM users WHERE status = 'active'\"\n✓ \"SELECT COUNT(*) FROM orders GROUP BY region\"\n✓ \"SHOW server_version\"\n✗ \"INSERT INTO users ...\" → use writeQuery\n✗ \"EXPLAIN SELECT ...\" → use explainQuery for structured analysis\n</examples>\n\n<what_it_returns>\nA JSON array of row objects, each keyed by column name.\n</what_it_returns>\n\n<pagination>\n`SELECT` results are paginated. Pass the prior response's `nextCursor` as `cursor` to fetch the next page. `SHOW` and `EXPLAIN` return a single page and ignore `cursor`.\n</pagination>",
     "inputSchema": {
-      "$schema": "https://json-schema.org/draft/2020-12/schema",
-      "description": "Request for the `readQuery` tool.",
       "properties": {
         "cursor": {
           "default": null,
@@ -812,12 +708,9 @@ expression: tools
       "required": [
         "query"
       ],
-      "title": "ReadQueryRequest",
       "type": "object"
     },
     "outputSchema": {
-      "$schema": "https://json-schema.org/draft/2020-12/schema",
-      "description": "Response for the `readQuery` tool.",
       "properties": {
         "nextCursor": {
           "description": "Opaque cursor pointing to the next page. Absent when this is the final\npage, when the result fits in one page, or when the statement is a\nnon-`SELECT` kind that does not paginate (e.g. `SHOW`, `EXPLAIN`).",
@@ -835,7 +728,6 @@ expression: tools
       "required": [
         "rows"
       ],
-      "title": "ReadQueryResponse",
       "type": "object"
     },
     "annotations": {
@@ -850,8 +742,6 @@ expression: tools
     "title": "Write Query",
     "description": "Execute a write SQL query (INSERT, UPDATE, DELETE, CREATE, ALTER, DROP).\n\n<usecase>\nUse when:\n- Inserting, updating, or deleting rows\n- Creating or altering tables, indexes, views, or other schema objects\n- Any data modification operation\n</usecase>\n\n<when_not_to_use>\n- Read-only queries (SELECT, SHOW) → use readQuery\n- Query performance analysis → use explainQuery\n- Creating/dropping entire databases → use createDatabase or dropDatabase\n</when_not_to_use>\n\n<examples>\n✓ \"INSERT INTO users (name, email) VALUES ('Alice', 'alice@example.com')\"\n✓ \"UPDATE orders SET status = 'shipped' WHERE id = 42\"\n✓ \"CREATE TABLE logs (id SERIAL PRIMARY KEY, message TEXT)\"\n✗ \"SELECT * FROM users\" → use readQuery\n</examples>\n\n<what_it_returns>\nA JSON array of affected/returning row objects, each keyed by column name.\n</what_it_returns>",
     "inputSchema": {
-      "$schema": "https://json-schema.org/draft/2020-12/schema",
-      "description": "Request for the `writeQuery` tool.",
       "properties": {
         "database": {
           "default": null,
@@ -869,12 +759,9 @@ expression: tools
       "required": [
         "query"
       ],
-      "title": "QueryRequest",
       "type": "object"
     },
     "outputSchema": {
-      "$schema": "https://json-schema.org/draft/2020-12/schema",
-      "description": "Response for the `writeQuery` and `explainQuery` tools.",
       "properties": {
         "rows": {
           "description": "Result rows, each a JSON object keyed by a column name.",
@@ -885,7 +772,6 @@ expression: tools
       "required": [
         "rows"
       ],
-      "title": "QueryResponse",
       "type": "object"
     },
     "annotations": {

--- a/tests/approval/snapshots/approval_sqlite__list_tools_read_only.snap
+++ b/tests/approval/snapshots/approval_sqlite__list_tools_read_only.snap
@@ -8,8 +8,6 @@ expression: tools
     "title": "Explain Query",
     "description": "Return the execution plan for a SQL query to diagnose performance. Use this tool instead of running EXPLAIN directly through readQuery — it provides structured output via EXPLAIN QUERY PLAN.\n\n<usecase>\nUse when:\n- A query runs slowly and you need to understand why\n- Understanding how SQLite will scan tables and use indexes\n- Deciding whether to add an index\n</usecase>\n\n<when_not_to_use>\n- Running actual queries → use readQuery or writeQuery\n- Checking table structure → use listTables with `detailed: true`\n</when_not_to_use>\n\n<examples>\n✓ \"Why is my SELECT on orders slow?\" → explainQuery(query=\"SELECT ...\")\n✓ \"How will SQLite execute this join?\" → explainQuery\n✗ \"Run this SELECT\" → use readQuery\n</examples>\n\n<what_it_returns>\nA JSON array of EXPLAIN QUERY PLAN rows showing how SQLite will scan tables, use indexes, and order operations.\n</what_it_returns>",
     "inputSchema": {
-      "$schema": "https://json-schema.org/draft/2020-12/schema",
-      "description": "Request for the `explainQuery` tool.",
       "properties": {
         "query": {
           "description": "The SQL query to explain.",
@@ -19,12 +17,9 @@ expression: tools
       "required": [
         "query"
       ],
-      "title": "ExplainQueryRequest",
       "type": "object"
     },
     "outputSchema": {
-      "$schema": "https://json-schema.org/draft/2020-12/schema",
-      "description": "Response for the `writeQuery` and `explainQuery` tools.",
       "properties": {
         "rows": {
           "description": "Result rows, each a JSON object keyed by a column name.",
@@ -35,7 +30,6 @@ expression: tools
       "required": [
         "rows"
       ],
-      "title": "QueryResponse",
       "type": "object"
     },
     "annotations": {
@@ -50,8 +44,6 @@ expression: tools
     "title": "List Tables",
     "description": "List tables in the connected database, optionally filtered and/or with full metadata.\n\n<usecase>\nUse when:\n- Exploring a database to find relevant tables (brief mode, default).\n- Searching for a table by partial name (pass `search`).\n- Inspecting a table's columns, constraints, indexes, and triggers before writing a query (pass `detailed: true`). This supersedes the legacy `getTableSchema` workflow.\n</usecase>\n\n<parameters>\n- `cursor` — Opaque pagination cursor; echo the prior response's `nextCursor`.\n- `search` — Case-insensitive filter on table names via `LIKE`. `%` matches any sequence; `_` matches a single character.\n- `detailed` — When `true`, returns full metadata objects keyed by table name instead of bare name strings. Default `false`.\n</parameters>\n\n<examples>\n✓ \"What tables are in this database?\" → listTables()\n✓ \"Find the orders table\" → listTables(search=\"order\")\n✓ \"What columns does orders have?\" → listTables(search=\"orders\", detailed=true)\n</examples>\n\n<what_it_returns>\nBrief mode (default): a sorted JSON array of table-name strings, e.g. `[\"customers\", \"orders\"]`.\nDetailed mode: a JSON object keyed by table name; each value carries `schema`, `kind`, `owner`, `comment`, `columns`, `constraints`, `indexes`, and `triggers` (the name is the key and is not repeated inside the value). Keys iterate in the same alphabetical order brief mode uses. Example: `{\"orders\": {\"schema\": \"main\", \"kind\": \"TABLE\", ...}}`.\n</what_it_returns>\n\n<pagination>\nPaginated. Pass the prior response's `nextCursor` as `cursor` to fetch the next page. The `search` filter must stay the same across pages for cursor continuity.\n</pagination>",
     "inputSchema": {
-      "$schema": "https://json-schema.org/draft/2020-12/schema",
-      "description": "Request for the `SQLite` `listTables` tool — supports optional search filter and detailed mode.",
       "properties": {
         "cursor": {
           "default": null,
@@ -75,12 +67,18 @@ expression: tools
           ]
         }
       },
-      "title": "ListTablesRequest",
       "type": "object"
     },
     "outputSchema": {
-      "$defs": {
-        "ListEntries": {
+      "properties": {
+        "nextCursor": {
+          "description": "Opaque cursor pointing to the next page. Absent when this is the final page.",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "tables": {
           "anyOf": [
             {
               "description": "Brief mode: sorted array of bare entity-name strings.",
@@ -95,28 +93,12 @@ expression: tools
               "type": "object"
             }
           ],
-          "description": "Two-shape listing payload: bare names in brief mode, name-keyed metadata in detailed mode.\n\nShared by [`ListTablesResponse`] and [`ListTriggersResponse`]. Serialises untagged:\nbrief mode → JSON array of strings, detailed mode → JSON object whose keys are\nentity names and whose values are the per-entity metadata."
-        }
-      },
-      "$schema": "https://json-schema.org/draft/2020-12/schema",
-      "description": "Response for the `listTables` tool.",
-      "properties": {
-        "nextCursor": {
-          "description": "Opaque cursor pointing to the next page. Absent when this is the final page.",
-          "type": [
-            "string",
-            "null"
-          ]
-        },
-        "tables": {
-          "$ref": "#/$defs/ListEntries",
           "description": "Page of matching tables. Shape depends on the request's `detailed` flag."
         }
       },
       "required": [
         "tables"
       ],
-      "title": "ListTablesResponse",
       "type": "object"
     },
     "annotations": {
@@ -131,8 +113,6 @@ expression: tools
     "title": "List Triggers",
     "description": "List triggers in the connected SQLite database, optionally filtered and/or with full metadata.\n\n<usecase>\nUse when:\n- Auditing trigger coverage across a database (brief mode, default).\n- Searching for a trigger by partial name (pass `search`).\n- Inspecting a trigger's table and full `CREATE TRIGGER` text before reasoning about side-effects (pass `detailed: true`). Detailed mode supersedes ad-hoc `readQuery` against `sqlite_schema`.\n</usecase>\n\n<parameters>\n- `cursor` — Opaque pagination cursor; echo the prior response's `nextCursor`.\n- `search` — Case-insensitive filter on trigger names via `LIKE` (SQLite's `LIKE` is ASCII-case-insensitive by default). `%` matches any sequence; `_` matches a single character.\n- `detailed` — When `true`, returns full metadata objects keyed by trigger name instead of bare name strings. Default `false`.\n</parameters>\n\n<examples>\n✓ \"What triggers are in this database?\" → listTriggers()\n✓ \"Find the audit triggers\" → listTriggers(search=\"audit\")\n✓ \"What does orders_audit_after_insert do?\" → listTriggers(search=\"orders_audit_after_insert\", detailed=true)\n✗ \"Show me a trigger's body\" → use detailed mode; the `definition` field carries the full `CREATE TRIGGER` text\n</examples>\n\n<what_it_returns>\nBrief mode (default): a sorted JSON array of trigger-name strings, e.g. `[\"customers_audit_after_insert\", \"orders_audit_after_insert\"]`.\nDetailed mode: a JSON object keyed by trigger name; each value carries exactly three fields — `schema` (always `\"main\"`), `table` (`sqlite_schema.tbl_name` — may be a view name for `INSTEAD OF` triggers), and `definition` (the original `CREATE TRIGGER` text from `sqlite_schema.sql`, byte-for-byte). Internal `sqlite_*` triggers are excluded.\nThe detailed payload deliberately diverges from the Postgres and MySQL/MariaDB `listTriggers` detailed payloads — `timing`, `events`, `activationLevel`, `status`, `functionName`, `sqlMode`, `characterSetClient`, `collationConnection`, `databaseCollation`, and `created` are absent. SQLite's catalogue does not expose those concepts as columns, and this tool deliberately avoids parsing the stored DDL to derive them; clients that need the timing or event keyword can read it off the prefix of `definition`.\nTriggers whose stored `sqlite_schema.sql` is `NULL` (rare; produced by extension-generated rows or hand-edited catalogues) are silently omitted from detailed mode but still listed by name in brief mode.\n</what_it_returns>\n\n<pagination>\nPaginated. Pass the prior response's `nextCursor` as `cursor` to fetch the next page. The `search` filter must stay the same across pages for cursor continuity.\n</pagination>",
     "inputSchema": {
-      "$schema": "https://json-schema.org/draft/2020-12/schema",
-      "description": "Request for the `SQLite` `listTriggers` tool — supports optional search filter and detailed mode.",
       "properties": {
         "cursor": {
           "default": null,
@@ -156,12 +136,18 @@ expression: tools
           ]
         }
       },
-      "title": "ListTriggersRequest",
       "type": "object"
     },
     "outputSchema": {
-      "$defs": {
-        "ListEntries": {
+      "properties": {
+        "nextCursor": {
+          "description": "Opaque cursor pointing to the next page. Absent when this is the final page.",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "triggers": {
           "anyOf": [
             {
               "description": "Brief mode: sorted array of bare entity-name strings.",
@@ -176,28 +162,12 @@ expression: tools
               "type": "object"
             }
           ],
-          "description": "Two-shape listing payload: bare names in brief mode, name-keyed metadata in detailed mode.\n\nShared by [`ListTablesResponse`] and [`ListTriggersResponse`]. Serialises untagged:\nbrief mode → JSON array of strings, detailed mode → JSON object whose keys are\nentity names and whose values are the per-entity metadata."
-        }
-      },
-      "$schema": "https://json-schema.org/draft/2020-12/schema",
-      "description": "Response for the `listTriggers` tool.",
-      "properties": {
-        "nextCursor": {
-          "description": "Opaque cursor pointing to the next page. Absent when this is the final page.",
-          "type": [
-            "string",
-            "null"
-          ]
-        },
-        "triggers": {
-          "$ref": "#/$defs/ListEntries",
           "description": "Page of matching triggers. Shape depends on the request's `detailed` flag."
         }
       },
       "required": [
         "triggers"
       ],
-      "title": "ListTriggersResponse",
       "type": "object"
     },
     "annotations": {
@@ -216,8 +186,15 @@ expression: tools
       "type": "object"
     },
     "outputSchema": {
-      "$defs": {
-        "ListEntries": {
+      "properties": {
+        "nextCursor": {
+          "description": "Opaque cursor pointing to the next page. Absent when this is the final page.",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "views": {
           "anyOf": [
             {
               "description": "Brief mode: sorted array of bare entity-name strings.",
@@ -232,28 +209,12 @@ expression: tools
               "type": "object"
             }
           ],
-          "description": "Two-shape listing payload: bare names in brief mode, name-keyed metadata in detailed mode.\n\nShared by [`ListTablesResponse`] and [`ListTriggersResponse`]. Serialises untagged:\nbrief mode → JSON array of strings, detailed mode → JSON object whose keys are\nentity names and whose values are the per-entity metadata."
-        }
-      },
-      "$schema": "https://json-schema.org/draft/2020-12/schema",
-      "description": "Response for the `listViews` tool.",
-      "properties": {
-        "nextCursor": {
-          "description": "Opaque cursor pointing to the next page. Absent when this is the final page.",
-          "type": [
-            "string",
-            "null"
-          ]
-        },
-        "views": {
-          "$ref": "#/$defs/ListEntries",
           "description": "Page of matching views. Shape depends on the request's `detailed` flag."
         }
       },
       "required": [
         "views"
       ],
-      "title": "ListViewsResponse",
       "type": "object"
     },
     "annotations": {
@@ -268,8 +229,6 @@ expression: tools
     "title": "Read Query",
     "description": "Execute a read-only SQL query. Allowed statements: SELECT, EXPLAIN.\n\n<usecase>\nUse when:\n- Querying data from tables (SELECT with WHERE, JOIN, GROUP BY, etc.)\n- Aggregations: COUNT, SUM, AVG, GROUP BY, HAVING\n- Checking data existence or counts\n</usecase>\n\n<when_not_to_use>\n- Data changes (INSERT, UPDATE, DELETE) → use writeQuery\n- Query performance analysis → use explainQuery\n- Discovering tables or columns → use listTables (pass `detailed: true` for columns)\n</when_not_to_use>\n\n<examples>\n✓ \"SELECT * FROM users WHERE status = 'active'\"\n✓ \"SELECT COUNT(*) FROM orders GROUP BY region\"\n✗ \"INSERT INTO users ...\" → use writeQuery\n✗ \"EXPLAIN SELECT ...\" → use explainQuery for structured analysis\n</examples>\n\n<what_it_returns>\nA JSON array of row objects, each keyed by column name.\n</what_it_returns>\n\n<pagination>\n`SELECT` results are paginated. Pass the prior response's `nextCursor` as `cursor` to fetch the next page. `EXPLAIN` returns a single page and ignores `cursor`.\n</pagination>",
     "inputSchema": {
-      "$schema": "https://json-schema.org/draft/2020-12/schema",
-      "description": "Request for the `readQuery` tool.",
       "properties": {
         "cursor": {
           "default": null,
@@ -287,12 +246,9 @@ expression: tools
       "required": [
         "query"
       ],
-      "title": "ReadQueryRequest",
       "type": "object"
     },
     "outputSchema": {
-      "$schema": "https://json-schema.org/draft/2020-12/schema",
-      "description": "Response for the `readQuery` tool.",
       "properties": {
         "nextCursor": {
           "description": "Opaque cursor pointing to the next page. Absent when this is the final\npage, when the result fits in one page, or when the statement is a\nnon-`SELECT` kind that does not paginate (e.g. `SHOW`, `EXPLAIN`).",
@@ -310,7 +266,6 @@ expression: tools
       "required": [
         "rows"
       ],
-      "title": "ReadQueryResponse",
       "type": "object"
     },
     "annotations": {

--- a/tests/approval/snapshots/approval_sqlite__list_tools_read_write.snap
+++ b/tests/approval/snapshots/approval_sqlite__list_tools_read_write.snap
@@ -8,8 +8,6 @@ expression: tools
     "title": "Drop Table",
     "description": "Drop a table from the database.\n\n<usecase>\nUse when:\n- Removing a table that is no longer needed\n- Cleaning up test or temporary tables\n</usecase>\n\n<examples>\n✓ \"Drop the temp_logs table\" → dropTable(table=\"temp_logs\")\n✗ \"Delete rows from a table\" → use writeQuery with DELETE\n</examples>\n\n<safety>\nIMPORTANT: This permanently deletes the table and ALL its data. This action cannot be undone.\n</safety>\n\n<what_it_returns>\nA confirmation message with the dropped table name.\n</what_it_returns>",
     "inputSchema": {
-      "$schema": "https://json-schema.org/draft/2020-12/schema",
-      "description": "Request for the `dropTable` tool.",
       "properties": {
         "table": {
           "description": "Name of the table to drop. Must be non-empty.",
@@ -19,12 +17,9 @@ expression: tools
       "required": [
         "table"
       ],
-      "title": "DropTableRequest",
       "type": "object"
     },
     "outputSchema": {
-      "$schema": "https://json-schema.org/draft/2020-12/schema",
-      "description": "Response for tools with no structured return data.",
       "properties": {
         "message": {
           "description": "Description of the completed operation.",
@@ -34,7 +29,6 @@ expression: tools
       "required": [
         "message"
       ],
-      "title": "MessageResponse",
       "type": "object"
     },
     "annotations": {
@@ -49,8 +43,6 @@ expression: tools
     "title": "Explain Query",
     "description": "Return the execution plan for a SQL query to diagnose performance. Use this tool instead of running EXPLAIN directly through readQuery — it provides structured output via EXPLAIN QUERY PLAN.\n\n<usecase>\nUse when:\n- A query runs slowly and you need to understand why\n- Understanding how SQLite will scan tables and use indexes\n- Deciding whether to add an index\n</usecase>\n\n<when_not_to_use>\n- Running actual queries → use readQuery or writeQuery\n- Checking table structure → use listTables with `detailed: true`\n</when_not_to_use>\n\n<examples>\n✓ \"Why is my SELECT on orders slow?\" → explainQuery(query=\"SELECT ...\")\n✓ \"How will SQLite execute this join?\" → explainQuery\n✗ \"Run this SELECT\" → use readQuery\n</examples>\n\n<what_it_returns>\nA JSON array of EXPLAIN QUERY PLAN rows showing how SQLite will scan tables, use indexes, and order operations.\n</what_it_returns>",
     "inputSchema": {
-      "$schema": "https://json-schema.org/draft/2020-12/schema",
-      "description": "Request for the `explainQuery` tool.",
       "properties": {
         "query": {
           "description": "The SQL query to explain.",
@@ -60,12 +52,9 @@ expression: tools
       "required": [
         "query"
       ],
-      "title": "ExplainQueryRequest",
       "type": "object"
     },
     "outputSchema": {
-      "$schema": "https://json-schema.org/draft/2020-12/schema",
-      "description": "Response for the `writeQuery` and `explainQuery` tools.",
       "properties": {
         "rows": {
           "description": "Result rows, each a JSON object keyed by a column name.",
@@ -76,7 +65,6 @@ expression: tools
       "required": [
         "rows"
       ],
-      "title": "QueryResponse",
       "type": "object"
     },
     "annotations": {
@@ -91,8 +79,6 @@ expression: tools
     "title": "List Tables",
     "description": "List tables in the connected database, optionally filtered and/or with full metadata.\n\n<usecase>\nUse when:\n- Exploring a database to find relevant tables (brief mode, default).\n- Searching for a table by partial name (pass `search`).\n- Inspecting a table's columns, constraints, indexes, and triggers before writing a query (pass `detailed: true`). This supersedes the legacy `getTableSchema` workflow.\n</usecase>\n\n<parameters>\n- `cursor` — Opaque pagination cursor; echo the prior response's `nextCursor`.\n- `search` — Case-insensitive filter on table names via `LIKE`. `%` matches any sequence; `_` matches a single character.\n- `detailed` — When `true`, returns full metadata objects keyed by table name instead of bare name strings. Default `false`.\n</parameters>\n\n<examples>\n✓ \"What tables are in this database?\" → listTables()\n✓ \"Find the orders table\" → listTables(search=\"order\")\n✓ \"What columns does orders have?\" → listTables(search=\"orders\", detailed=true)\n</examples>\n\n<what_it_returns>\nBrief mode (default): a sorted JSON array of table-name strings, e.g. `[\"customers\", \"orders\"]`.\nDetailed mode: a JSON object keyed by table name; each value carries `schema`, `kind`, `owner`, `comment`, `columns`, `constraints`, `indexes`, and `triggers` (the name is the key and is not repeated inside the value). Keys iterate in the same alphabetical order brief mode uses. Example: `{\"orders\": {\"schema\": \"main\", \"kind\": \"TABLE\", ...}}`.\n</what_it_returns>\n\n<pagination>\nPaginated. Pass the prior response's `nextCursor` as `cursor` to fetch the next page. The `search` filter must stay the same across pages for cursor continuity.\n</pagination>",
     "inputSchema": {
-      "$schema": "https://json-schema.org/draft/2020-12/schema",
-      "description": "Request for the `SQLite` `listTables` tool — supports optional search filter and detailed mode.",
       "properties": {
         "cursor": {
           "default": null,
@@ -116,12 +102,18 @@ expression: tools
           ]
         }
       },
-      "title": "ListTablesRequest",
       "type": "object"
     },
     "outputSchema": {
-      "$defs": {
-        "ListEntries": {
+      "properties": {
+        "nextCursor": {
+          "description": "Opaque cursor pointing to the next page. Absent when this is the final page.",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "tables": {
           "anyOf": [
             {
               "description": "Brief mode: sorted array of bare entity-name strings.",
@@ -136,28 +128,12 @@ expression: tools
               "type": "object"
             }
           ],
-          "description": "Two-shape listing payload: bare names in brief mode, name-keyed metadata in detailed mode.\n\nShared by [`ListTablesResponse`] and [`ListTriggersResponse`]. Serialises untagged:\nbrief mode → JSON array of strings, detailed mode → JSON object whose keys are\nentity names and whose values are the per-entity metadata."
-        }
-      },
-      "$schema": "https://json-schema.org/draft/2020-12/schema",
-      "description": "Response for the `listTables` tool.",
-      "properties": {
-        "nextCursor": {
-          "description": "Opaque cursor pointing to the next page. Absent when this is the final page.",
-          "type": [
-            "string",
-            "null"
-          ]
-        },
-        "tables": {
-          "$ref": "#/$defs/ListEntries",
           "description": "Page of matching tables. Shape depends on the request's `detailed` flag."
         }
       },
       "required": [
         "tables"
       ],
-      "title": "ListTablesResponse",
       "type": "object"
     },
     "annotations": {
@@ -172,8 +148,6 @@ expression: tools
     "title": "List Triggers",
     "description": "List triggers in the connected SQLite database, optionally filtered and/or with full metadata.\n\n<usecase>\nUse when:\n- Auditing trigger coverage across a database (brief mode, default).\n- Searching for a trigger by partial name (pass `search`).\n- Inspecting a trigger's table and full `CREATE TRIGGER` text before reasoning about side-effects (pass `detailed: true`). Detailed mode supersedes ad-hoc `readQuery` against `sqlite_schema`.\n</usecase>\n\n<parameters>\n- `cursor` — Opaque pagination cursor; echo the prior response's `nextCursor`.\n- `search` — Case-insensitive filter on trigger names via `LIKE` (SQLite's `LIKE` is ASCII-case-insensitive by default). `%` matches any sequence; `_` matches a single character.\n- `detailed` — When `true`, returns full metadata objects keyed by trigger name instead of bare name strings. Default `false`.\n</parameters>\n\n<examples>\n✓ \"What triggers are in this database?\" → listTriggers()\n✓ \"Find the audit triggers\" → listTriggers(search=\"audit\")\n✓ \"What does orders_audit_after_insert do?\" → listTriggers(search=\"orders_audit_after_insert\", detailed=true)\n✗ \"Show me a trigger's body\" → use detailed mode; the `definition` field carries the full `CREATE TRIGGER` text\n</examples>\n\n<what_it_returns>\nBrief mode (default): a sorted JSON array of trigger-name strings, e.g. `[\"customers_audit_after_insert\", \"orders_audit_after_insert\"]`.\nDetailed mode: a JSON object keyed by trigger name; each value carries exactly three fields — `schema` (always `\"main\"`), `table` (`sqlite_schema.tbl_name` — may be a view name for `INSTEAD OF` triggers), and `definition` (the original `CREATE TRIGGER` text from `sqlite_schema.sql`, byte-for-byte). Internal `sqlite_*` triggers are excluded.\nThe detailed payload deliberately diverges from the Postgres and MySQL/MariaDB `listTriggers` detailed payloads — `timing`, `events`, `activationLevel`, `status`, `functionName`, `sqlMode`, `characterSetClient`, `collationConnection`, `databaseCollation`, and `created` are absent. SQLite's catalogue does not expose those concepts as columns, and this tool deliberately avoids parsing the stored DDL to derive them; clients that need the timing or event keyword can read it off the prefix of `definition`.\nTriggers whose stored `sqlite_schema.sql` is `NULL` (rare; produced by extension-generated rows or hand-edited catalogues) are silently omitted from detailed mode but still listed by name in brief mode.\n</what_it_returns>\n\n<pagination>\nPaginated. Pass the prior response's `nextCursor` as `cursor` to fetch the next page. The `search` filter must stay the same across pages for cursor continuity.\n</pagination>",
     "inputSchema": {
-      "$schema": "https://json-schema.org/draft/2020-12/schema",
-      "description": "Request for the `SQLite` `listTriggers` tool — supports optional search filter and detailed mode.",
       "properties": {
         "cursor": {
           "default": null,
@@ -197,12 +171,18 @@ expression: tools
           ]
         }
       },
-      "title": "ListTriggersRequest",
       "type": "object"
     },
     "outputSchema": {
-      "$defs": {
-        "ListEntries": {
+      "properties": {
+        "nextCursor": {
+          "description": "Opaque cursor pointing to the next page. Absent when this is the final page.",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "triggers": {
           "anyOf": [
             {
               "description": "Brief mode: sorted array of bare entity-name strings.",
@@ -217,28 +197,12 @@ expression: tools
               "type": "object"
             }
           ],
-          "description": "Two-shape listing payload: bare names in brief mode, name-keyed metadata in detailed mode.\n\nShared by [`ListTablesResponse`] and [`ListTriggersResponse`]. Serialises untagged:\nbrief mode → JSON array of strings, detailed mode → JSON object whose keys are\nentity names and whose values are the per-entity metadata."
-        }
-      },
-      "$schema": "https://json-schema.org/draft/2020-12/schema",
-      "description": "Response for the `listTriggers` tool.",
-      "properties": {
-        "nextCursor": {
-          "description": "Opaque cursor pointing to the next page. Absent when this is the final page.",
-          "type": [
-            "string",
-            "null"
-          ]
-        },
-        "triggers": {
-          "$ref": "#/$defs/ListEntries",
           "description": "Page of matching triggers. Shape depends on the request's `detailed` flag."
         }
       },
       "required": [
         "triggers"
       ],
-      "title": "ListTriggersResponse",
       "type": "object"
     },
     "annotations": {
@@ -257,8 +221,15 @@ expression: tools
       "type": "object"
     },
     "outputSchema": {
-      "$defs": {
-        "ListEntries": {
+      "properties": {
+        "nextCursor": {
+          "description": "Opaque cursor pointing to the next page. Absent when this is the final page.",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "views": {
           "anyOf": [
             {
               "description": "Brief mode: sorted array of bare entity-name strings.",
@@ -273,28 +244,12 @@ expression: tools
               "type": "object"
             }
           ],
-          "description": "Two-shape listing payload: bare names in brief mode, name-keyed metadata in detailed mode.\n\nShared by [`ListTablesResponse`] and [`ListTriggersResponse`]. Serialises untagged:\nbrief mode → JSON array of strings, detailed mode → JSON object whose keys are\nentity names and whose values are the per-entity metadata."
-        }
-      },
-      "$schema": "https://json-schema.org/draft/2020-12/schema",
-      "description": "Response for the `listViews` tool.",
-      "properties": {
-        "nextCursor": {
-          "description": "Opaque cursor pointing to the next page. Absent when this is the final page.",
-          "type": [
-            "string",
-            "null"
-          ]
-        },
-        "views": {
-          "$ref": "#/$defs/ListEntries",
           "description": "Page of matching views. Shape depends on the request's `detailed` flag."
         }
       },
       "required": [
         "views"
       ],
-      "title": "ListViewsResponse",
       "type": "object"
     },
     "annotations": {
@@ -309,8 +264,6 @@ expression: tools
     "title": "Read Query",
     "description": "Execute a read-only SQL query. Allowed statements: SELECT, EXPLAIN.\n\n<usecase>\nUse when:\n- Querying data from tables (SELECT with WHERE, JOIN, GROUP BY, etc.)\n- Aggregations: COUNT, SUM, AVG, GROUP BY, HAVING\n- Checking data existence or counts\n</usecase>\n\n<when_not_to_use>\n- Data changes (INSERT, UPDATE, DELETE) → use writeQuery\n- Query performance analysis → use explainQuery\n- Discovering tables or columns → use listTables (pass `detailed: true` for columns)\n</when_not_to_use>\n\n<examples>\n✓ \"SELECT * FROM users WHERE status = 'active'\"\n✓ \"SELECT COUNT(*) FROM orders GROUP BY region\"\n✗ \"INSERT INTO users ...\" → use writeQuery\n✗ \"EXPLAIN SELECT ...\" → use explainQuery for structured analysis\n</examples>\n\n<what_it_returns>\nA JSON array of row objects, each keyed by column name.\n</what_it_returns>\n\n<pagination>\n`SELECT` results are paginated. Pass the prior response's `nextCursor` as `cursor` to fetch the next page. `EXPLAIN` returns a single page and ignores `cursor`.\n</pagination>",
     "inputSchema": {
-      "$schema": "https://json-schema.org/draft/2020-12/schema",
-      "description": "Request for the `readQuery` tool.",
       "properties": {
         "cursor": {
           "default": null,
@@ -328,12 +281,9 @@ expression: tools
       "required": [
         "query"
       ],
-      "title": "ReadQueryRequest",
       "type": "object"
     },
     "outputSchema": {
-      "$schema": "https://json-schema.org/draft/2020-12/schema",
-      "description": "Response for the `readQuery` tool.",
       "properties": {
         "nextCursor": {
           "description": "Opaque cursor pointing to the next page. Absent when this is the final\npage, when the result fits in one page, or when the statement is a\nnon-`SELECT` kind that does not paginate (e.g. `SHOW`, `EXPLAIN`).",
@@ -351,7 +301,6 @@ expression: tools
       "required": [
         "rows"
       ],
-      "title": "ReadQueryResponse",
       "type": "object"
     },
     "annotations": {
@@ -366,8 +315,6 @@ expression: tools
     "title": "Write Query",
     "description": "Execute a write SQL query (INSERT, UPDATE, DELETE, CREATE, ALTER, DROP).\n\n<usecase>\nUse when:\n- Inserting, updating, or deleting rows\n- Creating or altering tables, indexes, views, or other schema objects\n- Any data modification operation\n</usecase>\n\n<when_not_to_use>\n- Read-only queries (SELECT) → use readQuery\n- Query performance analysis → use explainQuery\n</when_not_to_use>\n\n<examples>\n✓ \"INSERT INTO users (name, email) VALUES ('Alice', 'alice@example.com')\"\n✓ \"UPDATE orders SET status = 'shipped' WHERE id = 42\"\n✓ \"CREATE TABLE logs (id INTEGER PRIMARY KEY, message TEXT)\"\n✗ \"SELECT * FROM users\" → use readQuery\n</examples>\n\n<what_it_returns>\nA JSON array of affected/returning row objects, each keyed by column name.\n</what_it_returns>",
     "inputSchema": {
-      "$schema": "https://json-schema.org/draft/2020-12/schema",
-      "description": "Request for the `writeQuery` tool.",
       "properties": {
         "query": {
           "description": "The SQL query to execute.",
@@ -377,12 +324,9 @@ expression: tools
       "required": [
         "query"
       ],
-      "title": "QueryRequest",
       "type": "object"
     },
     "outputSchema": {
-      "$schema": "https://json-schema.org/draft/2020-12/schema",
-      "description": "Response for the `writeQuery` and `explainQuery` tools.",
       "properties": {
         "rows": {
           "description": "Result rows, each a JSON object keyed by a column name.",
@@ -393,7 +337,6 @@ expression: tools
       "required": [
         "rows"
       ],
-      "title": "QueryResponse",
       "type": "object"
     },
     "annotations": {


### PR DESCRIPTION
## Summary

- Slim every MCP tool input/output JSON schema at the source — backends override `ToolBase::{input_schema, output_schema}` to call shared `dbmcp_server::schema::{input_schema, output_schema}` helpers that strip the four root metadata fields (`$schema`, `title`, `description`) and inline every `$defs`/`$ref` indirection. No more post-processing the `tools/list` response.
- Implement the metadata strip as a `schemars::transform::Transform` (`StripRootMetadata`) registered via `SchemaSettings::with_transform`, so all shaping happens inside the schemars pipeline rather than as a post-build `JsonObject` mutation.
- Drop the 34 now-unused `#[schemars(rename = "...")]` attributes on pinned/unpinned request variants. They previously aligned shared `$defs` keys / root `title`s; with `inline_subschemas = true` and the new transform, neither appears in output.
- Snapshot tests (`approval_*__list_tools_*`) capture the resulting trim — every backend snapshot shrinks substantially (mysql/postgres/sqlite, pinned + unpinned, read-only + read-write).

## Test plan

- [x] `cargo fmt --check`
- [x] `cargo clippy --workspace --tests -- -D warnings`
- [x] `cargo test --workspace --lib --bins` (snapshot tests in `tests/approval/*` included)
- [x] `./tests/run.sh` — 734 integration tests across mariadb_12, mysql_9, postgres_18, sqlite, all PASS