### PR TITLE
refactor(server)!: unify list-tool responses into ListEntriesResponse

### DIFF
--- a/crates/mysql/src/tools/list_functions.rs
+++ b/crates/mysql/src/tools/list_functions.rs
@@ -1,7 +1,7 @@
 //! MCP tool: `listFunctions`.
 
 use dbmcp_server::pagination::{Cursor, Pager};
-use dbmcp_server::types::ListFunctionsResponse;
+use dbmcp_server::types::ListEntriesResponse;
 
 use super::prelude::*;
 use crate::types::{PinnedListFunctionsRequest, UnpinnedListFunctionsRequest};
@@ -24,7 +24,7 @@ pub(crate) struct PinnedListFunctionsTool;
 
 impl ToolBase for PinnedListFunctionsTool {
     type Parameter = PinnedListFunctionsRequest;
-    type Output = ListFunctionsResponse;
+    type Output = ListEntriesResponse;
     type Error = ErrorData;
 
     fn name() -> Cow<'static, str> {
@@ -65,7 +65,7 @@ pub(crate) struct UnpinnedListFunctionsTool;
 
 impl ToolBase for UnpinnedListFunctionsTool {
     type Parameter = UnpinnedListFunctionsRequest;
-    type Output = ListFunctionsResponse;
+    type Output = ListEntriesResponse;
     type Error = ErrorData;
 
     fn name() -> Cow<'static, str> {
@@ -227,7 +227,7 @@ impl MysqlHandler {
         cursor: Option<Cursor>,
         search: Option<String>,
         detailed: bool,
-    ) -> Result<ListFunctionsResponse, ErrorData> {
+    ) -> Result<ListEntriesResponse, ErrorData> {
         let database = database
             .as_deref()
             .map(str::trim)
@@ -251,7 +251,7 @@ impl MysqlHandler {
                 )
                 .await?;
             let (rows, next_cursor) = pager.paginate(rows);
-            return Ok(ListFunctionsResponse::detailed(
+            return Ok(ListEntriesResponse::detailed(
                 rows.into_iter().map(|(name, json)| (name, json.0)).collect(),
                 next_cursor,
             ));
@@ -270,6 +270,6 @@ impl MysqlHandler {
             )
             .await?;
         let (functions, next_cursor) = pager.paginate(rows);
-        Ok(ListFunctionsResponse::brief(functions, next_cursor))
+        Ok(ListEntriesResponse::brief(functions, next_cursor))
     }
 }

--- a/crates/mysql/src/tools/list_procedures.rs
+++ b/crates/mysql/src/tools/list_procedures.rs
@@ -3,7 +3,7 @@
 use dbmcp_server::pagination::{Cursor, Pager};
 
 use super::prelude::*;
-use crate::types::{ListProceduresResponse, PinnedListProceduresRequest, UnpinnedListProceduresRequest};
+use crate::types::{ListEntriesResponse, PinnedListProceduresRequest, UnpinnedListProceduresRequest};
 
 const NAME: &str = "listProcedures";
 const TITLE: &str = "List Procedures";
@@ -23,7 +23,7 @@ pub(crate) struct PinnedListProceduresTool;
 
 impl ToolBase for PinnedListProceduresTool {
     type Parameter = PinnedListProceduresRequest;
-    type Output = ListProceduresResponse;
+    type Output = ListEntriesResponse;
     type Error = ErrorData;
 
     fn name() -> Cow<'static, str> {
@@ -64,7 +64,7 @@ pub(crate) struct UnpinnedListProceduresTool;
 
 impl ToolBase for UnpinnedListProceduresTool {
     type Parameter = UnpinnedListProceduresRequest;
-    type Output = ListProceduresResponse;
+    type Output = ListEntriesResponse;
     type Error = ErrorData;
 
     fn name() -> Cow<'static, str> {
@@ -236,7 +236,7 @@ impl MysqlHandler {
         cursor: Option<Cursor>,
         search: Option<String>,
         detailed: bool,
-    ) -> Result<ListProceduresResponse, ErrorData> {
+    ) -> Result<ListEntriesResponse, ErrorData> {
         let database = database
             .as_deref()
             .map(str::trim)
@@ -260,7 +260,7 @@ impl MysqlHandler {
                 )
                 .await?;
             let (rows, next_cursor) = pager.paginate(rows);
-            return Ok(ListProceduresResponse::detailed(
+            return Ok(ListEntriesResponse::detailed(
                 rows.into_iter().map(|(name, json)| (name, json.0)).collect(),
                 next_cursor,
             ));
@@ -279,6 +279,6 @@ impl MysqlHandler {
             )
             .await?;
         let (procedures, next_cursor) = pager.paginate(rows);
-        Ok(ListProceduresResponse::brief(procedures, next_cursor))
+        Ok(ListEntriesResponse::brief(procedures, next_cursor))
     }
 }

--- a/crates/mysql/src/tools/list_tables.rs
+++ b/crates/mysql/src/tools/list_tables.rs
@@ -3,7 +3,7 @@
 use dbmcp_server::pagination::{Cursor, Pager};
 
 use super::prelude::*;
-use crate::types::{ListTablesResponse, PinnedListTablesRequest, UnpinnedListTablesRequest};
+use crate::types::{ListEntriesResponse, PinnedListTablesRequest, UnpinnedListTablesRequest};
 
 /// Brief-mode SQL: `information_schema.TABLES` filtered to `BASE TABLE` rows.
 ///
@@ -302,7 +302,7 @@ pub(crate) struct PinnedListTablesTool;
 
 impl ToolBase for PinnedListTablesTool {
     type Parameter = PinnedListTablesRequest;
-    type Output = ListTablesResponse;
+    type Output = ListEntriesResponse;
     type Error = ErrorData;
 
     fn name() -> Cow<'static, str> {
@@ -343,7 +343,7 @@ pub(crate) struct UnpinnedListTablesTool;
 
 impl ToolBase for UnpinnedListTablesTool {
     type Parameter = UnpinnedListTablesRequest;
-    type Output = ListTablesResponse;
+    type Output = ListEntriesResponse;
     type Error = ErrorData;
 
     fn name() -> Cow<'static, str> {
@@ -398,7 +398,7 @@ impl MysqlHandler {
         cursor: Option<Cursor>,
         search: Option<String>,
         detailed: bool,
-    ) -> Result<ListTablesResponse, ErrorData> {
+    ) -> Result<ListEntriesResponse, ErrorData> {
         let database = database
             .as_deref()
             .map(str::trim)
@@ -423,7 +423,7 @@ impl MysqlHandler {
                 )
                 .await?;
             let (rows, next_cursor) = pager.paginate(rows);
-            return Ok(ListTablesResponse::detailed(
+            return Ok(ListEntriesResponse::detailed(
                 rows.into_iter().map(|(name, json)| (name, json.0)).collect(),
                 next_cursor,
             ));
@@ -442,6 +442,6 @@ impl MysqlHandler {
             )
             .await?;
         let (tables, next_cursor) = pager.paginate(rows);
-        Ok(ListTablesResponse::brief(tables, next_cursor))
+        Ok(ListEntriesResponse::brief(tables, next_cursor))
     }
 }

--- a/crates/mysql/src/tools/list_triggers.rs
+++ b/crates/mysql/src/tools/list_triggers.rs
@@ -1,7 +1,7 @@
 //! MCP tool: `listTriggers`.
 
 use dbmcp_server::pagination::{Cursor, Pager};
-use dbmcp_server::types::{ListTriggersResponse, PinnedListTriggersRequest, UnpinnedListTriggersRequest};
+use dbmcp_server::types::{ListEntriesResponse, PinnedListTriggersRequest, UnpinnedListTriggersRequest};
 
 use super::prelude::*;
 
@@ -23,7 +23,7 @@ pub(crate) struct PinnedListTriggersTool;
 
 impl ToolBase for PinnedListTriggersTool {
     type Parameter = PinnedListTriggersRequest;
-    type Output = ListTriggersResponse;
+    type Output = ListEntriesResponse;
     type Error = ErrorData;
 
     fn name() -> Cow<'static, str> {
@@ -64,7 +64,7 @@ pub(crate) struct UnpinnedListTriggersTool;
 
 impl ToolBase for UnpinnedListTriggersTool {
     type Parameter = UnpinnedListTriggersRequest;
-    type Output = ListTriggersResponse;
+    type Output = ListEntriesResponse;
     type Error = ErrorData;
 
     fn name() -> Cow<'static, str> {
@@ -181,7 +181,7 @@ impl MysqlHandler {
         cursor: Option<Cursor>,
         search: Option<String>,
         detailed: bool,
-    ) -> Result<ListTriggersResponse, ErrorData> {
+    ) -> Result<ListEntriesResponse, ErrorData> {
         let database = database
             .as_deref()
             .map(str::trim)
@@ -205,7 +205,7 @@ impl MysqlHandler {
                 )
                 .await?;
             let (rows, next_cursor) = pager.paginate(rows);
-            return Ok(ListTriggersResponse::detailed(
+            return Ok(ListEntriesResponse::detailed(
                 rows.into_iter().map(|(name, json)| (name, json.0)).collect(),
                 next_cursor,
             ));
@@ -224,6 +224,6 @@ impl MysqlHandler {
             )
             .await?;
         let (triggers, next_cursor) = pager.paginate(rows);
-        Ok(ListTriggersResponse::brief(triggers, next_cursor))
+        Ok(ListEntriesResponse::brief(triggers, next_cursor))
     }
 }

--- a/crates/mysql/src/tools/list_views.rs
+++ b/crates/mysql/src/tools/list_views.rs
@@ -3,7 +3,7 @@
 use dbmcp_server::pagination::{Cursor, Pager};
 
 use super::prelude::*;
-use crate::types::{ListViewsResponse, PinnedListViewsRequest, UnpinnedListViewsRequest};
+use crate::types::{ListEntriesResponse, PinnedListViewsRequest, UnpinnedListViewsRequest};
 
 const NAME: &str = "listViews";
 const TITLE: &str = "List Views";
@@ -23,7 +23,7 @@ pub(crate) struct PinnedListViewsTool;
 
 impl ToolBase for PinnedListViewsTool {
     type Parameter = PinnedListViewsRequest;
-    type Output = ListViewsResponse;
+    type Output = ListEntriesResponse;
     type Error = ErrorData;
 
     fn name() -> Cow<'static, str> {
@@ -64,7 +64,7 @@ pub(crate) struct UnpinnedListViewsTool;
 
 impl ToolBase for UnpinnedListViewsTool {
     type Parameter = UnpinnedListViewsRequest;
-    type Output = ListViewsResponse;
+    type Output = ListEntriesResponse;
     type Error = ErrorData;
 
     fn name() -> Cow<'static, str> {
@@ -164,7 +164,7 @@ impl MysqlHandler {
         cursor: Option<Cursor>,
         search: Option<String>,
         detailed: bool,
-    ) -> Result<ListViewsResponse, ErrorData> {
+    ) -> Result<ListEntriesResponse, ErrorData> {
         let database = database
             .as_deref()
             .map(str::trim)
@@ -188,7 +188,7 @@ impl MysqlHandler {
                 )
                 .await?;
             let (rows, next_cursor) = pager.paginate(rows);
-            return Ok(ListViewsResponse::detailed(
+            return Ok(ListEntriesResponse::detailed(
                 rows.into_iter().map(|(name, json)| (name, json.0)).collect(),
                 next_cursor,
             ));
@@ -208,6 +208,6 @@ impl MysqlHandler {
             .await?;
         let (views, next_cursor) = pager.paginate(rows);
 
-        Ok(ListViewsResponse::brief(views, next_cursor))
+        Ok(ListEntriesResponse::brief(views, next_cursor))
     }
 }

--- a/crates/mysql/src/types.rs
+++ b/crates/mysql/src/types.rs
@@ -1,6 +1,6 @@
 //! MySQL/MariaDB-specific MCP tool request types.
 //!
-//! `ListEntries` and `ListTablesResponse` live in the shared `dbmcp-server`
+//! `ListEntries` and `ListEntriesResponse` live in the shared `dbmcp-server`
 //! crate; they are re-exported here so call sites can keep importing them
 //! from `crate::types`.
 
@@ -8,9 +8,7 @@ use dbmcp_server::pagination::Cursor;
 use schemars::JsonSchema;
 use serde::Deserialize;
 
-pub use dbmcp_server::types::{
-    ListEntries, ListFunctionsResponse, ListProceduresResponse, ListTablesResponse, ListViewsResponse,
-};
+pub use dbmcp_server::types::{ListEntries, ListEntriesResponse};
 
 /// Request for the `dropTable` tool.
 #[derive(Debug, Default, Deserialize, JsonSchema)]

--- a/crates/postgres/src/tools/list_functions.rs
+++ b/crates/postgres/src/tools/list_functions.rs
@@ -3,7 +3,7 @@
 use dbmcp_server::pagination::{Cursor, Pager};
 
 use super::prelude::*;
-use crate::types::{ListFunctionsResponse, PinnedListFunctionsRequest, UnpinnedListFunctionsRequest};
+use crate::types::{ListEntriesResponse, PinnedListFunctionsRequest, UnpinnedListFunctionsRequest};
 
 const NAME: &str = "listFunctions";
 const TITLE: &str = "List Functions";
@@ -23,7 +23,7 @@ pub(crate) struct PinnedListFunctionsTool;
 
 impl ToolBase for PinnedListFunctionsTool {
     type Parameter = PinnedListFunctionsRequest;
-    type Output = ListFunctionsResponse;
+    type Output = ListEntriesResponse;
     type Error = ErrorData;
 
     fn name() -> Cow<'static, str> {
@@ -64,7 +64,7 @@ pub(crate) struct UnpinnedListFunctionsTool;
 
 impl ToolBase for UnpinnedListFunctionsTool {
     type Parameter = UnpinnedListFunctionsRequest;
-    type Output = ListFunctionsResponse;
+    type Output = ListEntriesResponse;
     type Error = ErrorData;
 
     fn name() -> Cow<'static, str> {
@@ -190,7 +190,7 @@ impl PostgresHandler {
         cursor: Option<Cursor>,
         search: Option<String>,
         detailed: bool,
-    ) -> Result<ListFunctionsResponse, ErrorData> {
+    ) -> Result<ListEntriesResponse, ErrorData> {
         let database = database.as_deref().map(str::trim).filter(|s| !s.is_empty());
         let pattern = search.as_deref().map(str::trim).filter(|s| !s.is_empty());
         let pager = Pager::new(cursor, self.config.page_size);
@@ -207,7 +207,7 @@ impl PostgresHandler {
                 )
                 .await?;
             let (rows, next_cursor) = pager.paginate(rows);
-            return Ok(ListFunctionsResponse::detailed(
+            return Ok(ListEntriesResponse::detailed(
                 rows.into_iter().map(|(key, json)| (key, json.0)).collect(),
                 next_cursor,
             ));
@@ -224,6 +224,6 @@ impl PostgresHandler {
             )
             .await?;
         let (functions, next_cursor) = pager.paginate(rows);
-        Ok(ListFunctionsResponse::brief(functions, next_cursor))
+        Ok(ListEntriesResponse::brief(functions, next_cursor))
     }
 }

--- a/crates/postgres/src/tools/list_materialized_views.rs
+++ b/crates/postgres/src/tools/list_materialized_views.rs
@@ -3,9 +3,7 @@
 use dbmcp_server::pagination::{Cursor, Pager};
 
 use super::prelude::*;
-use crate::types::{
-    ListMaterializedViewsResponse, PinnedListMaterializedViewsRequest, UnpinnedListMaterializedViewsRequest,
-};
+use crate::types::{ListEntriesResponse, PinnedListMaterializedViewsRequest, UnpinnedListMaterializedViewsRequest};
 
 const NAME: &str = "listMaterializedViews";
 const TITLE: &str = "List Materialized Views";
@@ -25,7 +23,7 @@ pub(crate) struct PinnedListMaterializedViewsTool;
 
 impl ToolBase for PinnedListMaterializedViewsTool {
     type Parameter = PinnedListMaterializedViewsRequest;
-    type Output = ListMaterializedViewsResponse;
+    type Output = ListEntriesResponse;
     type Error = ErrorData;
 
     fn name() -> Cow<'static, str> {
@@ -66,7 +64,7 @@ pub(crate) struct UnpinnedListMaterializedViewsTool;
 
 impl ToolBase for UnpinnedListMaterializedViewsTool {
     type Parameter = UnpinnedListMaterializedViewsRequest;
-    type Output = ListMaterializedViewsResponse;
+    type Output = ListEntriesResponse;
     type Error = ErrorData;
 
     fn name() -> Cow<'static, str> {
@@ -166,7 +164,7 @@ impl PostgresHandler {
         cursor: Option<Cursor>,
         search: Option<String>,
         detailed: bool,
-    ) -> Result<ListMaterializedViewsResponse, ErrorData> {
+    ) -> Result<ListEntriesResponse, ErrorData> {
         let database = database.as_deref().map(str::trim).filter(|s| !s.is_empty());
         let pattern = search.as_deref().map(str::trim).filter(|s| !s.is_empty());
         let pager = Pager::new(cursor, self.config.page_size);
@@ -183,7 +181,7 @@ impl PostgresHandler {
                 )
                 .await?;
             let (rows, next_cursor) = pager.paginate(rows);
-            return Ok(ListMaterializedViewsResponse::detailed(
+            return Ok(ListEntriesResponse::detailed(
                 rows.into_iter().map(|(key, json)| (key, json.0)).collect(),
                 next_cursor,
             ));
@@ -200,6 +198,6 @@ impl PostgresHandler {
             )
             .await?;
         let (materialized_views, next_cursor) = pager.paginate(rows);
-        Ok(ListMaterializedViewsResponse::brief(materialized_views, next_cursor))
+        Ok(ListEntriesResponse::brief(materialized_views, next_cursor))
     }
 }

--- a/crates/postgres/src/tools/list_procedures.rs
+++ b/crates/postgres/src/tools/list_procedures.rs
@@ -3,7 +3,7 @@
 use dbmcp_server::pagination::{Cursor, Pager};
 
 use super::prelude::*;
-use crate::types::{ListProceduresResponse, PinnedListProceduresRequest, UnpinnedListProceduresRequest};
+use crate::types::{ListEntriesResponse, PinnedListProceduresRequest, UnpinnedListProceduresRequest};
 
 const NAME: &str = "listProcedures";
 const TITLE: &str = "List Procedures";
@@ -23,7 +23,7 @@ pub(crate) struct PinnedListProceduresTool;
 
 impl ToolBase for PinnedListProceduresTool {
     type Parameter = PinnedListProceduresRequest;
-    type Output = ListProceduresResponse;
+    type Output = ListEntriesResponse;
     type Error = ErrorData;
 
     fn name() -> Cow<'static, str> {
@@ -64,7 +64,7 @@ pub(crate) struct UnpinnedListProceduresTool;
 
 impl ToolBase for UnpinnedListProceduresTool {
     type Parameter = UnpinnedListProceduresRequest;
-    type Output = ListProceduresResponse;
+    type Output = ListEntriesResponse;
     type Error = ErrorData;
 
     fn name() -> Cow<'static, str> {
@@ -175,7 +175,7 @@ impl PostgresHandler {
         cursor: Option<Cursor>,
         search: Option<String>,
         detailed: bool,
-    ) -> Result<ListProceduresResponse, ErrorData> {
+    ) -> Result<ListEntriesResponse, ErrorData> {
         let database = database.as_deref().map(str::trim).filter(|s| !s.is_empty());
         let pattern = search.as_deref().map(str::trim).filter(|s| !s.is_empty());
         let pager = Pager::new(cursor, self.config.page_size);
@@ -192,7 +192,7 @@ impl PostgresHandler {
                 )
                 .await?;
             let (rows, next_cursor) = pager.paginate(rows);
-            return Ok(ListProceduresResponse::detailed(
+            return Ok(ListEntriesResponse::detailed(
                 rows.into_iter().map(|(key, json)| (key, json.0)).collect(),
                 next_cursor,
             ));
@@ -209,6 +209,6 @@ impl PostgresHandler {
             )
             .await?;
         let (procedures, next_cursor) = pager.paginate(rows);
-        Ok(ListProceduresResponse::brief(procedures, next_cursor))
+        Ok(ListEntriesResponse::brief(procedures, next_cursor))
     }
 }

--- a/crates/postgres/src/tools/list_tables.rs
+++ b/crates/postgres/src/tools/list_tables.rs
@@ -3,7 +3,7 @@
 use dbmcp_server::pagination::{Cursor, Pager};
 
 use super::prelude::*;
-use crate::types::{ListTablesResponse, PinnedListTablesRequest, UnpinnedListTablesRequest};
+use crate::types::{ListEntriesResponse, PinnedListTablesRequest, UnpinnedListTablesRequest};
 
 const NAME: &str = "listTables";
 const TITLE: &str = "List Tables";
@@ -23,7 +23,7 @@ pub(crate) struct PinnedListTablesTool;
 
 impl ToolBase for PinnedListTablesTool {
     type Parameter = PinnedListTablesRequest;
-    type Output = ListTablesResponse;
+    type Output = ListEntriesResponse;
     type Error = ErrorData;
 
     fn name() -> Cow<'static, str> {
@@ -64,7 +64,7 @@ pub(crate) struct UnpinnedListTablesTool;
 
 impl ToolBase for UnpinnedListTablesTool {
     type Parameter = UnpinnedListTablesRequest;
-    type Output = ListTablesResponse;
+    type Output = ListEntriesResponse;
     type Error = ErrorData;
 
     fn name() -> Cow<'static, str> {
@@ -276,7 +276,7 @@ impl PostgresHandler {
         cursor: Option<Cursor>,
         search: Option<String>,
         detailed: bool,
-    ) -> Result<ListTablesResponse, ErrorData> {
+    ) -> Result<ListEntriesResponse, ErrorData> {
         // Identifier validation runs inside the connection pool — passing the
         // trimmed name straight through avoids a redundant round-trip check.
         let database = database.as_deref().map(str::trim).filter(|s| !s.is_empty());
@@ -295,7 +295,7 @@ impl PostgresHandler {
                 )
                 .await?;
             let (rows, next_cursor) = pager.paginate(rows);
-            return Ok(ListTablesResponse::detailed(
+            return Ok(ListEntriesResponse::detailed(
                 rows.into_iter().map(|(name, json)| (name, json.0)).collect(),
                 next_cursor,
             ));
@@ -312,6 +312,6 @@ impl PostgresHandler {
             )
             .await?;
         let (tables, next_cursor) = pager.paginate(rows);
-        Ok(ListTablesResponse::brief(tables, next_cursor))
+        Ok(ListEntriesResponse::brief(tables, next_cursor))
     }
 }

--- a/crates/postgres/src/tools/list_triggers.rs
+++ b/crates/postgres/src/tools/list_triggers.rs
@@ -3,7 +3,7 @@
 use dbmcp_server::pagination::{Cursor, Pager};
 
 use super::prelude::*;
-use crate::types::{ListTriggersResponse, PinnedListTriggersRequest, UnpinnedListTriggersRequest};
+use crate::types::{ListEntriesResponse, PinnedListTriggersRequest, UnpinnedListTriggersRequest};
 
 const NAME: &str = "listTriggers";
 const TITLE: &str = "List Triggers";
@@ -23,7 +23,7 @@ pub(crate) struct PinnedListTriggersTool;
 
 impl ToolBase for PinnedListTriggersTool {
     type Parameter = PinnedListTriggersRequest;
-    type Output = ListTriggersResponse;
+    type Output = ListEntriesResponse;
     type Error = ErrorData;
 
     fn name() -> Cow<'static, str> {
@@ -64,7 +64,7 @@ pub(crate) struct UnpinnedListTriggersTool;
 
 impl ToolBase for UnpinnedListTriggersTool {
     type Parameter = UnpinnedListTriggersRequest;
-    type Output = ListTriggersResponse;
+    type Output = ListEntriesResponse;
     type Error = ErrorData;
 
     fn name() -> Cow<'static, str> {
@@ -187,7 +187,7 @@ impl PostgresHandler {
         cursor: Option<Cursor>,
         search: Option<String>,
         detailed: bool,
-    ) -> Result<ListTriggersResponse, ErrorData> {
+    ) -> Result<ListEntriesResponse, ErrorData> {
         let database = database.as_deref().map(str::trim).filter(|s| !s.is_empty());
         let pattern = search.as_deref().map(str::trim).filter(|s| !s.is_empty());
         let pager = Pager::new(cursor, self.config.page_size);
@@ -204,7 +204,7 @@ impl PostgresHandler {
                 )
                 .await?;
             let (rows, next_cursor) = pager.paginate(rows);
-            return Ok(ListTriggersResponse::detailed(
+            return Ok(ListEntriesResponse::detailed(
                 rows.into_iter().map(|(name, json)| (name, json.0)).collect(),
                 next_cursor,
             ));
@@ -221,6 +221,6 @@ impl PostgresHandler {
             )
             .await?;
         let (triggers, next_cursor) = pager.paginate(rows);
-        Ok(ListTriggersResponse::brief(triggers, next_cursor))
+        Ok(ListEntriesResponse::brief(triggers, next_cursor))
     }
 }

--- a/crates/postgres/src/tools/list_views.rs
+++ b/crates/postgres/src/tools/list_views.rs
@@ -3,7 +3,7 @@
 use dbmcp_server::pagination::{Cursor, Pager};
 
 use super::prelude::*;
-use crate::types::{ListViewsResponse, PinnedListViewsRequest, UnpinnedListViewsRequest};
+use crate::types::{ListEntriesResponse, PinnedListViewsRequest, UnpinnedListViewsRequest};
 
 const NAME: &str = "listViews";
 const TITLE: &str = "List Views";
@@ -23,7 +23,7 @@ pub(crate) struct PinnedListViewsTool;
 
 impl ToolBase for PinnedListViewsTool {
     type Parameter = PinnedListViewsRequest;
-    type Output = ListViewsResponse;
+    type Output = ListEntriesResponse;
     type Error = ErrorData;
 
     fn name() -> Cow<'static, str> {
@@ -64,7 +64,7 @@ pub(crate) struct UnpinnedListViewsTool;
 
 impl ToolBase for UnpinnedListViewsTool {
     type Parameter = UnpinnedListViewsRequest;
-    type Output = ListViewsResponse;
+    type Output = ListEntriesResponse;
     type Error = ErrorData;
 
     fn name() -> Cow<'static, str> {
@@ -159,7 +159,7 @@ impl PostgresHandler {
         cursor: Option<Cursor>,
         search: Option<String>,
         detailed: bool,
-    ) -> Result<ListViewsResponse, ErrorData> {
+    ) -> Result<ListEntriesResponse, ErrorData> {
         let database = database.as_deref().map(str::trim).filter(|s| !s.is_empty());
         let pattern = search.as_deref().map(str::trim).filter(|s| !s.is_empty());
         let pager = Pager::new(cursor, self.config.page_size);
@@ -176,7 +176,7 @@ impl PostgresHandler {
                 )
                 .await?;
             let (rows, next_cursor) = pager.paginate(rows);
-            return Ok(ListViewsResponse::detailed(
+            return Ok(ListEntriesResponse::detailed(
                 rows.into_iter().map(|(key, json)| (key, json.0)).collect(),
                 next_cursor,
             ));
@@ -193,6 +193,6 @@ impl PostgresHandler {
             )
             .await?;
         let (views, next_cursor) = pager.paginate(rows);
-        Ok(ListViewsResponse::brief(views, next_cursor))
+        Ok(ListEntriesResponse::brief(views, next_cursor))
     }
 }

--- a/crates/postgres/src/types.rs
+++ b/crates/postgres/src/types.rs
@@ -171,12 +171,9 @@ pub struct UnpinnedListProceduresRequest {
 
 #[cfg(test)]
 mod tests {
-    use indexmap::IndexMap;
-    use serde_json::json;
-
     use super::{
-        ListEntries, ListEntriesResponse, PinnedListFunctionsRequest, PinnedListMaterializedViewsRequest,
-        PinnedListProceduresRequest, PinnedListTablesRequest, PinnedListViewsRequest, UnpinnedListFunctionsRequest,
+        PinnedListFunctionsRequest, PinnedListMaterializedViewsRequest, PinnedListProceduresRequest,
+        PinnedListTablesRequest, PinnedListViewsRequest, UnpinnedListFunctionsRequest,
         UnpinnedListMaterializedViewsRequest, UnpinnedListProceduresRequest, UnpinnedListTablesRequest,
         UnpinnedListViewsRequest,
     };
@@ -288,28 +285,5 @@ mod tests {
     fn pinned_list_materialized_views_request_accepts_database() {
         let req: UnpinnedListMaterializedViewsRequest = serde_json::from_str(r#"{"database": "mydb"}"#).expect("parse");
         assert_eq!(req.database.as_deref(), Some("mydb"));
-    }
-
-    #[test]
-    fn list_materialized_views_response_brief_constructor_wraps_vec() {
-        let response = ListEntriesResponse::brief(vec!["mv_recent_orders".into()], None);
-        assert!(matches!(response.entries, ListEntries::Brief(ref v) if v == &["mv_recent_orders"]));
-        assert!(response.next_cursor.is_none());
-    }
-
-    #[test]
-    fn list_materialized_views_response_detailed_constructor_wraps_indexmap() {
-        let map = IndexMap::from([("mv_recent_orders".into(), json!({"populated": true}))]);
-        let response = ListEntriesResponse::detailed(map, None);
-        assert!(matches!(response.entries, ListEntries::Detailed(_)));
-    }
-
-    #[test]
-    fn list_materialized_views_response_brief_matches_entries_wire_shape() {
-        let response = ListEntriesResponse::brief(vec!["mv_recent_orders".into()], None);
-        assert_eq!(
-            serde_json::to_value(&response).unwrap(),
-            json!({"entries": ["mv_recent_orders"]})
-        );
     }
 }

--- a/crates/postgres/src/types.rs
+++ b/crates/postgres/src/types.rs
@@ -1,19 +1,16 @@
 //! PostgreSQL-specific MCP tool request types.
 //!
-//! Shared `listTriggers` types (`UnpinnedListTriggersRequest`, `PinnedListTriggersRequest`,
-//! `ListTriggersResponse`) and the shared brief/detailed payload (`ListEntries`,
-//! `ListTablesResponse`) live in the `dbmcp-server` crate; they are re-exported
-//! here so call sites can keep importing them from `crate::types`.
+//! Shared `listTriggers` types (`UnpinnedListTriggersRequest`, `PinnedListTriggersRequest`)
+//! and the shared brief/detailed payload (`ListEntries`, `ListEntriesResponse`) live in
+//! the `dbmcp-server` crate; they are re-exported here so call sites can keep importing
+//! them from `crate::types`.
 
 use dbmcp_server::pagination::Cursor;
-use indexmap::IndexMap;
 use schemars::JsonSchema;
-use serde::{Deserialize, Serialize};
-use serde_json::Value;
+use serde::Deserialize;
 
 pub use dbmcp_server::types::{
-    ListEntries, ListFunctionsResponse, ListProceduresResponse, ListTablesResponse, ListTriggersResponse,
-    ListViewsResponse, PinnedListTriggersRequest, UnpinnedListTriggersRequest,
+    ListEntries, ListEntriesResponse, PinnedListTriggersRequest, UnpinnedListTriggersRequest,
 };
 
 /// Request for the `dropTable` tool.
@@ -145,37 +142,6 @@ pub struct UnpinnedListMaterializedViewsRequest {
     pub database: Option<String>,
 }
 
-/// Response for the `listMaterializedViews` tool.
-#[derive(Debug, Serialize, JsonSchema)]
-pub struct ListMaterializedViewsResponse {
-    /// Page of matching materialized views. Shape depends on the request's `detailed` flag.
-    #[serde(rename = "materializedViews")]
-    pub materialized_views: ListEntries,
-    /// Opaque cursor pointing to the next page. Absent when this is the final page.
-    #[serde(rename = "nextCursor", skip_serializing_if = "Option::is_none")]
-    pub next_cursor: Option<Cursor>,
-}
-
-impl ListMaterializedViewsResponse {
-    /// Builds a brief-mode response from a page of bare matview names.
-    #[must_use]
-    pub fn brief(materialized_views: Vec<String>, next_cursor: Option<Cursor>) -> Self {
-        Self {
-            materialized_views: ListEntries::Brief(materialized_views),
-            next_cursor,
-        }
-    }
-
-    /// Builds a detailed-mode response from a page of name → metadata entries.
-    #[must_use]
-    pub fn detailed(materialized_views: IndexMap<String, Value>, next_cursor: Option<Cursor>) -> Self {
-        Self {
-            materialized_views: ListEntries::Detailed(materialized_views),
-            next_cursor,
-        }
-    }
-}
-
 /// Request for the Postgres `listProcedures` tool — extends the shared shape with `search` and `detailed`.
 #[derive(Debug, Default, Deserialize, JsonSchema)]
 pub struct PinnedListProceduresRequest {
@@ -209,7 +175,7 @@ mod tests {
     use serde_json::json;
 
     use super::{
-        ListEntries, ListMaterializedViewsResponse, PinnedListFunctionsRequest, PinnedListMaterializedViewsRequest,
+        ListEntries, ListEntriesResponse, PinnedListFunctionsRequest, PinnedListMaterializedViewsRequest,
         PinnedListProceduresRequest, PinnedListTablesRequest, PinnedListViewsRequest, UnpinnedListFunctionsRequest,
         UnpinnedListMaterializedViewsRequest, UnpinnedListProceduresRequest, UnpinnedListTablesRequest,
         UnpinnedListViewsRequest,
@@ -326,24 +292,24 @@ mod tests {
 
     #[test]
     fn list_materialized_views_response_brief_constructor_wraps_vec() {
-        let response = ListMaterializedViewsResponse::brief(vec!["mv_recent_orders".into()], None);
-        assert!(matches!(response.materialized_views, ListEntries::Brief(ref v) if v == &["mv_recent_orders"]));
+        let response = ListEntriesResponse::brief(vec!["mv_recent_orders".into()], None);
+        assert!(matches!(response.entries, ListEntries::Brief(ref v) if v == &["mv_recent_orders"]));
         assert!(response.next_cursor.is_none());
     }
 
     #[test]
     fn list_materialized_views_response_detailed_constructor_wraps_indexmap() {
         let map = IndexMap::from([("mv_recent_orders".into(), json!({"populated": true}))]);
-        let response = ListMaterializedViewsResponse::detailed(map, None);
-        assert!(matches!(response.materialized_views, ListEntries::Detailed(_)));
+        let response = ListEntriesResponse::detailed(map, None);
+        assert!(matches!(response.entries, ListEntries::Detailed(_)));
     }
 
     #[test]
-    fn list_materialized_views_response_brief_matches_legacy_wire_shape() {
-        let response = ListMaterializedViewsResponse::brief(vec!["mv_recent_orders".into()], None);
+    fn list_materialized_views_response_brief_matches_entries_wire_shape() {
+        let response = ListEntriesResponse::brief(vec!["mv_recent_orders".into()], None);
         assert_eq!(
             serde_json::to_value(&response).unwrap(),
-            json!({"materializedViews": ["mv_recent_orders"]})
+            json!({"entries": ["mv_recent_orders"]})
         );
     }
 }

--- a/crates/server/src/types.rs
+++ b/crates/server/src/types.rs
@@ -1,6 +1,9 @@
 //! Request and response types for MCP tool parameters.
 //!
-//! Each struct maps to the JSON input or output schema of one MCP tool.
+//! Most structs map to the input or output schema of a single MCP tool;
+//! [`ListEntriesResponse`] is the shared output for every `list*` tool
+//! (`listTables`, `listViews`, `listTriggers`, `listFunctions`,
+//! `listProcedures`, `listMaterializedViews`).
 
 use indexmap::IndexMap;
 use schemars::JsonSchema;
@@ -411,19 +414,5 @@ mod tests {
         let new_len = serde_json::to_vec(&ListEntries::Detailed(new_map)).unwrap().len();
         let old_len = serde_json::to_vec(&old).unwrap().len();
         assert!(new_len < old_len, "payload not smaller: new={new_len} old={old_len}");
-    }
-
-    #[test]
-    fn list_entries_response_brief_constructor_wraps_vec() {
-        let response = ListEntriesResponse::brief(vec!["calc_total".into()], None);
-        assert!(matches!(response.entries, ListEntries::Brief(ref v) if v == &["calc_total"]));
-        assert!(response.next_cursor.is_none());
-    }
-
-    #[test]
-    fn list_entries_response_detailed_constructor_wraps_indexmap() {
-        let map = IndexMap::from([("calc_total(integer)".into(), json!({"language": "sql"}))]);
-        let response = ListEntriesResponse::detailed(map, None);
-        assert!(matches!(response.entries, ListEntries::Detailed(_)));
     }
 }

--- a/crates/server/src/types.rs
+++ b/crates/server/src/types.rs
@@ -11,7 +11,7 @@ use crate::pagination::Cursor;
 
 /// Two-shape listing payload: bare names in brief mode, name-keyed metadata in detailed mode.
 ///
-/// Shared by [`ListTablesResponse`] and [`ListTriggersResponse`]. Serialises untagged:
+/// Embedded as the `entries` field of [`ListEntriesResponse`]. Serialises untagged:
 /// brief mode → JSON array of strings, detailed mode → JSON object whose keys are
 /// entity names and whose values are the per-entity metadata.
 #[derive(Debug, Serialize, JsonSchema)]
@@ -58,31 +58,32 @@ impl ListEntries {
     }
 }
 
-/// Response for the `listTables` tool.
+/// Response for list-style tools (`listTables`, `listViews`, `listTriggers`,
+/// `listFunctions`, `listProcedures`, `listMaterializedViews`).
 #[derive(Debug, Serialize, JsonSchema)]
-pub struct ListTablesResponse {
-    /// Page of matching tables. Shape depends on the request's `detailed` flag.
-    pub tables: ListEntries,
+pub struct ListEntriesResponse {
+    /// Page of matching entries. Shape depends on the request's `detailed` flag.
+    pub entries: ListEntries,
     /// Opaque cursor pointing to the next page. Absent when this is the final page.
     #[serde(rename = "nextCursor", skip_serializing_if = "Option::is_none")]
     pub next_cursor: Option<Cursor>,
 }
 
-impl ListTablesResponse {
-    /// Builds a brief-mode response from a page of bare table names.
+impl ListEntriesResponse {
+    /// Builds a brief-mode response from a page of bare entity names.
     #[must_use]
-    pub fn brief(tables: Vec<String>, next_cursor: Option<Cursor>) -> Self {
+    pub fn brief(entries: Vec<String>, next_cursor: Option<Cursor>) -> Self {
         Self {
-            tables: ListEntries::Brief(tables),
+            entries: ListEntries::Brief(entries),
             next_cursor,
         }
     }
 
     /// Builds a detailed-mode response from a page of name → metadata entries.
     #[must_use]
-    pub fn detailed(tables: IndexMap<String, Value>, next_cursor: Option<Cursor>) -> Self {
+    pub fn detailed(entries: IndexMap<String, Value>, next_cursor: Option<Cursor>) -> Self {
         Self {
-            tables: ListEntries::Detailed(tables),
+            entries: ListEntries::Detailed(entries),
             next_cursor,
         }
     }
@@ -145,36 +146,6 @@ pub struct UnpinnedListViewsRequest {
     pub database: Option<String>,
 }
 
-/// Response for the `listViews` tool.
-#[derive(Debug, Serialize, JsonSchema)]
-pub struct ListViewsResponse {
-    /// Page of matching views. Shape depends on the request's `detailed` flag.
-    pub views: ListEntries,
-    /// Opaque cursor pointing to the next page. Absent when this is the final page.
-    #[serde(rename = "nextCursor", skip_serializing_if = "Option::is_none")]
-    pub next_cursor: Option<Cursor>,
-}
-
-impl ListViewsResponse {
-    /// Builds a brief-mode response from a page of bare view names.
-    #[must_use]
-    pub fn brief(views: Vec<String>, next_cursor: Option<Cursor>) -> Self {
-        Self {
-            views: ListEntries::Brief(views),
-            next_cursor,
-        }
-    }
-
-    /// Builds a detailed-mode response from a page of name → metadata entries.
-    #[must_use]
-    pub fn detailed(views: IndexMap<String, Value>, next_cursor: Option<Cursor>) -> Self {
-        Self {
-            views: ListEntries::Detailed(views),
-            next_cursor,
-        }
-    }
-}
-
 /// Request for the `listTriggers` tool.
 #[derive(Debug, Default, Deserialize, JsonSchema)]
 pub struct PinnedListTriggersRequest {
@@ -202,36 +173,6 @@ pub struct UnpinnedListTriggersRequest {
     pub database: Option<String>,
 }
 
-/// Response for the `listTriggers` tool.
-#[derive(Debug, Serialize, JsonSchema)]
-pub struct ListTriggersResponse {
-    /// Page of matching triggers. Shape depends on the request's `detailed` flag.
-    pub triggers: ListEntries,
-    /// Opaque cursor pointing to the next page. Absent when this is the final page.
-    #[serde(rename = "nextCursor", skip_serializing_if = "Option::is_none")]
-    pub next_cursor: Option<Cursor>,
-}
-
-impl ListTriggersResponse {
-    /// Builds a brief-mode response from a page of bare trigger names.
-    #[must_use]
-    pub fn brief(triggers: Vec<String>, next_cursor: Option<Cursor>) -> Self {
-        Self {
-            triggers: ListEntries::Brief(triggers),
-            next_cursor,
-        }
-    }
-
-    /// Builds a detailed-mode response from a page of name → metadata entries.
-    #[must_use]
-    pub fn detailed(triggers: IndexMap<String, Value>, next_cursor: Option<Cursor>) -> Self {
-        Self {
-            triggers: ListEntries::Detailed(triggers),
-            next_cursor,
-        }
-    }
-}
-
 /// Request for the `listFunctions` tool.
 #[derive(Debug, Default, Deserialize, JsonSchema)]
 pub struct PinnedListFunctionsRequest {
@@ -248,66 +189,6 @@ pub struct UnpinnedListFunctionsRequest {
     /// Database to list functions from. Defaults to the active database.
     #[serde(default)]
     pub database: Option<String>,
-}
-
-/// Response for the `listFunctions` tool.
-#[derive(Debug, Serialize, JsonSchema)]
-pub struct ListFunctionsResponse {
-    /// Page of matching functions. Shape depends on the request's `detailed` flag.
-    pub functions: ListEntries,
-    /// Opaque cursor pointing to the next page. Absent when this is the final page.
-    #[serde(rename = "nextCursor", skip_serializing_if = "Option::is_none")]
-    pub next_cursor: Option<Cursor>,
-}
-
-impl ListFunctionsResponse {
-    /// Builds a brief-mode response from a page of bare function names.
-    #[must_use]
-    pub fn brief(functions: Vec<String>, next_cursor: Option<Cursor>) -> Self {
-        Self {
-            functions: ListEntries::Brief(functions),
-            next_cursor,
-        }
-    }
-
-    /// Builds a detailed-mode response from a page of signature → metadata entries.
-    #[must_use]
-    pub fn detailed(functions: IndexMap<String, Value>, next_cursor: Option<Cursor>) -> Self {
-        Self {
-            functions: ListEntries::Detailed(functions),
-            next_cursor,
-        }
-    }
-}
-
-/// Response for the `listProcedures` tool.
-#[derive(Debug, Serialize, JsonSchema)]
-pub struct ListProceduresResponse {
-    /// Page of matching procedures. Shape depends on the request's `detailed` flag.
-    pub procedures: ListEntries,
-    /// Opaque cursor pointing to the next page. Absent when this is the final page.
-    #[serde(rename = "nextCursor", skip_serializing_if = "Option::is_none")]
-    pub next_cursor: Option<Cursor>,
-}
-
-impl ListProceduresResponse {
-    /// Builds a brief-mode response from a page of bare procedure names.
-    #[must_use]
-    pub fn brief(procedures: Vec<String>, next_cursor: Option<Cursor>) -> Self {
-        Self {
-            procedures: ListEntries::Brief(procedures),
-            next_cursor,
-        }
-    }
-
-    /// Builds a detailed-mode response from a page of signature → metadata entries.
-    #[must_use]
-    pub fn detailed(procedures: IndexMap<String, Value>, next_cursor: Option<Cursor>) -> Self {
-        Self {
-            procedures: ListEntries::Detailed(procedures),
-            next_cursor,
-        }
-    }
 }
 
 /// Request for the `writeQuery` tool.
@@ -388,10 +269,7 @@ pub struct UnpinnedExplainQueryRequest {
 
 #[cfg(test)]
 mod tests {
-    use super::{
-        IndexMap, ListEntries, ListFunctionsResponse, ListTablesResponse, ListTriggersResponse,
-        PinnedListTriggersRequest, UnpinnedListTriggersRequest,
-    };
+    use super::{IndexMap, ListEntries, ListEntriesResponse, PinnedListTriggersRequest, UnpinnedListTriggersRequest};
     use serde_json::{Value, json};
 
     #[test]
@@ -459,21 +337,29 @@ mod tests {
     }
 
     #[test]
-    fn list_tables_response_brief_matches_legacy_wire_shape() {
-        let response = ListTablesResponse {
-            tables: ListEntries::Brief(vec!["a".into()]),
-            next_cursor: None,
-        };
-        assert_eq!(serde_json::to_value(&response).unwrap(), json!({"tables": ["a"]}));
+    fn list_entries_response_brief_serializes_with_entries_key() {
+        let response = ListEntriesResponse::brief(vec!["a".into()], None);
+        assert_eq!(serde_json::to_value(&response).unwrap(), json!({"entries": ["a"]}));
     }
 
     #[test]
-    fn list_triggers_response_brief_matches_legacy_wire_shape() {
-        let response = ListTriggersResponse {
-            triggers: ListEntries::Brief(vec!["t1".into()]),
-            next_cursor: None,
-        };
-        assert_eq!(serde_json::to_value(&response).unwrap(), json!({"triggers": ["t1"]}));
+    fn list_entries_response_detailed_serializes_with_entries_key() {
+        let map = IndexMap::from([("a".into(), json!({"kind": "TABLE"}))]);
+        let response = ListEntriesResponse::detailed(map, None);
+        assert_eq!(
+            serde_json::to_value(&response).unwrap(),
+            json!({"entries": {"a": {"kind": "TABLE"}}})
+        );
+    }
+
+    #[test]
+    fn list_entries_response_omits_next_cursor_when_none() {
+        let response = ListEntriesResponse::brief(vec!["a".into()], None);
+        let value = serde_json::to_value(&response).unwrap();
+        assert!(
+            value.get("nextCursor").is_none(),
+            "nextCursor must be omitted when None"
+        );
     }
 
     #[test]
@@ -528,71 +414,16 @@ mod tests {
     }
 
     #[test]
-    fn list_functions_response_brief_constructor_wraps_vec() {
-        let response = ListFunctionsResponse::brief(vec!["calc_total".into()], None);
-        assert!(matches!(response.functions, ListEntries::Brief(ref v) if v == &["calc_total"]));
+    fn list_entries_response_brief_constructor_wraps_vec() {
+        let response = ListEntriesResponse::brief(vec!["calc_total".into()], None);
+        assert!(matches!(response.entries, ListEntries::Brief(ref v) if v == &["calc_total"]));
         assert!(response.next_cursor.is_none());
     }
 
     #[test]
-    fn list_functions_response_detailed_constructor_wraps_indexmap() {
+    fn list_entries_response_detailed_constructor_wraps_indexmap() {
         let map = IndexMap::from([("calc_total(integer)".into(), json!({"language": "sql"}))]);
-        let response = ListFunctionsResponse::detailed(map, None);
-        assert!(matches!(response.functions, ListEntries::Detailed(_)));
-    }
-
-    #[test]
-    fn list_functions_response_brief_matches_legacy_wire_shape() {
-        let response = ListFunctionsResponse::brief(vec!["audit_user_login".into()], None);
-        assert_eq!(
-            serde_json::to_value(&response).unwrap(),
-            json!({"functions": ["audit_user_login"]})
-        );
-    }
-
-    #[test]
-    fn list_procedures_response_brief_constructor_wraps_vec() {
-        let response = super::ListProceduresResponse::brief(vec!["archive_order".into()], None);
-        assert!(matches!(response.procedures, ListEntries::Brief(ref v) if v == &["archive_order"]));
-        assert!(response.next_cursor.is_none());
-    }
-
-    #[test]
-    fn list_procedures_response_detailed_constructor_wraps_indexmap() {
-        let map = IndexMap::from([("archive_order(integer)".into(), json!({"language": "plpgsql"}))]);
-        let response = super::ListProceduresResponse::detailed(map, None);
-        assert!(matches!(response.procedures, ListEntries::Detailed(_)));
-    }
-
-    #[test]
-    fn list_procedures_response_brief_matches_legacy_wire_shape() {
-        let response = super::ListProceduresResponse::brief(vec!["archive_order".into()], None);
-        assert_eq!(
-            serde_json::to_value(&response).unwrap(),
-            json!({"procedures": ["archive_order"]})
-        );
-    }
-
-    #[test]
-    fn list_views_response_brief_constructor_wraps_vec() {
-        let response = super::ListViewsResponse::brief(vec!["active_users".into()], None);
-        assert!(matches!(response.views, ListEntries::Brief(ref v) if v == &["active_users"]));
-        assert!(response.next_cursor.is_none());
-    }
-
-    #[test]
-    fn list_views_response_detailed_constructor_wraps_indexmap() {
-        let map = IndexMap::from([("active_users".into(), json!({"schema": "public"}))]);
-        let response = super::ListViewsResponse::detailed(map, None);
-        assert!(matches!(response.views, ListEntries::Detailed(_)));
-    }
-
-    #[test]
-    fn list_views_response_brief_matches_legacy_wire_shape() {
-        let response = super::ListViewsResponse::brief(vec!["active_users".into()], None);
-        assert_eq!(
-            serde_json::to_value(&response).unwrap(),
-            json!({"views": ["active_users"]})
-        );
+        let response = ListEntriesResponse::detailed(map, None);
+        assert!(matches!(response.entries, ListEntries::Detailed(_)));
     }
 }

--- a/crates/sqlite/src/tools/list_tables.rs
+++ b/crates/sqlite/src/tools/list_tables.rs
@@ -3,7 +3,7 @@
 use dbmcp_server::pagination::Pager;
 
 use super::prelude::*;
-use crate::types::{ListTablesRequest, ListTablesResponse};
+use crate::types::{ListEntriesResponse, ListTablesRequest};
 
 const NAME: &str = "listTables";
 const TITLE: &str = "List Tables";
@@ -14,7 +14,7 @@ pub(crate) struct ListTablesTool;
 
 impl ToolBase for ListTablesTool {
     type Parameter = ListTablesRequest;
-    type Output = ListTablesResponse;
+    type Output = ListEntriesResponse;
     type Error = ErrorData;
 
     fn name() -> Cow<'static, str> {
@@ -256,7 +256,7 @@ impl SqliteHandler {
             search,
             detailed,
         }: ListTablesRequest,
-    ) -> Result<ListTablesResponse, ErrorData> {
+    ) -> Result<ListEntriesResponse, ErrorData> {
         let pattern = search.as_deref().map(str::trim).filter(|s| !s.is_empty());
         let pager = Pager::new(cursor, self.config.page_size);
 
@@ -272,7 +272,7 @@ impl SqliteHandler {
                 )
                 .await?;
             let (rows, next_cursor) = pager.paginate(rows);
-            return Ok(ListTablesResponse::detailed(
+            return Ok(ListEntriesResponse::detailed(
                 rows.into_iter().map(|(name, json)| (name, json.0)).collect(),
                 next_cursor,
             ));
@@ -289,6 +289,6 @@ impl SqliteHandler {
             )
             .await?;
         let (tables, next_cursor) = pager.paginate(rows);
-        Ok(ListTablesResponse::brief(tables, next_cursor))
+        Ok(ListEntriesResponse::brief(tables, next_cursor))
     }
 }

--- a/crates/sqlite/src/tools/list_triggers.rs
+++ b/crates/sqlite/src/tools/list_triggers.rs
@@ -1,7 +1,7 @@
 //! MCP tool: `listTriggers`.
 
 use dbmcp_server::pagination::Pager;
-use dbmcp_server::types::ListTriggersResponse;
+use dbmcp_server::types::ListEntriesResponse;
 
 use super::prelude::*;
 use crate::types::ListTriggersRequest;
@@ -15,7 +15,7 @@ pub(crate) struct ListTriggersTool;
 
 impl ToolBase for ListTriggersTool {
     type Parameter = ListTriggersRequest;
-    type Output = ListTriggersResponse;
+    type Output = ListEntriesResponse;
     type Error = ErrorData;
 
     fn name() -> Cow<'static, str> {
@@ -112,7 +112,7 @@ impl SqliteHandler {
             search,
             detailed,
         }: ListTriggersRequest,
-    ) -> Result<ListTriggersResponse, ErrorData> {
+    ) -> Result<ListEntriesResponse, ErrorData> {
         let pattern = search.as_deref().map(str::trim).filter(|s| !s.is_empty());
         let pager = Pager::new(cursor, self.config.page_size);
 
@@ -128,7 +128,7 @@ impl SqliteHandler {
                 )
                 .await?;
             let (rows, next_cursor) = pager.paginate(rows);
-            return Ok(ListTriggersResponse::detailed(
+            return Ok(ListEntriesResponse::detailed(
                 rows.into_iter().map(|(name, json)| (name, json.0)).collect(),
                 next_cursor,
             ));
@@ -145,6 +145,6 @@ impl SqliteHandler {
             )
             .await?;
         let (triggers, next_cursor) = pager.paginate(rows);
-        Ok(ListTriggersResponse::brief(triggers, next_cursor))
+        Ok(ListEntriesResponse::brief(triggers, next_cursor))
     }
 }

--- a/crates/sqlite/src/tools/list_views.rs
+++ b/crates/sqlite/src/tools/list_views.rs
@@ -1,7 +1,7 @@
 //! MCP tool: `listViews`.
 
 use dbmcp_server::pagination::Pager;
-use dbmcp_server::types::ListViewsResponse;
+use dbmcp_server::types::ListEntriesResponse;
 
 use super::prelude::*;
 use crate::types::ListViewsRequest;
@@ -15,7 +15,7 @@ pub(crate) struct ListViewsTool;
 
 impl ToolBase for ListViewsTool {
     type Parameter = ListViewsRequest;
-    type Output = ListViewsResponse;
+    type Output = ListEntriesResponse;
     type Error = ErrorData;
 
     fn name() -> Cow<'static, str> {
@@ -65,7 +65,7 @@ impl SqliteHandler {
     pub async fn list_views(
         &self,
         ListViewsRequest { cursor }: ListViewsRequest,
-    ) -> Result<ListViewsResponse, ErrorData> {
+    ) -> Result<ListEntriesResponse, ErrorData> {
         let pager = Pager::new(cursor, self.config.page_size);
         let query = format!(
             r"
@@ -81,6 +81,6 @@ impl SqliteHandler {
         let rows: Vec<String> = self.connection.fetch_scalar(query.as_str(), None).await?;
         let (views, next_cursor) = pager.paginate(rows);
 
-        Ok(ListViewsResponse::brief(views, next_cursor))
+        Ok(ListEntriesResponse::brief(views, next_cursor))
     }
 }

--- a/crates/sqlite/src/types.rs
+++ b/crates/sqlite/src/types.rs
@@ -3,7 +3,7 @@
 //! Unlike `MySQL` and `PostgreSQL`, `SQLite` operates on a single file and
 //! has no database selection, so these types omit the `database` field
 //! present in the shared server types. `ListEntries` and
-//! `ListTablesResponse` live in the shared `dbmcp-server` crate; they are
+//! `ListEntriesResponse` live in the shared `dbmcp-server` crate; they are
 //! re-exported here so call sites can keep importing them from
 //! `crate::types`.
 
@@ -11,7 +11,7 @@ use dbmcp_server::pagination::Cursor;
 use schemars::JsonSchema;
 use serde::Deserialize;
 
-pub use dbmcp_server::types::{ListEntries, ListTablesResponse};
+pub use dbmcp_server::types::{ListEntries, ListEntriesResponse};
 
 /// Request for the `dropTable` tool.
 #[derive(Debug, Default, Deserialize, JsonSchema)]

--- a/docs/content/docs/features.mdx
+++ b/docs/content/docs/features.mdx
@@ -69,7 +69,7 @@ In **brief mode** (default) the response shape is:
 
 ```json
 {
-  "tables": ["customers", "orders", "products"],
+  "entries": ["customers", "orders", "products"],
   "nextCursor": "<opaque or absent>"
 }
 ```
@@ -78,7 +78,7 @@ In **detailed mode** the response is keyed by table name:
 
 ```json
 {
-  "tables": {
+  "entries": {
     "orders": {
       "schema": "public",
       "kind": "TABLE",
@@ -108,7 +108,7 @@ In **brief mode** (default) the response is a sorted JSON array of view-name str
 
 ```json
 {
-  "views": ["active_users", "monthly_revenue"],
+  "entries": ["active_users", "monthly_revenue"],
   "nextCursor": "<opaque or absent>"
 }
 ```
@@ -124,7 +124,7 @@ The PostgreSQL payload carries owner and comment plus the SELECT body:
 
 ```json
 {
-  "views": {
+  "entries": {
     "active_users": {
       "schema": "public",
       "owner": "app_user",
@@ -140,7 +140,7 @@ The MySQL/MariaDB payload carries definer / security / check-option / updatabili
 
 ```json
 {
-  "views": {
+  "entries": {
     "active_users": {
       "schema": "app",
       "definer": "root@%",
@@ -177,7 +177,7 @@ In **brief mode** (default) the response shape is:
 
 ```json
 {
-  "triggers": ["customers_audit_after_insert", "orders_audit_after_insert", "set_updated_at"],
+  "entries": ["customers_audit_after_insert", "orders_audit_after_insert", "set_updated_at"],
   "nextCursor": "<opaque or absent>"
 }
 ```
@@ -186,7 +186,7 @@ In **detailed mode** the response is keyed by trigger name. The PostgreSQL paylo
 
 ```json
 {
-  "triggers": {
+  "entries": {
     "orders_audit_after_iu": {
       "schema": "public",
       "table": "orders",
@@ -222,7 +222,7 @@ In **brief mode** (default) the response is a sorted JSON array of function-name
 
 ```json
 {
-  "functions": ["calc_order_subtotal", "calc_order_total", "calc_order_total"],
+  "entries": ["calc_order_subtotal", "calc_order_total", "calc_order_total"],
   "nextCursor": null
 }
 ```
@@ -231,7 +231,7 @@ In **detailed mode** the response is keyed by function signature. The PostgreSQL
 
 ```json
 {
-  "functions": {
+  "entries": {
     "calc_order_total(order_id integer, tax_rate numeric)": {
       "schema": "public",
       "name": "calc_order_total",
@@ -264,7 +264,7 @@ In **brief mode** (default) the response is a sorted JSON array of procedure-nam
 
 ```json
 {
-  "procedures": ["archive_order", "archive_order_history", "archive_order_history"],
+  "entries": ["archive_order", "archive_order_history", "archive_order_history"],
   "nextCursor": null
 }
 ```
@@ -273,7 +273,7 @@ In **detailed mode** the response is keyed by procedure signature. The PostgreSQ
 
 ```json
 {
-  "procedures": {
+  "entries": {
     "archive_order(order_id integer)": {
       "schema": "public",
       "name": "archive_order",
@@ -308,7 +308,7 @@ In **brief mode** (default) the response is a sorted JSON array of matview-name 
 
 ```json
 {
-  "materializedViews": ["mv_archived_orders", "mv_orders_by_region", "mv_recent_orders"],
+  "entries": ["mv_archived_orders", "mv_orders_by_region", "mv_recent_orders"],
   "nextCursor": null
 }
 ```
@@ -317,7 +317,7 @@ In **detailed mode** the response is keyed by **bare matview name** — matviews
 
 ```json
 {
-  "materializedViews": {
+  "entries": {
     "mv_orders_by_region": {
       "schema": "public",
       "owner": "app_user",

--- a/tests/approval/snapshots/approval_mysql__list_tools_read_only_pinned.snap
+++ b/tests/approval/snapshots/approval_mysql__list_tools_read_only_pinned.snap
@@ -76,7 +76,7 @@ expression: tools
     },
     "outputSchema": {
       "properties": {
-        "functions": {
+        "entries": {
           "anyOf": [
             {
               "description": "Brief mode: sorted array of bare entity-name strings.",
@@ -91,7 +91,7 @@ expression: tools
               "type": "object"
             }
           ],
-          "description": "Page of matching functions. Shape depends on the request's `detailed` flag."
+          "description": "Page of matching entries. Shape depends on the request's `detailed` flag."
         },
         "nextCursor": {
           "description": "Opaque cursor pointing to the next page. Absent when this is the final page.",
@@ -102,7 +102,7 @@ expression: tools
         }
       },
       "required": [
-        "functions"
+        "entries"
       ],
       "type": "object"
     },
@@ -145,14 +145,7 @@ expression: tools
     },
     "outputSchema": {
       "properties": {
-        "nextCursor": {
-          "description": "Opaque cursor pointing to the next page. Absent when this is the final page.",
-          "type": [
-            "string",
-            "null"
-          ]
-        },
-        "procedures": {
+        "entries": {
           "anyOf": [
             {
               "description": "Brief mode: sorted array of bare entity-name strings.",
@@ -167,11 +160,18 @@ expression: tools
               "type": "object"
             }
           ],
-          "description": "Page of matching procedures. Shape depends on the request's `detailed` flag."
+          "description": "Page of matching entries. Shape depends on the request's `detailed` flag."
+        },
+        "nextCursor": {
+          "description": "Opaque cursor pointing to the next page. Absent when this is the final page.",
+          "type": [
+            "string",
+            "null"
+          ]
         }
       },
       "required": [
-        "procedures"
+        "entries"
       ],
       "type": "object"
     },
@@ -214,14 +214,7 @@ expression: tools
     },
     "outputSchema": {
       "properties": {
-        "nextCursor": {
-          "description": "Opaque cursor pointing to the next page. Absent when this is the final page.",
-          "type": [
-            "string",
-            "null"
-          ]
-        },
-        "tables": {
+        "entries": {
           "anyOf": [
             {
               "description": "Brief mode: sorted array of bare entity-name strings.",
@@ -236,11 +229,18 @@ expression: tools
               "type": "object"
             }
           ],
-          "description": "Page of matching tables. Shape depends on the request's `detailed` flag."
+          "description": "Page of matching entries. Shape depends on the request's `detailed` flag."
+        },
+        "nextCursor": {
+          "description": "Opaque cursor pointing to the next page. Absent when this is the final page.",
+          "type": [
+            "string",
+            "null"
+          ]
         }
       },
       "required": [
-        "tables"
+        "entries"
       ],
       "type": "object"
     },
@@ -283,14 +283,7 @@ expression: tools
     },
     "outputSchema": {
       "properties": {
-        "nextCursor": {
-          "description": "Opaque cursor pointing to the next page. Absent when this is the final page.",
-          "type": [
-            "string",
-            "null"
-          ]
-        },
-        "triggers": {
+        "entries": {
           "anyOf": [
             {
               "description": "Brief mode: sorted array of bare entity-name strings.",
@@ -305,11 +298,18 @@ expression: tools
               "type": "object"
             }
           ],
-          "description": "Page of matching triggers. Shape depends on the request's `detailed` flag."
+          "description": "Page of matching entries. Shape depends on the request's `detailed` flag."
+        },
+        "nextCursor": {
+          "description": "Opaque cursor pointing to the next page. Absent when this is the final page.",
+          "type": [
+            "string",
+            "null"
+          ]
         }
       },
       "required": [
-        "triggers"
+        "entries"
       ],
       "type": "object"
     },
@@ -352,14 +352,7 @@ expression: tools
     },
     "outputSchema": {
       "properties": {
-        "nextCursor": {
-          "description": "Opaque cursor pointing to the next page. Absent when this is the final page.",
-          "type": [
-            "string",
-            "null"
-          ]
-        },
-        "views": {
+        "entries": {
           "anyOf": [
             {
               "description": "Brief mode: sorted array of bare entity-name strings.",
@@ -374,11 +367,18 @@ expression: tools
               "type": "object"
             }
           ],
-          "description": "Page of matching views. Shape depends on the request's `detailed` flag."
+          "description": "Page of matching entries. Shape depends on the request's `detailed` flag."
+        },
+        "nextCursor": {
+          "description": "Opaque cursor pointing to the next page. Absent when this is the final page.",
+          "type": [
+            "string",
+            "null"
+          ]
         }
       },
       "required": [
-        "views"
+        "entries"
       ],
       "type": "object"
     },

--- a/tests/approval/snapshots/approval_mysql__list_tools_read_only_unpinned.snap
+++ b/tests/approval/snapshots/approval_mysql__list_tools_read_only_unpinned.snap
@@ -138,7 +138,7 @@ expression: tools
     },
     "outputSchema": {
       "properties": {
-        "functions": {
+        "entries": {
           "anyOf": [
             {
               "description": "Brief mode: sorted array of bare entity-name strings.",
@@ -153,7 +153,7 @@ expression: tools
               "type": "object"
             }
           ],
-          "description": "Page of matching functions. Shape depends on the request's `detailed` flag."
+          "description": "Page of matching entries. Shape depends on the request's `detailed` flag."
         },
         "nextCursor": {
           "description": "Opaque cursor pointing to the next page. Absent when this is the final page.",
@@ -164,7 +164,7 @@ expression: tools
         }
       },
       "required": [
-        "functions"
+        "entries"
       ],
       "type": "object"
     },
@@ -215,14 +215,7 @@ expression: tools
     },
     "outputSchema": {
       "properties": {
-        "nextCursor": {
-          "description": "Opaque cursor pointing to the next page. Absent when this is the final page.",
-          "type": [
-            "string",
-            "null"
-          ]
-        },
-        "procedures": {
+        "entries": {
           "anyOf": [
             {
               "description": "Brief mode: sorted array of bare entity-name strings.",
@@ -237,11 +230,18 @@ expression: tools
               "type": "object"
             }
           ],
-          "description": "Page of matching procedures. Shape depends on the request's `detailed` flag."
+          "description": "Page of matching entries. Shape depends on the request's `detailed` flag."
+        },
+        "nextCursor": {
+          "description": "Opaque cursor pointing to the next page. Absent when this is the final page.",
+          "type": [
+            "string",
+            "null"
+          ]
         }
       },
       "required": [
-        "procedures"
+        "entries"
       ],
       "type": "object"
     },
@@ -292,14 +292,7 @@ expression: tools
     },
     "outputSchema": {
       "properties": {
-        "nextCursor": {
-          "description": "Opaque cursor pointing to the next page. Absent when this is the final page.",
-          "type": [
-            "string",
-            "null"
-          ]
-        },
-        "tables": {
+        "entries": {
           "anyOf": [
             {
               "description": "Brief mode: sorted array of bare entity-name strings.",
@@ -314,11 +307,18 @@ expression: tools
               "type": "object"
             }
           ],
-          "description": "Page of matching tables. Shape depends on the request's `detailed` flag."
+          "description": "Page of matching entries. Shape depends on the request's `detailed` flag."
+        },
+        "nextCursor": {
+          "description": "Opaque cursor pointing to the next page. Absent when this is the final page.",
+          "type": [
+            "string",
+            "null"
+          ]
         }
       },
       "required": [
-        "tables"
+        "entries"
       ],
       "type": "object"
     },
@@ -369,14 +369,7 @@ expression: tools
     },
     "outputSchema": {
       "properties": {
-        "nextCursor": {
-          "description": "Opaque cursor pointing to the next page. Absent when this is the final page.",
-          "type": [
-            "string",
-            "null"
-          ]
-        },
-        "triggers": {
+        "entries": {
           "anyOf": [
             {
               "description": "Brief mode: sorted array of bare entity-name strings.",
@@ -391,11 +384,18 @@ expression: tools
               "type": "object"
             }
           ],
-          "description": "Page of matching triggers. Shape depends on the request's `detailed` flag."
+          "description": "Page of matching entries. Shape depends on the request's `detailed` flag."
+        },
+        "nextCursor": {
+          "description": "Opaque cursor pointing to the next page. Absent when this is the final page.",
+          "type": [
+            "string",
+            "null"
+          ]
         }
       },
       "required": [
-        "triggers"
+        "entries"
       ],
       "type": "object"
     },
@@ -446,14 +446,7 @@ expression: tools
     },
     "outputSchema": {
       "properties": {
-        "nextCursor": {
-          "description": "Opaque cursor pointing to the next page. Absent when this is the final page.",
-          "type": [
-            "string",
-            "null"
-          ]
-        },
-        "views": {
+        "entries": {
           "anyOf": [
             {
               "description": "Brief mode: sorted array of bare entity-name strings.",
@@ -468,11 +461,18 @@ expression: tools
               "type": "object"
             }
           ],
-          "description": "Page of matching views. Shape depends on the request's `detailed` flag."
+          "description": "Page of matching entries. Shape depends on the request's `detailed` flag."
+        },
+        "nextCursor": {
+          "description": "Opaque cursor pointing to the next page. Absent when this is the final page.",
+          "type": [
+            "string",
+            "null"
+          ]
         }
       },
       "required": [
-        "views"
+        "entries"
       ],
       "type": "object"
     },

--- a/tests/approval/snapshots/approval_mysql__list_tools_read_write_pinned.snap
+++ b/tests/approval/snapshots/approval_mysql__list_tools_read_write_pinned.snap
@@ -111,7 +111,7 @@ expression: tools
     },
     "outputSchema": {
       "properties": {
-        "functions": {
+        "entries": {
           "anyOf": [
             {
               "description": "Brief mode: sorted array of bare entity-name strings.",
@@ -126,7 +126,7 @@ expression: tools
               "type": "object"
             }
           ],
-          "description": "Page of matching functions. Shape depends on the request's `detailed` flag."
+          "description": "Page of matching entries. Shape depends on the request's `detailed` flag."
         },
         "nextCursor": {
           "description": "Opaque cursor pointing to the next page. Absent when this is the final page.",
@@ -137,7 +137,7 @@ expression: tools
         }
       },
       "required": [
-        "functions"
+        "entries"
       ],
       "type": "object"
     },
@@ -180,14 +180,7 @@ expression: tools
     },
     "outputSchema": {
       "properties": {
-        "nextCursor": {
-          "description": "Opaque cursor pointing to the next page. Absent when this is the final page.",
-          "type": [
-            "string",
-            "null"
-          ]
-        },
-        "procedures": {
+        "entries": {
           "anyOf": [
             {
               "description": "Brief mode: sorted array of bare entity-name strings.",
@@ -202,11 +195,18 @@ expression: tools
               "type": "object"
             }
           ],
-          "description": "Page of matching procedures. Shape depends on the request's `detailed` flag."
+          "description": "Page of matching entries. Shape depends on the request's `detailed` flag."
+        },
+        "nextCursor": {
+          "description": "Opaque cursor pointing to the next page. Absent when this is the final page.",
+          "type": [
+            "string",
+            "null"
+          ]
         }
       },
       "required": [
-        "procedures"
+        "entries"
       ],
       "type": "object"
     },
@@ -249,14 +249,7 @@ expression: tools
     },
     "outputSchema": {
       "properties": {
-        "nextCursor": {
-          "description": "Opaque cursor pointing to the next page. Absent when this is the final page.",
-          "type": [
-            "string",
-            "null"
-          ]
-        },
-        "tables": {
+        "entries": {
           "anyOf": [
             {
               "description": "Brief mode: sorted array of bare entity-name strings.",
@@ -271,11 +264,18 @@ expression: tools
               "type": "object"
             }
           ],
-          "description": "Page of matching tables. Shape depends on the request's `detailed` flag."
+          "description": "Page of matching entries. Shape depends on the request's `detailed` flag."
+        },
+        "nextCursor": {
+          "description": "Opaque cursor pointing to the next page. Absent when this is the final page.",
+          "type": [
+            "string",
+            "null"
+          ]
         }
       },
       "required": [
-        "tables"
+        "entries"
       ],
       "type": "object"
     },
@@ -318,14 +318,7 @@ expression: tools
     },
     "outputSchema": {
       "properties": {
-        "nextCursor": {
-          "description": "Opaque cursor pointing to the next page. Absent when this is the final page.",
-          "type": [
-            "string",
-            "null"
-          ]
-        },
-        "triggers": {
+        "entries": {
           "anyOf": [
             {
               "description": "Brief mode: sorted array of bare entity-name strings.",
@@ -340,11 +333,18 @@ expression: tools
               "type": "object"
             }
           ],
-          "description": "Page of matching triggers. Shape depends on the request's `detailed` flag."
+          "description": "Page of matching entries. Shape depends on the request's `detailed` flag."
+        },
+        "nextCursor": {
+          "description": "Opaque cursor pointing to the next page. Absent when this is the final page.",
+          "type": [
+            "string",
+            "null"
+          ]
         }
       },
       "required": [
-        "triggers"
+        "entries"
       ],
       "type": "object"
     },
@@ -387,14 +387,7 @@ expression: tools
     },
     "outputSchema": {
       "properties": {
-        "nextCursor": {
-          "description": "Opaque cursor pointing to the next page. Absent when this is the final page.",
-          "type": [
-            "string",
-            "null"
-          ]
-        },
-        "views": {
+        "entries": {
           "anyOf": [
             {
               "description": "Brief mode: sorted array of bare entity-name strings.",
@@ -409,11 +402,18 @@ expression: tools
               "type": "object"
             }
           ],
-          "description": "Page of matching views. Shape depends on the request's `detailed` flag."
+          "description": "Page of matching entries. Shape depends on the request's `detailed` flag."
+        },
+        "nextCursor": {
+          "description": "Opaque cursor pointing to the next page. Absent when this is the final page.",
+          "type": [
+            "string",
+            "null"
+          ]
         }
       },
       "required": [
-        "views"
+        "entries"
       ],
       "type": "object"
     },

--- a/tests/approval/snapshots/approval_mysql__list_tools_read_write_unpinned.snap
+++ b/tests/approval/snapshots/approval_mysql__list_tools_read_write_unpinned.snap
@@ -251,7 +251,7 @@ expression: tools
     },
     "outputSchema": {
       "properties": {
-        "functions": {
+        "entries": {
           "anyOf": [
             {
               "description": "Brief mode: sorted array of bare entity-name strings.",
@@ -266,7 +266,7 @@ expression: tools
               "type": "object"
             }
           ],
-          "description": "Page of matching functions. Shape depends on the request's `detailed` flag."
+          "description": "Page of matching entries. Shape depends on the request's `detailed` flag."
         },
         "nextCursor": {
           "description": "Opaque cursor pointing to the next page. Absent when this is the final page.",
@@ -277,7 +277,7 @@ expression: tools
         }
       },
       "required": [
-        "functions"
+        "entries"
       ],
       "type": "object"
     },
@@ -328,14 +328,7 @@ expression: tools
     },
     "outputSchema": {
       "properties": {
-        "nextCursor": {
-          "description": "Opaque cursor pointing to the next page. Absent when this is the final page.",
-          "type": [
-            "string",
-            "null"
-          ]
-        },
-        "procedures": {
+        "entries": {
           "anyOf": [
             {
               "description": "Brief mode: sorted array of bare entity-name strings.",
@@ -350,11 +343,18 @@ expression: tools
               "type": "object"
             }
           ],
-          "description": "Page of matching procedures. Shape depends on the request's `detailed` flag."
+          "description": "Page of matching entries. Shape depends on the request's `detailed` flag."
+        },
+        "nextCursor": {
+          "description": "Opaque cursor pointing to the next page. Absent when this is the final page.",
+          "type": [
+            "string",
+            "null"
+          ]
         }
       },
       "required": [
-        "procedures"
+        "entries"
       ],
       "type": "object"
     },
@@ -405,14 +405,7 @@ expression: tools
     },
     "outputSchema": {
       "properties": {
-        "nextCursor": {
-          "description": "Opaque cursor pointing to the next page. Absent when this is the final page.",
-          "type": [
-            "string",
-            "null"
-          ]
-        },
-        "tables": {
+        "entries": {
           "anyOf": [
             {
               "description": "Brief mode: sorted array of bare entity-name strings.",
@@ -427,11 +420,18 @@ expression: tools
               "type": "object"
             }
           ],
-          "description": "Page of matching tables. Shape depends on the request's `detailed` flag."
+          "description": "Page of matching entries. Shape depends on the request's `detailed` flag."
+        },
+        "nextCursor": {
+          "description": "Opaque cursor pointing to the next page. Absent when this is the final page.",
+          "type": [
+            "string",
+            "null"
+          ]
         }
       },
       "required": [
-        "tables"
+        "entries"
       ],
       "type": "object"
     },
@@ -482,14 +482,7 @@ expression: tools
     },
     "outputSchema": {
       "properties": {
-        "nextCursor": {
-          "description": "Opaque cursor pointing to the next page. Absent when this is the final page.",
-          "type": [
-            "string",
-            "null"
-          ]
-        },
-        "triggers": {
+        "entries": {
           "anyOf": [
             {
               "description": "Brief mode: sorted array of bare entity-name strings.",
@@ -504,11 +497,18 @@ expression: tools
               "type": "object"
             }
           ],
-          "description": "Page of matching triggers. Shape depends on the request's `detailed` flag."
+          "description": "Page of matching entries. Shape depends on the request's `detailed` flag."
+        },
+        "nextCursor": {
+          "description": "Opaque cursor pointing to the next page. Absent when this is the final page.",
+          "type": [
+            "string",
+            "null"
+          ]
         }
       },
       "required": [
-        "triggers"
+        "entries"
       ],
       "type": "object"
     },
@@ -559,14 +559,7 @@ expression: tools
     },
     "outputSchema": {
       "properties": {
-        "nextCursor": {
-          "description": "Opaque cursor pointing to the next page. Absent when this is the final page.",
-          "type": [
-            "string",
-            "null"
-          ]
-        },
-        "views": {
+        "entries": {
           "anyOf": [
             {
               "description": "Brief mode: sorted array of bare entity-name strings.",
@@ -581,11 +574,18 @@ expression: tools
               "type": "object"
             }
           ],
-          "description": "Page of matching views. Shape depends on the request's `detailed` flag."
+          "description": "Page of matching entries. Shape depends on the request's `detailed` flag."
+        },
+        "nextCursor": {
+          "description": "Opaque cursor pointing to the next page. Absent when this is the final page.",
+          "type": [
+            "string",
+            "null"
+          ]
         }
       },
       "required": [
-        "views"
+        "entries"
       ],
       "type": "object"
     },

--- a/tests/approval/snapshots/approval_postgres__list_tools_read_only_pinned.snap
+++ b/tests/approval/snapshots/approval_postgres__list_tools_read_only_pinned.snap
@@ -76,7 +76,7 @@ expression: tools
     },
     "outputSchema": {
       "properties": {
-        "functions": {
+        "entries": {
           "anyOf": [
             {
               "description": "Brief mode: sorted array of bare entity-name strings.",
@@ -91,7 +91,7 @@ expression: tools
               "type": "object"
             }
           ],
-          "description": "Page of matching functions. Shape depends on the request's `detailed` flag."
+          "description": "Page of matching entries. Shape depends on the request's `detailed` flag."
         },
         "nextCursor": {
           "description": "Opaque cursor pointing to the next page. Absent when this is the final page.",
@@ -102,7 +102,7 @@ expression: tools
         }
       },
       "required": [
-        "functions"
+        "entries"
       ],
       "type": "object"
     },
@@ -145,7 +145,7 @@ expression: tools
     },
     "outputSchema": {
       "properties": {
-        "materializedViews": {
+        "entries": {
           "anyOf": [
             {
               "description": "Brief mode: sorted array of bare entity-name strings.",
@@ -160,7 +160,7 @@ expression: tools
               "type": "object"
             }
           ],
-          "description": "Page of matching materialized views. Shape depends on the request's `detailed` flag."
+          "description": "Page of matching entries. Shape depends on the request's `detailed` flag."
         },
         "nextCursor": {
           "description": "Opaque cursor pointing to the next page. Absent when this is the final page.",
@@ -171,7 +171,7 @@ expression: tools
         }
       },
       "required": [
-        "materializedViews"
+        "entries"
       ],
       "type": "object"
     },
@@ -214,14 +214,7 @@ expression: tools
     },
     "outputSchema": {
       "properties": {
-        "nextCursor": {
-          "description": "Opaque cursor pointing to the next page. Absent when this is the final page.",
-          "type": [
-            "string",
-            "null"
-          ]
-        },
-        "procedures": {
+        "entries": {
           "anyOf": [
             {
               "description": "Brief mode: sorted array of bare entity-name strings.",
@@ -236,11 +229,18 @@ expression: tools
               "type": "object"
             }
           ],
-          "description": "Page of matching procedures. Shape depends on the request's `detailed` flag."
+          "description": "Page of matching entries. Shape depends on the request's `detailed` flag."
+        },
+        "nextCursor": {
+          "description": "Opaque cursor pointing to the next page. Absent when this is the final page.",
+          "type": [
+            "string",
+            "null"
+          ]
         }
       },
       "required": [
-        "procedures"
+        "entries"
       ],
       "type": "object"
     },
@@ -283,14 +283,7 @@ expression: tools
     },
     "outputSchema": {
       "properties": {
-        "nextCursor": {
-          "description": "Opaque cursor pointing to the next page. Absent when this is the final page.",
-          "type": [
-            "string",
-            "null"
-          ]
-        },
-        "tables": {
+        "entries": {
           "anyOf": [
             {
               "description": "Brief mode: sorted array of bare entity-name strings.",
@@ -305,11 +298,18 @@ expression: tools
               "type": "object"
             }
           ],
-          "description": "Page of matching tables. Shape depends on the request's `detailed` flag."
+          "description": "Page of matching entries. Shape depends on the request's `detailed` flag."
+        },
+        "nextCursor": {
+          "description": "Opaque cursor pointing to the next page. Absent when this is the final page.",
+          "type": [
+            "string",
+            "null"
+          ]
         }
       },
       "required": [
-        "tables"
+        "entries"
       ],
       "type": "object"
     },
@@ -352,14 +352,7 @@ expression: tools
     },
     "outputSchema": {
       "properties": {
-        "nextCursor": {
-          "description": "Opaque cursor pointing to the next page. Absent when this is the final page.",
-          "type": [
-            "string",
-            "null"
-          ]
-        },
-        "triggers": {
+        "entries": {
           "anyOf": [
             {
               "description": "Brief mode: sorted array of bare entity-name strings.",
@@ -374,11 +367,18 @@ expression: tools
               "type": "object"
             }
           ],
-          "description": "Page of matching triggers. Shape depends on the request's `detailed` flag."
+          "description": "Page of matching entries. Shape depends on the request's `detailed` flag."
+        },
+        "nextCursor": {
+          "description": "Opaque cursor pointing to the next page. Absent when this is the final page.",
+          "type": [
+            "string",
+            "null"
+          ]
         }
       },
       "required": [
-        "triggers"
+        "entries"
       ],
       "type": "object"
     },
@@ -421,14 +421,7 @@ expression: tools
     },
     "outputSchema": {
       "properties": {
-        "nextCursor": {
-          "description": "Opaque cursor pointing to the next page. Absent when this is the final page.",
-          "type": [
-            "string",
-            "null"
-          ]
-        },
-        "views": {
+        "entries": {
           "anyOf": [
             {
               "description": "Brief mode: sorted array of bare entity-name strings.",
@@ -443,11 +436,18 @@ expression: tools
               "type": "object"
             }
           ],
-          "description": "Page of matching views. Shape depends on the request's `detailed` flag."
+          "description": "Page of matching entries. Shape depends on the request's `detailed` flag."
+        },
+        "nextCursor": {
+          "description": "Opaque cursor pointing to the next page. Absent when this is the final page.",
+          "type": [
+            "string",
+            "null"
+          ]
         }
       },
       "required": [
-        "views"
+        "entries"
       ],
       "type": "object"
     },

--- a/tests/approval/snapshots/approval_postgres__list_tools_read_only_unpinned.snap
+++ b/tests/approval/snapshots/approval_postgres__list_tools_read_only_unpinned.snap
@@ -138,7 +138,7 @@ expression: tools
     },
     "outputSchema": {
       "properties": {
-        "functions": {
+        "entries": {
           "anyOf": [
             {
               "description": "Brief mode: sorted array of bare entity-name strings.",
@@ -153,7 +153,7 @@ expression: tools
               "type": "object"
             }
           ],
-          "description": "Page of matching functions. Shape depends on the request's `detailed` flag."
+          "description": "Page of matching entries. Shape depends on the request's `detailed` flag."
         },
         "nextCursor": {
           "description": "Opaque cursor pointing to the next page. Absent when this is the final page.",
@@ -164,7 +164,7 @@ expression: tools
         }
       },
       "required": [
-        "functions"
+        "entries"
       ],
       "type": "object"
     },
@@ -215,7 +215,7 @@ expression: tools
     },
     "outputSchema": {
       "properties": {
-        "materializedViews": {
+        "entries": {
           "anyOf": [
             {
               "description": "Brief mode: sorted array of bare entity-name strings.",
@@ -230,7 +230,7 @@ expression: tools
               "type": "object"
             }
           ],
-          "description": "Page of matching materialized views. Shape depends on the request's `detailed` flag."
+          "description": "Page of matching entries. Shape depends on the request's `detailed` flag."
         },
         "nextCursor": {
           "description": "Opaque cursor pointing to the next page. Absent when this is the final page.",
@@ -241,7 +241,7 @@ expression: tools
         }
       },
       "required": [
-        "materializedViews"
+        "entries"
       ],
       "type": "object"
     },
@@ -292,14 +292,7 @@ expression: tools
     },
     "outputSchema": {
       "properties": {
-        "nextCursor": {
-          "description": "Opaque cursor pointing to the next page. Absent when this is the final page.",
-          "type": [
-            "string",
-            "null"
-          ]
-        },
-        "procedures": {
+        "entries": {
           "anyOf": [
             {
               "description": "Brief mode: sorted array of bare entity-name strings.",
@@ -314,11 +307,18 @@ expression: tools
               "type": "object"
             }
           ],
-          "description": "Page of matching procedures. Shape depends on the request's `detailed` flag."
+          "description": "Page of matching entries. Shape depends on the request's `detailed` flag."
+        },
+        "nextCursor": {
+          "description": "Opaque cursor pointing to the next page. Absent when this is the final page.",
+          "type": [
+            "string",
+            "null"
+          ]
         }
       },
       "required": [
-        "procedures"
+        "entries"
       ],
       "type": "object"
     },
@@ -369,14 +369,7 @@ expression: tools
     },
     "outputSchema": {
       "properties": {
-        "nextCursor": {
-          "description": "Opaque cursor pointing to the next page. Absent when this is the final page.",
-          "type": [
-            "string",
-            "null"
-          ]
-        },
-        "tables": {
+        "entries": {
           "anyOf": [
             {
               "description": "Brief mode: sorted array of bare entity-name strings.",
@@ -391,11 +384,18 @@ expression: tools
               "type": "object"
             }
           ],
-          "description": "Page of matching tables. Shape depends on the request's `detailed` flag."
+          "description": "Page of matching entries. Shape depends on the request's `detailed` flag."
+        },
+        "nextCursor": {
+          "description": "Opaque cursor pointing to the next page. Absent when this is the final page.",
+          "type": [
+            "string",
+            "null"
+          ]
         }
       },
       "required": [
-        "tables"
+        "entries"
       ],
       "type": "object"
     },
@@ -446,14 +446,7 @@ expression: tools
     },
     "outputSchema": {
       "properties": {
-        "nextCursor": {
-          "description": "Opaque cursor pointing to the next page. Absent when this is the final page.",
-          "type": [
-            "string",
-            "null"
-          ]
-        },
-        "triggers": {
+        "entries": {
           "anyOf": [
             {
               "description": "Brief mode: sorted array of bare entity-name strings.",
@@ -468,11 +461,18 @@ expression: tools
               "type": "object"
             }
           ],
-          "description": "Page of matching triggers. Shape depends on the request's `detailed` flag."
+          "description": "Page of matching entries. Shape depends on the request's `detailed` flag."
+        },
+        "nextCursor": {
+          "description": "Opaque cursor pointing to the next page. Absent when this is the final page.",
+          "type": [
+            "string",
+            "null"
+          ]
         }
       },
       "required": [
-        "triggers"
+        "entries"
       ],
       "type": "object"
     },
@@ -523,14 +523,7 @@ expression: tools
     },
     "outputSchema": {
       "properties": {
-        "nextCursor": {
-          "description": "Opaque cursor pointing to the next page. Absent when this is the final page.",
-          "type": [
-            "string",
-            "null"
-          ]
-        },
-        "views": {
+        "entries": {
           "anyOf": [
             {
               "description": "Brief mode: sorted array of bare entity-name strings.",
@@ -545,11 +538,18 @@ expression: tools
               "type": "object"
             }
           ],
-          "description": "Page of matching views. Shape depends on the request's `detailed` flag."
+          "description": "Page of matching entries. Shape depends on the request's `detailed` flag."
+        },
+        "nextCursor": {
+          "description": "Opaque cursor pointing to the next page. Absent when this is the final page.",
+          "type": [
+            "string",
+            "null"
+          ]
         }
       },
       "required": [
-        "views"
+        "entries"
       ],
       "type": "object"
     },

--- a/tests/approval/snapshots/approval_postgres__list_tools_read_write_pinned.snap
+++ b/tests/approval/snapshots/approval_postgres__list_tools_read_write_pinned.snap
@@ -116,7 +116,7 @@ expression: tools
     },
     "outputSchema": {
       "properties": {
-        "functions": {
+        "entries": {
           "anyOf": [
             {
               "description": "Brief mode: sorted array of bare entity-name strings.",
@@ -131,7 +131,7 @@ expression: tools
               "type": "object"
             }
           ],
-          "description": "Page of matching functions. Shape depends on the request's `detailed` flag."
+          "description": "Page of matching entries. Shape depends on the request's `detailed` flag."
         },
         "nextCursor": {
           "description": "Opaque cursor pointing to the next page. Absent when this is the final page.",
@@ -142,7 +142,7 @@ expression: tools
         }
       },
       "required": [
-        "functions"
+        "entries"
       ],
       "type": "object"
     },
@@ -185,7 +185,7 @@ expression: tools
     },
     "outputSchema": {
       "properties": {
-        "materializedViews": {
+        "entries": {
           "anyOf": [
             {
               "description": "Brief mode: sorted array of bare entity-name strings.",
@@ -200,7 +200,7 @@ expression: tools
               "type": "object"
             }
           ],
-          "description": "Page of matching materialized views. Shape depends on the request's `detailed` flag."
+          "description": "Page of matching entries. Shape depends on the request's `detailed` flag."
         },
         "nextCursor": {
           "description": "Opaque cursor pointing to the next page. Absent when this is the final page.",
@@ -211,7 +211,7 @@ expression: tools
         }
       },
       "required": [
-        "materializedViews"
+        "entries"
       ],
       "type": "object"
     },
@@ -254,14 +254,7 @@ expression: tools
     },
     "outputSchema": {
       "properties": {
-        "nextCursor": {
-          "description": "Opaque cursor pointing to the next page. Absent when this is the final page.",
-          "type": [
-            "string",
-            "null"
-          ]
-        },
-        "procedures": {
+        "entries": {
           "anyOf": [
             {
               "description": "Brief mode: sorted array of bare entity-name strings.",
@@ -276,11 +269,18 @@ expression: tools
               "type": "object"
             }
           ],
-          "description": "Page of matching procedures. Shape depends on the request's `detailed` flag."
+          "description": "Page of matching entries. Shape depends on the request's `detailed` flag."
+        },
+        "nextCursor": {
+          "description": "Opaque cursor pointing to the next page. Absent when this is the final page.",
+          "type": [
+            "string",
+            "null"
+          ]
         }
       },
       "required": [
-        "procedures"
+        "entries"
       ],
       "type": "object"
     },
@@ -323,14 +323,7 @@ expression: tools
     },
     "outputSchema": {
       "properties": {
-        "nextCursor": {
-          "description": "Opaque cursor pointing to the next page. Absent when this is the final page.",
-          "type": [
-            "string",
-            "null"
-          ]
-        },
-        "tables": {
+        "entries": {
           "anyOf": [
             {
               "description": "Brief mode: sorted array of bare entity-name strings.",
@@ -345,11 +338,18 @@ expression: tools
               "type": "object"
             }
           ],
-          "description": "Page of matching tables. Shape depends on the request's `detailed` flag."
+          "description": "Page of matching entries. Shape depends on the request's `detailed` flag."
+        },
+        "nextCursor": {
+          "description": "Opaque cursor pointing to the next page. Absent when this is the final page.",
+          "type": [
+            "string",
+            "null"
+          ]
         }
       },
       "required": [
-        "tables"
+        "entries"
       ],
       "type": "object"
     },
@@ -392,14 +392,7 @@ expression: tools
     },
     "outputSchema": {
       "properties": {
-        "nextCursor": {
-          "description": "Opaque cursor pointing to the next page. Absent when this is the final page.",
-          "type": [
-            "string",
-            "null"
-          ]
-        },
-        "triggers": {
+        "entries": {
           "anyOf": [
             {
               "description": "Brief mode: sorted array of bare entity-name strings.",
@@ -414,11 +407,18 @@ expression: tools
               "type": "object"
             }
           ],
-          "description": "Page of matching triggers. Shape depends on the request's `detailed` flag."
+          "description": "Page of matching entries. Shape depends on the request's `detailed` flag."
+        },
+        "nextCursor": {
+          "description": "Opaque cursor pointing to the next page. Absent when this is the final page.",
+          "type": [
+            "string",
+            "null"
+          ]
         }
       },
       "required": [
-        "triggers"
+        "entries"
       ],
       "type": "object"
     },
@@ -461,14 +461,7 @@ expression: tools
     },
     "outputSchema": {
       "properties": {
-        "nextCursor": {
-          "description": "Opaque cursor pointing to the next page. Absent when this is the final page.",
-          "type": [
-            "string",
-            "null"
-          ]
-        },
-        "views": {
+        "entries": {
           "anyOf": [
             {
               "description": "Brief mode: sorted array of bare entity-name strings.",
@@ -483,11 +476,18 @@ expression: tools
               "type": "object"
             }
           ],
-          "description": "Page of matching views. Shape depends on the request's `detailed` flag."
+          "description": "Page of matching entries. Shape depends on the request's `detailed` flag."
+        },
+        "nextCursor": {
+          "description": "Opaque cursor pointing to the next page. Absent when this is the final page.",
+          "type": [
+            "string",
+            "null"
+          ]
         }
       },
       "required": [
-        "views"
+        "entries"
       ],
       "type": "object"
     },

--- a/tests/approval/snapshots/approval_postgres__list_tools_read_write_unpinned.snap
+++ b/tests/approval/snapshots/approval_postgres__list_tools_read_write_unpinned.snap
@@ -256,7 +256,7 @@ expression: tools
     },
     "outputSchema": {
       "properties": {
-        "functions": {
+        "entries": {
           "anyOf": [
             {
               "description": "Brief mode: sorted array of bare entity-name strings.",
@@ -271,7 +271,7 @@ expression: tools
               "type": "object"
             }
           ],
-          "description": "Page of matching functions. Shape depends on the request's `detailed` flag."
+          "description": "Page of matching entries. Shape depends on the request's `detailed` flag."
         },
         "nextCursor": {
           "description": "Opaque cursor pointing to the next page. Absent when this is the final page.",
@@ -282,7 +282,7 @@ expression: tools
         }
       },
       "required": [
-        "functions"
+        "entries"
       ],
       "type": "object"
     },
@@ -333,7 +333,7 @@ expression: tools
     },
     "outputSchema": {
       "properties": {
-        "materializedViews": {
+        "entries": {
           "anyOf": [
             {
               "description": "Brief mode: sorted array of bare entity-name strings.",
@@ -348,7 +348,7 @@ expression: tools
               "type": "object"
             }
           ],
-          "description": "Page of matching materialized views. Shape depends on the request's `detailed` flag."
+          "description": "Page of matching entries. Shape depends on the request's `detailed` flag."
         },
         "nextCursor": {
           "description": "Opaque cursor pointing to the next page. Absent when this is the final page.",
@@ -359,7 +359,7 @@ expression: tools
         }
       },
       "required": [
-        "materializedViews"
+        "entries"
       ],
       "type": "object"
     },
@@ -410,14 +410,7 @@ expression: tools
     },
     "outputSchema": {
       "properties": {
-        "nextCursor": {
-          "description": "Opaque cursor pointing to the next page. Absent when this is the final page.",
-          "type": [
-            "string",
-            "null"
-          ]
-        },
-        "procedures": {
+        "entries": {
           "anyOf": [
             {
               "description": "Brief mode: sorted array of bare entity-name strings.",
@@ -432,11 +425,18 @@ expression: tools
               "type": "object"
             }
           ],
-          "description": "Page of matching procedures. Shape depends on the request's `detailed` flag."
+          "description": "Page of matching entries. Shape depends on the request's `detailed` flag."
+        },
+        "nextCursor": {
+          "description": "Opaque cursor pointing to the next page. Absent when this is the final page.",
+          "type": [
+            "string",
+            "null"
+          ]
         }
       },
       "required": [
-        "procedures"
+        "entries"
       ],
       "type": "object"
     },
@@ -487,14 +487,7 @@ expression: tools
     },
     "outputSchema": {
       "properties": {
-        "nextCursor": {
-          "description": "Opaque cursor pointing to the next page. Absent when this is the final page.",
-          "type": [
-            "string",
-            "null"
-          ]
-        },
-        "tables": {
+        "entries": {
           "anyOf": [
             {
               "description": "Brief mode: sorted array of bare entity-name strings.",
@@ -509,11 +502,18 @@ expression: tools
               "type": "object"
             }
           ],
-          "description": "Page of matching tables. Shape depends on the request's `detailed` flag."
+          "description": "Page of matching entries. Shape depends on the request's `detailed` flag."
+        },
+        "nextCursor": {
+          "description": "Opaque cursor pointing to the next page. Absent when this is the final page.",
+          "type": [
+            "string",
+            "null"
+          ]
         }
       },
       "required": [
-        "tables"
+        "entries"
       ],
       "type": "object"
     },
@@ -564,14 +564,7 @@ expression: tools
     },
     "outputSchema": {
       "properties": {
-        "nextCursor": {
-          "description": "Opaque cursor pointing to the next page. Absent when this is the final page.",
-          "type": [
-            "string",
-            "null"
-          ]
-        },
-        "triggers": {
+        "entries": {
           "anyOf": [
             {
               "description": "Brief mode: sorted array of bare entity-name strings.",
@@ -586,11 +579,18 @@ expression: tools
               "type": "object"
             }
           ],
-          "description": "Page of matching triggers. Shape depends on the request's `detailed` flag."
+          "description": "Page of matching entries. Shape depends on the request's `detailed` flag."
+        },
+        "nextCursor": {
+          "description": "Opaque cursor pointing to the next page. Absent when this is the final page.",
+          "type": [
+            "string",
+            "null"
+          ]
         }
       },
       "required": [
-        "triggers"
+        "entries"
       ],
       "type": "object"
     },
@@ -641,14 +641,7 @@ expression: tools
     },
     "outputSchema": {
       "properties": {
-        "nextCursor": {
-          "description": "Opaque cursor pointing to the next page. Absent when this is the final page.",
-          "type": [
-            "string",
-            "null"
-          ]
-        },
-        "views": {
+        "entries": {
           "anyOf": [
             {
               "description": "Brief mode: sorted array of bare entity-name strings.",
@@ -663,11 +656,18 @@ expression: tools
               "type": "object"
             }
           ],
-          "description": "Page of matching views. Shape depends on the request's `detailed` flag."
+          "description": "Page of matching entries. Shape depends on the request's `detailed` flag."
+        },
+        "nextCursor": {
+          "description": "Opaque cursor pointing to the next page. Absent when this is the final page.",
+          "type": [
+            "string",
+            "null"
+          ]
         }
       },
       "required": [
-        "views"
+        "entries"
       ],
       "type": "object"
     },

--- a/tests/approval/snapshots/approval_sqlite__list_tools_read_only.snap
+++ b/tests/approval/snapshots/approval_sqlite__list_tools_read_only.snap
@@ -71,14 +71,7 @@ expression: tools
     },
     "outputSchema": {
       "properties": {
-        "nextCursor": {
-          "description": "Opaque cursor pointing to the next page. Absent when this is the final page.",
-          "type": [
-            "string",
-            "null"
-          ]
-        },
-        "tables": {
+        "entries": {
           "anyOf": [
             {
               "description": "Brief mode: sorted array of bare entity-name strings.",
@@ -93,11 +86,18 @@ expression: tools
               "type": "object"
             }
           ],
-          "description": "Page of matching tables. Shape depends on the request's `detailed` flag."
+          "description": "Page of matching entries. Shape depends on the request's `detailed` flag."
+        },
+        "nextCursor": {
+          "description": "Opaque cursor pointing to the next page. Absent when this is the final page.",
+          "type": [
+            "string",
+            "null"
+          ]
         }
       },
       "required": [
-        "tables"
+        "entries"
       ],
       "type": "object"
     },
@@ -140,14 +140,7 @@ expression: tools
     },
     "outputSchema": {
       "properties": {
-        "nextCursor": {
-          "description": "Opaque cursor pointing to the next page. Absent when this is the final page.",
-          "type": [
-            "string",
-            "null"
-          ]
-        },
-        "triggers": {
+        "entries": {
           "anyOf": [
             {
               "description": "Brief mode: sorted array of bare entity-name strings.",
@@ -162,11 +155,18 @@ expression: tools
               "type": "object"
             }
           ],
-          "description": "Page of matching triggers. Shape depends on the request's `detailed` flag."
+          "description": "Page of matching entries. Shape depends on the request's `detailed` flag."
+        },
+        "nextCursor": {
+          "description": "Opaque cursor pointing to the next page. Absent when this is the final page.",
+          "type": [
+            "string",
+            "null"
+          ]
         }
       },
       "required": [
-        "triggers"
+        "entries"
       ],
       "type": "object"
     },
@@ -187,14 +187,7 @@ expression: tools
     },
     "outputSchema": {
       "properties": {
-        "nextCursor": {
-          "description": "Opaque cursor pointing to the next page. Absent when this is the final page.",
-          "type": [
-            "string",
-            "null"
-          ]
-        },
-        "views": {
+        "entries": {
           "anyOf": [
             {
               "description": "Brief mode: sorted array of bare entity-name strings.",
@@ -209,11 +202,18 @@ expression: tools
               "type": "object"
             }
           ],
-          "description": "Page of matching views. Shape depends on the request's `detailed` flag."
+          "description": "Page of matching entries. Shape depends on the request's `detailed` flag."
+        },
+        "nextCursor": {
+          "description": "Opaque cursor pointing to the next page. Absent when this is the final page.",
+          "type": [
+            "string",
+            "null"
+          ]
         }
       },
       "required": [
-        "views"
+        "entries"
       ],
       "type": "object"
     },

--- a/tests/approval/snapshots/approval_sqlite__list_tools_read_write.snap
+++ b/tests/approval/snapshots/approval_sqlite__list_tools_read_write.snap
@@ -106,14 +106,7 @@ expression: tools
     },
     "outputSchema": {
       "properties": {
-        "nextCursor": {
-          "description": "Opaque cursor pointing to the next page. Absent when this is the final page.",
-          "type": [
-            "string",
-            "null"
-          ]
-        },
-        "tables": {
+        "entries": {
           "anyOf": [
             {
               "description": "Brief mode: sorted array of bare entity-name strings.",
@@ -128,11 +121,18 @@ expression: tools
               "type": "object"
             }
           ],
-          "description": "Page of matching tables. Shape depends on the request's `detailed` flag."
+          "description": "Page of matching entries. Shape depends on the request's `detailed` flag."
+        },
+        "nextCursor": {
+          "description": "Opaque cursor pointing to the next page. Absent when this is the final page.",
+          "type": [
+            "string",
+            "null"
+          ]
         }
       },
       "required": [
-        "tables"
+        "entries"
       ],
       "type": "object"
     },
@@ -175,14 +175,7 @@ expression: tools
     },
     "outputSchema": {
       "properties": {
-        "nextCursor": {
-          "description": "Opaque cursor pointing to the next page. Absent when this is the final page.",
-          "type": [
-            "string",
-            "null"
-          ]
-        },
-        "triggers": {
+        "entries": {
           "anyOf": [
             {
               "description": "Brief mode: sorted array of bare entity-name strings.",
@@ -197,11 +190,18 @@ expression: tools
               "type": "object"
             }
           ],
-          "description": "Page of matching triggers. Shape depends on the request's `detailed` flag."
+          "description": "Page of matching entries. Shape depends on the request's `detailed` flag."
+        },
+        "nextCursor": {
+          "description": "Opaque cursor pointing to the next page. Absent when this is the final page.",
+          "type": [
+            "string",
+            "null"
+          ]
         }
       },
       "required": [
-        "triggers"
+        "entries"
       ],
       "type": "object"
     },
@@ -222,14 +222,7 @@ expression: tools
     },
     "outputSchema": {
       "properties": {
-        "nextCursor": {
-          "description": "Opaque cursor pointing to the next page. Absent when this is the final page.",
-          "type": [
-            "string",
-            "null"
-          ]
-        },
-        "views": {
+        "entries": {
           "anyOf": [
             {
               "description": "Brief mode: sorted array of bare entity-name strings.",
@@ -244,11 +237,18 @@ expression: tools
               "type": "object"
             }
           ],
-          "description": "Page of matching views. Shape depends on the request's `detailed` flag."
+          "description": "Page of matching entries. Shape depends on the request's `detailed` flag."
+        },
+        "nextCursor": {
+          "description": "Opaque cursor pointing to the next page. Absent when this is the final page.",
+          "type": [
+            "string",
+            "null"
+          ]
         }
       },
       "required": [
-        "views"
+        "entries"
       ],
       "type": "object"
     },

--- a/tests/functional/mysql.rs
+++ b/tests/functional/mysql.rs
@@ -182,7 +182,7 @@ async fn test_lists_tables() {
         .list_tables(Some("app".into()), None, None, false)
         .await
         .unwrap();
-    let ListEntries::Brief(tables) = response.tables else {
+    let ListEntries::Brief(tables) = response.entries else {
         panic!("expected brief-mode tables");
     };
 
@@ -310,7 +310,7 @@ async fn test_lists_tables_cross_database() {
         .list_tables(Some("analytics".into()), None, None, false)
         .await
         .unwrap();
-    let ListEntries::Brief(tables) = response.tables else {
+    let ListEntries::Brief(tables) = response.entries else {
         panic!("expected brief-mode tables");
     };
 
@@ -378,7 +378,7 @@ async fn test_uses_default_pool_for_matching_database() {
         .list_tables(Some("app".into()), None, None, false)
         .await
         .unwrap();
-    let ListEntries::Brief(tables) = response.tables else {
+    let ListEntries::Brief(tables) = response.entries else {
         panic!("expected brief-mode tables");
     };
 
@@ -464,7 +464,7 @@ async fn test_drop_table_success() {
         .list_tables(Some("app".into()), None, None, false)
         .await
         .unwrap();
-    let ListEntries::Brief(tables) = response.tables else {
+    let ListEntries::Brief(tables) = response.entries else {
         panic!("expected brief-mode tables");
     };
     assert!(
@@ -552,9 +552,9 @@ async fn test_list_tables_nonexistent_database_returns_empty() {
         .await
         .unwrap();
     assert!(
-        response.tables.is_empty(),
+        response.entries.is_empty(),
         "Nonexistent database should return empty table list, got: {:?}",
-        response.tables
+        response.entries
     );
 }
 
@@ -566,7 +566,7 @@ async fn test_list_tables_empty_database_falls_back_to_default() {
         .list_tables(Some(String::new()), None, None, false)
         .await
         .expect("empty db should default to --db-name");
-    let tables = response.tables.as_brief().expect("brief-mode tables");
+    let tables = response.entries.as_brief().expect("brief-mode tables");
     assert!(
         tables.iter().any(|t| t == "users"),
         "expected default-database tables, got {tables:?}",
@@ -581,7 +581,7 @@ async fn test_list_tables_omitted_database_falls_back_to_default() {
         .list_tables(None, None, None, false)
         .await
         .expect("omitted db should default to --db-name");
-    let tables = response.tables.as_brief().expect("brief-mode tables");
+    let tables = response.entries.as_brief().expect("brief-mode tables");
     assert!(
         tables.iter().any(|t| t == "users"),
         "expected default-database tables, got {tables:?}",
@@ -1133,7 +1133,7 @@ async fn collect_all_paged(handler: &MysqlHandler) -> Vec<String> {
             .list_tables(Some(MY_DB.into()), cursor.take(), None, false)
             .await
             .expect("list page");
-        all.extend(response.tables.into_brief().expect("brief-mode page"));
+        all.extend(response.entries.into_brief().expect("brief-mode page"));
         match response.next_cursor {
             Some(c) => cursor = Some(c),
             None => break,
@@ -1154,7 +1154,7 @@ async fn test_list_tables_pagination_traverses_pages() {
         .await
         .expect("single page");
 
-    let single_page_tables = single_page.tables.into_brief().expect("brief-mode page");
+    let single_page_tables = single_page.entries.into_brief().expect("brief-mode page");
     assert_eq!(
         collected, single_page_tables,
         "paged traversal must yield identical results (and ordering) to a single full page"
@@ -1183,7 +1183,7 @@ async fn test_list_tables_pagination_boundary_page_size_equals_total() {
         .list_tables(Some(MY_DB.into()), None, None, false)
         .await
         .expect("discover total")
-        .tables
+        .entries
         .len();
     let page_size = u16::try_from(total).expect("seed total fits in u16");
 
@@ -1193,7 +1193,7 @@ async fn test_list_tables_pagination_boundary_page_size_equals_total() {
         .await
         .unwrap();
     assert_eq!(
-        response.tables.len(),
+        response.entries.len(),
         total,
         "page_size equal to total must return everything on one page"
     );
@@ -1214,9 +1214,9 @@ async fn test_list_tables_pagination_off_the_end_cursor_returns_empty_page() {
         .unwrap();
 
     assert!(
-        response.tables.is_empty(),
+        response.entries.is_empty(),
         "off-the-end cursor must return empty tables, got {:?}",
-        response.tables
+        response.entries
     );
     assert!(response.next_cursor.is_none(), "off-the-end must not emit nextCursor");
 }
@@ -1228,7 +1228,7 @@ async fn test_list_tables_respects_configured_page_size() {
         .list_tables(Some(MY_DB.into()), None, None, false)
         .await
         .expect("first page");
-    assert_eq!(first.tables.len(), 2, "configured page_size=2 must cap page 1");
+    assert_eq!(first.entries.len(), 2, "configured page_size=2 must cap page 1");
     assert!(
         first.next_cursor.is_some(),
         "page 1 must emit nextCursor when total > page_size"
@@ -1242,7 +1242,7 @@ async fn test_list_tables_respects_configured_page_size_minimum() {
         .list_tables(Some(MY_DB.into()), None, None, false)
         .await
         .expect("first page");
-    assert_eq!(first.tables.len(), 1, "page_size=1 must return one table per page");
+    assert_eq!(first.entries.len(), 1, "page_size=1 must return one table per page");
     assert!(first.next_cursor.is_some(), "page 1 must emit nextCursor");
 }
 
@@ -1570,7 +1570,7 @@ async fn test_list_views_returns_seeded_views() {
         .await
         .expect("list_views");
 
-    let names = response.views.as_brief().expect("brief mode");
+    let names = response.entries.as_brief().expect("brief mode");
     assert!(
         names.contains(&"active_users".to_string()),
         "expected seeded active_users view in {names:?}"
@@ -1589,7 +1589,7 @@ async fn test_list_views_excludes_base_tables() {
         .await
         .expect("list_views");
 
-    let names = response.views.as_brief().expect("brief mode");
+    let names = response.entries.as_brief().expect("brief mode");
     assert!(
         !names.contains(&"users".to_string()),
         "base table `users` must not appear in listViews, got {names:?}"
@@ -1609,9 +1609,9 @@ async fn test_list_views_empty_for_view_less_database() {
         .expect("list_views");
 
     assert!(
-        response.views.as_brief().expect("brief").is_empty(),
+        response.entries.as_brief().expect("brief").is_empty(),
         "analytics has no views, got {:?}",
-        response.views
+        response.entries
     );
 }
 
@@ -1623,9 +1623,9 @@ async fn test_list_views_empty_database_falls_back_to_default() {
         .await
         .expect("empty db should default to --db-name");
     assert!(
-        !response.views.as_brief().expect("brief").is_empty(),
+        !response.entries.as_brief().expect("brief").is_empty(),
         "default db has seeded views, got {:?}",
-        response.views
+        response.entries
     );
 }
 
@@ -1637,9 +1637,9 @@ async fn test_list_views_omitted_database_falls_back_to_default() {
         .await
         .expect("omitted db should default to --db-name");
     assert!(
-        !response.views.as_brief().expect("brief").is_empty(),
+        !response.entries.as_brief().expect("brief").is_empty(),
         "default db has seeded views, got {:?}",
-        response.views
+        response.entries
     );
 }
 
@@ -1655,7 +1655,7 @@ async fn test_list_views_pagination_traverses_pages() {
             .list_views(Some("app".into()), cursor.take(), None, false)
             .await
             .expect("paged list_views");
-        all.extend(response.views.as_brief().expect("brief").iter().cloned());
+        all.extend(response.entries.as_brief().expect("brief").iter().cloned());
         match response.next_cursor {
             Some(c) => cursor = Some(c),
             None => break,
@@ -1667,7 +1667,7 @@ async fn test_list_views_pagination_traverses_pages() {
         .await
         .expect("single-page list_views");
 
-    let single_names = single.views.as_brief().expect("brief").to_vec();
+    let single_names = single.entries.as_brief().expect("brief").to_vec();
     assert_eq!(all, single_names, "paginated traversal should equal single page");
 }
 
@@ -1680,7 +1680,7 @@ async fn test_list_views_works_in_read_only_mode() {
         .expect("list_views in read-only mode");
 
     assert!(
-        !response.views.as_brief().expect("brief").is_empty(),
+        !response.entries.as_brief().expect("brief").is_empty(),
         "read-only mode must still allow listViews"
     );
 }
@@ -1693,7 +1693,7 @@ async fn test_list_triggers_returns_seeded_triggers() {
         .await
         .expect("list_triggers");
 
-    let names = response.triggers.as_brief().expect("brief mode");
+    let names = response.entries.as_brief().expect("brief mode");
     assert!(
         names.contains(&"users_before_insert".to_string()),
         "expected seeded users_before_insert trigger, got {names:?}"
@@ -1712,7 +1712,7 @@ async fn test_list_triggers_empty_for_trigger_less_database() {
         .await
         .expect("list_triggers");
 
-    let names = response.triggers.as_brief().expect("brief mode");
+    let names = response.entries.as_brief().expect("brief mode");
     assert!(names.is_empty(), "analytics has no triggers, got {names:?}");
 }
 
@@ -1724,9 +1724,9 @@ async fn test_list_triggers_empty_database_falls_back_to_default() {
         .await
         .expect("empty db should default to --db-name");
     assert!(
-        !response.triggers.is_empty(),
+        !response.entries.is_empty(),
         "default db has seeded triggers, got {:?}",
-        response.triggers
+        response.entries
     );
 }
 
@@ -1738,9 +1738,9 @@ async fn test_list_triggers_omitted_database_falls_back_to_default() {
         .await
         .expect("omitted db should default to --db-name");
     assert!(
-        !response.triggers.is_empty(),
+        !response.entries.is_empty(),
         "default db has seeded triggers, got {:?}",
-        response.triggers
+        response.entries
     );
 }
 
@@ -1753,7 +1753,7 @@ async fn test_list_triggers_works_in_read_only_mode() {
         .expect("list_triggers in read-only mode");
 
     assert!(
-        !response.triggers.is_empty(),
+        !response.entries.is_empty(),
         "read-only mode must still allow listTriggers"
     );
 }
@@ -1766,7 +1766,7 @@ async fn test_list_triggers_search_filter_returns_only_matches() {
         .await
         .expect("list_triggers");
 
-    let names = response.triggers.as_brief().expect("brief mode");
+    let names = response.entries.as_brief().expect("brief mode");
     let expected = [
         "posts_audit_after_delete".to_string(),
         "posts_audit_after_insert".to_string(),
@@ -1787,7 +1787,7 @@ async fn test_list_triggers_search_is_case_insensitive() {
         .list_triggers(Some("app".into()), None, Some("audit".into()), false)
         .await
         .expect("lower");
-    assert_eq!(upper.triggers.as_brief(), lower.triggers.as_brief());
+    assert_eq!(upper.entries.as_brief(), lower.entries.as_brief());
 }
 
 #[tokio::test]
@@ -1798,7 +1798,7 @@ async fn test_list_triggers_search_no_match_returns_empty() {
         .await
         .expect("list_triggers");
 
-    assert!(response.triggers.as_brief().expect("brief").is_empty());
+    assert!(response.entries.as_brief().expect("brief").is_empty());
     assert!(response.next_cursor.is_none());
 }
 
@@ -1816,7 +1816,7 @@ async fn test_list_triggers_search_supports_wildcard_semantics() {
         .list_triggers(Some("app".into()), None, Some("%audit%".into()), false)
         .await
         .expect("wildcard");
-    assert_eq!(plain.triggers.as_brief(), with_wildcard.triggers.as_brief());
+    assert_eq!(plain.entries.as_brief(), with_wildcard.entries.as_brief());
 }
 
 #[tokio::test]
@@ -1829,7 +1829,7 @@ async fn test_list_triggers_search_sql_meta_payloads_are_safe() {
             .unwrap_or_else(|e| panic!("list_triggers failed for payload {payload:?}: {e:?}"));
 
         assert!(
-            response.triggers.as_brief().is_some(),
+            response.entries.as_brief().is_some(),
             "payload {payload:?} returned non-brief shape"
         );
     }
@@ -1845,7 +1845,7 @@ async fn test_list_triggers_search_paginates_filtered_results() {
             .list_triggers(Some("app".into()), cursor.take(), Some("audit".into()), false)
             .await
             .expect("list_triggers paginated");
-        let names = response.triggers.as_brief().expect("brief").to_vec();
+        let names = response.entries.as_brief().expect("brief").to_vec();
         all.extend(names);
         cursor = response.next_cursor;
         if cursor.is_none() {
@@ -1859,7 +1859,7 @@ async fn test_list_triggers_search_paginates_filtered_results() {
         .expect("single-page list_triggers");
     assert_eq!(
         all,
-        single.triggers.as_brief().expect("brief"),
+        single.entries.as_brief().expect("brief"),
         "paginated traversal should equal single-page result"
     );
 }
@@ -1880,8 +1880,8 @@ async fn test_list_triggers_search_empty_is_same_as_no_filter() {
         .await
         .expect("whitespace");
 
-    assert_eq!(no_filter.triggers.as_brief(), empty.triggers.as_brief());
-    assert_eq!(no_filter.triggers.as_brief(), whitespace.triggers.as_brief());
+    assert_eq!(no_filter.entries.as_brief(), empty.entries.as_brief());
+    assert_eq!(no_filter.entries.as_brief(), whitespace.entries.as_brief());
 }
 
 #[tokio::test]
@@ -1897,9 +1897,9 @@ async fn test_list_triggers_arbitrary_database_identifier_is_bound_as_literal() 
             .await
             .unwrap_or_else(|e| panic!("expected bound-literal handling, got error: {e:?} for {bound:?}"));
         assert!(
-            result.triggers.as_brief().expect("brief").is_empty(),
+            result.entries.as_brief().expect("brief").is_empty(),
             "non-existent schema {bound:?} should return empty list, got {:?}",
-            result.triggers
+            result.entries
         );
     }
 }
@@ -1912,7 +1912,7 @@ async fn test_list_triggers_detailed_returns_keyed_object_with_all_fields() {
         .await
         .expect("list_triggers");
 
-    let entries = response.triggers.as_detailed().expect("detailed mode");
+    let entries = response.entries.as_detailed().expect("detailed mode");
     assert_eq!(entries.len(), 1, "expected one match, got {entries:?}");
     let entry = entries
         .get("posts_audit_after_insert")
@@ -1969,7 +1969,7 @@ async fn test_list_triggers_detailed_definition_uses_canonical_definer_form() {
         .await
         .expect("list_triggers");
 
-    let entries = response.triggers.as_detailed().expect("detailed mode");
+    let entries = response.entries.as_detailed().expect("detailed mode");
     let entry = entries.get("posts_audit_after_insert").expect("entry present");
     let definition = entry
         .get("definition")
@@ -2013,7 +2013,7 @@ async fn test_list_triggers_detailed_definition_matches_canonical_create_trigger
         .list_triggers(Some("app".into()), None, Some("posts_audit_after_insert".into()), true)
         .await
         .expect("list_triggers");
-    let entries = response.triggers.as_detailed().expect("detailed mode");
+    let entries = response.entries.as_detailed().expect("detailed mode");
     let definition = entries
         .get("posts_audit_after_insert")
         .and_then(|e| e.get("definition"))
@@ -2044,7 +2044,7 @@ async fn test_list_triggers_detailed_per_event_returns_single_element_events_arr
         .await
         .expect("list_triggers");
 
-    let entries = response.triggers.as_detailed().expect("detailed mode");
+    let entries = response.entries.as_detailed().expect("detailed mode");
     let cases = [
         ("posts_audit_after_delete", "DELETE"),
         ("posts_audit_after_insert", "INSERT"),
@@ -2073,7 +2073,7 @@ async fn test_list_triggers_detailed_session_context_fields_are_populated() {
         .await
         .expect("list_triggers");
 
-    let entries = response.triggers.as_detailed().expect("detailed mode");
+    let entries = response.entries.as_detailed().expect("detailed mode");
     assert!(!entries.is_empty(), "expected at least one audit trigger");
     for (name, entry) in entries {
         for field in [
@@ -2102,7 +2102,7 @@ async fn test_list_triggers_detailed_definition_round_trips_multiline_body() {
         .await
         .expect("list_triggers");
 
-    let entries = response.triggers.as_detailed().expect("detailed mode");
+    let entries = response.entries.as_detailed().expect("detailed mode");
     let definition = entries
         .get("users_audit_after_insert")
         .and_then(|e| e.get("definition"))
@@ -2133,7 +2133,7 @@ async fn test_list_triggers_brief_mode_wire_shape_unchanged() {
         .expect("list_triggers");
 
     let payload = serde_json::to_value(&response).expect("serialize");
-    let triggers = payload.get("triggers").expect("triggers field");
+    let triggers = payload.get("entries").expect("entries field");
     assert!(triggers.is_array(), "expected array, got {triggers:?}");
     assert!(
         triggers.as_array().unwrap().iter().all(Value::is_string),
@@ -2149,7 +2149,7 @@ async fn test_list_triggers_detailed_search_narrows_payload() {
         .await
         .expect("list_triggers");
 
-    let entries = response.triggers.as_detailed().expect("detailed mode");
+    let entries = response.entries.as_detailed().expect("detailed mode");
     for name in entries.keys() {
         assert!(
             name.contains("audit"),
@@ -2175,7 +2175,7 @@ async fn test_list_triggers_detailed_paginates() {
             .list_triggers(Some("app".into()), cursor.take(), Some("audit".into()), true)
             .await
             .expect("list_triggers paginated");
-        let entries = response.triggers.as_detailed().expect("detailed");
+        let entries = response.entries.as_detailed().expect("detailed");
         assert!(entries.len() <= 2, "page exceeds page_size: {}", entries.len());
         all.extend(entries.keys().cloned());
         cursor = response.next_cursor;
@@ -2189,7 +2189,7 @@ async fn test_list_triggers_detailed_paginates() {
         .await
         .expect("single-page list_triggers");
     let single_keys: Vec<String> = single
-        .triggers
+        .entries
         .as_detailed()
         .expect("detailed")
         .keys()
@@ -2217,7 +2217,7 @@ async fn test_list_triggers_detailed_sort_is_deterministic() {
             .await
             .expect("list_triggers");
         let keys: Vec<String> = response
-            .triggers
+            .entries
             .as_detailed()
             .expect("detailed")
             .keys()
@@ -2242,7 +2242,7 @@ async fn test_list_tables_detailed_triggers_use_canonical_definer_form() {
         .await
         .expect("list_tables");
 
-    let entries = response.tables.as_detailed().expect("detailed mode");
+    let entries = response.entries.as_detailed().expect("detailed mode");
     let posts = entries.get("posts").expect("posts table present");
     let triggers = posts.get("triggers").and_then(Value::as_array).expect("triggers array");
     assert!(!triggers.is_empty(), "posts has at least one seeded trigger");
@@ -2271,7 +2271,7 @@ async fn test_list_functions_returns_seeded_functions() {
         .await
         .expect("list_functions");
 
-    let names = response.functions.as_brief().expect("brief mode").to_vec();
+    let names = response.entries.as_brief().expect("brief mode").to_vec();
     assert!(
         names.contains(&"calc_total".to_string()),
         "expected calc_total, got {names:?}"
@@ -2290,7 +2290,7 @@ async fn test_list_functions_excludes_procedures() {
         .await
         .expect("list_functions");
 
-    let names = response.functions.as_brief().expect("brief mode").to_vec();
+    let names = response.entries.as_brief().expect("brief mode").to_vec();
     for proc_name in ["archive_user", "touch_post"] {
         assert!(
             !names.contains(&proc_name.to_string()),
@@ -2307,7 +2307,7 @@ async fn test_list_procedures_returns_seeded_procedures() {
         .await
         .expect("list_procedures");
 
-    let names = response.procedures.as_brief().expect("brief mode").to_vec();
+    let names = response.entries.as_brief().expect("brief mode").to_vec();
     assert!(
         names.contains(&"archive_user".to_string()),
         "expected seeded archive_user procedure, got {names:?}"
@@ -2326,7 +2326,7 @@ async fn test_list_procedures_excludes_functions() {
         .await
         .expect("list_procedures");
 
-    let names = response.procedures.as_brief().expect("brief mode").to_vec();
+    let names = response.entries.as_brief().expect("brief mode").to_vec();
     for func_name in ["calc_total", "double_it"] {
         assert!(
             !names.contains(&func_name.to_string()),
@@ -2343,9 +2343,9 @@ async fn test_list_routines_empty_for_empty_database() {
         .await
         .expect("list_functions");
     assert!(
-        functions.functions.is_empty(),
+        functions.entries.is_empty(),
         "analytics has no functions, got {:?}",
-        functions.functions
+        functions.entries
     );
 
     let procedures = handler
@@ -2353,9 +2353,9 @@ async fn test_list_routines_empty_for_empty_database() {
         .await
         .expect("list_procedures");
     assert!(
-        procedures.procedures.is_empty(),
+        procedures.entries.is_empty(),
         "analytics has no procedures, got {:?}",
-        procedures.procedures
+        procedures.entries
     );
 }
 
@@ -2366,7 +2366,7 @@ async fn brief_tables(handler: &MysqlHandler, search: Option<&str>) -> Vec<Strin
         .list_tables(Some("app".into()), None, search.map(str::to_owned), false)
         .await
         .expect("brief list_tables");
-    response.tables.into_brief().expect("brief mode")
+    response.entries.into_brief().expect("brief mode")
 }
 
 async fn detailed_entries(handler: &MysqlHandler, search: &str) -> indexmap::IndexMap<String, Value> {
@@ -2374,7 +2374,7 @@ async fn detailed_entries(handler: &MysqlHandler, search: &str) -> indexmap::Ind
         .list_tables(Some("app".into()), None, Some(search.into()), true)
         .await
         .expect("detailed list_tables");
-    response.tables.as_detailed().expect("detailed mode").clone()
+    response.entries.as_detailed().expect("detailed mode").clone()
 }
 
 #[tokio::test]
@@ -2446,7 +2446,7 @@ async fn list_tables_brief_pagination_under_search() {
             .list_tables(Some("app".into()), cursor.take(), Some("post".into()), false)
             .await
             .expect("paged brief search");
-        let page = response.tables.into_brief().expect("brief mode");
+        let page = response.entries.into_brief().expect("brief mode");
         assert!(page.len() <= 1, "page_size=1 caps to 1 per page");
         collected.extend(page);
         match response.next_cursor {
@@ -2656,7 +2656,7 @@ async fn list_tables_detailed_search_preserves_filter_across_pages() {
             .list_tables(Some("app".into()), cursor.take(), Some("post".into()), true)
             .await
             .expect("paged detailed search");
-        let page = response.tables.as_detailed().expect("detailed mode");
+        let page = response.entries.as_detailed().expect("detailed mode");
         assert!(page.len() <= 1, "page_size=1 caps to 1 per page");
         collected.extend(page.keys().cloned());
         match response.next_cursor {
@@ -2684,7 +2684,7 @@ async fn list_tables_detailed_excludes_system_schemas_passes_through_validation(
         .list_tables(Some("information_schema".into()), None, None, true)
         .await
         .expect("information_schema is identifier-valid");
-    let entries = response.tables.as_detailed().expect("detailed mode");
+    let entries = response.entries.as_detailed().expect("detailed mode");
     for (name, value) in entries {
         assert_eq!(
             value["schema"], "information_schema",
@@ -2738,7 +2738,7 @@ async fn test_list_functions_search_filter_returns_only_matches() {
         .await
         .expect("list_functions");
 
-    let names = response.functions.as_brief().expect("brief mode");
+    let names = response.entries.as_brief().expect("brief mode");
     let expected = [
         "calc_order_subtotal".to_string(),
         "calc_order_total".to_string(),
@@ -2758,7 +2758,7 @@ async fn test_list_functions_search_is_case_insensitive() {
         .list_functions(Some("app".into()), None, Some("order".into()), false)
         .await
         .expect("lower");
-    assert_eq!(upper.functions.as_brief(), lower.functions.as_brief());
+    assert_eq!(upper.entries.as_brief(), lower.entries.as_brief());
 }
 
 #[tokio::test]
@@ -2769,7 +2769,7 @@ async fn test_list_functions_search_no_match_returns_empty() {
         .await
         .expect("list_functions");
 
-    assert!(response.functions.as_brief().expect("brief").is_empty());
+    assert!(response.entries.as_brief().expect("brief").is_empty());
     assert!(response.next_cursor.is_none());
 }
 
@@ -2784,7 +2784,7 @@ async fn test_list_functions_search_supports_wildcard_semantics() {
         .list_functions(Some("app".into()), None, Some("%order%".into()), false)
         .await
         .expect("wildcard");
-    assert_eq!(plain.functions.as_brief(), with_wildcard.functions.as_brief());
+    assert_eq!(plain.entries.as_brief(), with_wildcard.entries.as_brief());
 }
 
 #[tokio::test]
@@ -2805,7 +2805,7 @@ async fn test_list_functions_search_sql_meta_payloads_are_safe() {
             .unwrap_or_else(|e| panic!("list_functions failed for payload {payload:?}: {e:?}"));
 
         assert!(
-            response.functions.as_brief().is_some(),
+            response.entries.as_brief().is_some(),
             "payload {payload:?} returned non-brief shape"
         );
     }
@@ -2821,7 +2821,7 @@ async fn test_list_functions_search_paginates_filtered_results() {
             .list_functions(Some("app".into()), cursor.take(), Some("order".into()), false)
             .await
             .expect("list_functions paginated");
-        let names = response.functions.as_brief().expect("brief").to_vec();
+        let names = response.entries.as_brief().expect("brief").to_vec();
         all.extend(names);
         cursor = response.next_cursor;
         if cursor.is_none() {
@@ -2835,7 +2835,7 @@ async fn test_list_functions_search_paginates_filtered_results() {
         .expect("single-page list_functions");
     assert_eq!(
         all,
-        single.functions.as_brief().expect("brief"),
+        single.entries.as_brief().expect("brief"),
         "paginated traversal should equal single-page result"
     );
 }
@@ -2848,17 +2848,17 @@ async fn test_list_functions_brief_mode_wire_shape_unchanged() {
         .await
         .expect("list_functions");
 
-    let names = response.functions.as_brief().expect("brief mode (Vec<String>)");
+    let names = response.entries.as_brief().expect("brief mode (Vec<String>)");
     assert!(
         names.iter().all(|s| !s.is_empty()),
         "brief mode names must be non-empty strings, got {names:?}"
     );
     // Must serialise as a flat array of strings (no object wrapping).
     let json = serde_json::to_value(&response).expect("serialize");
-    let functions = json.get("functions").expect("functions key");
+    let functions = json.get("entries").expect("entries key");
     assert!(
         functions.is_array(),
-        "brief mode `functions` must be a JSON array, got {functions:?}"
+        "brief mode `entries` must be a JSON array, got {functions:?}"
     );
 }
 
@@ -2870,7 +2870,7 @@ async fn test_list_functions_detailed_returns_keyed_object_with_all_fields() {
         .await
         .expect("list_functions");
 
-    let entries = response.functions.as_detailed().expect("detailed mode");
+    let entries = response.entries.as_detailed().expect("detailed mode");
     // Search "calc_order_total" matches both `calc_order_total` and
     // `recalc_order_total_v2` because the latter contains the former as a
     // substring. Field-shape assertions only need the calc_order_total entry.
@@ -2927,7 +2927,7 @@ async fn test_list_functions_detailed_definition_uses_canonical_definer_form() {
         .await
         .expect("list_functions");
 
-    let entries = response.functions.as_detailed().expect("detailed");
+    let entries = response.entries.as_detailed().expect("detailed");
     let definition = entries
         .get("calc_order_total")
         .and_then(|e| e.get("definition"))
@@ -2975,7 +2975,7 @@ async fn test_list_functions_detailed_two_field_safety_split() {
         .await
         .expect("list_functions");
     let entry = resp
-        .functions
+        .entries
         .as_detailed()
         .expect("detailed")
         .get("recalc_order_total_v2")
@@ -2994,7 +2994,7 @@ async fn test_list_functions_detailed_two_field_safety_split() {
         .await
         .expect("list_functions");
     let entry = resp
-        .functions
+        .entries
         .as_detailed()
         .expect("detailed")
         .get("current_pricing_version")
@@ -3010,7 +3010,7 @@ async fn test_list_functions_detailed_two_field_safety_split() {
         .await
         .expect("list_functions");
     let entry = resp
-        .functions
+        .entries
         .as_detailed()
         .expect("detailed")
         .get("double_it")
@@ -3029,7 +3029,7 @@ async fn test_list_functions_detailed_arguments_field_round_trips_dtd() {
         .await
         .expect("list_functions");
     let entry = resp
-        .functions
+        .entries
         .as_detailed()
         .expect("detailed")
         .get("calc_order_subtotal")
@@ -3064,7 +3064,7 @@ async fn test_list_functions_detailed_arguments_field_round_trips_dtd() {
         .await
         .expect("list_functions");
     let entry = resp
-        .functions
+        .entries
         .as_detailed()
         .expect("detailed")
         .get("current_pricing_version")
@@ -3088,7 +3088,7 @@ async fn test_list_functions_detailed_description_null_coercion() {
         .await
         .expect("list_functions");
     let entry = resp
-        .functions
+        .entries
         .as_detailed()
         .expect("detailed")
         .get("double_it")
@@ -3106,7 +3106,7 @@ async fn test_list_functions_detailed_description_null_coercion() {
         .await
         .expect("list_functions");
     let entry = resp
-        .functions
+        .entries
         .as_detailed()
         .expect("detailed")
         .get("calc_order_total")
@@ -3126,7 +3126,7 @@ async fn test_list_functions_detailed_session_context_fields_are_populated() {
         .await
         .expect("list_functions");
 
-    let entries = response.functions.as_detailed().expect("detailed");
+    let entries = response.entries.as_detailed().expect("detailed");
     assert!(!entries.is_empty(), "expected order matches");
     for (name, value) in entries {
         for key in [
@@ -3153,7 +3153,7 @@ async fn test_list_functions_detailed_definition_round_trips_multiline_body() {
         .expect("list_functions");
 
     let definition = response
-        .functions
+        .entries
         .as_detailed()
         .expect("detailed")
         .get("format_audit_note")
@@ -3178,7 +3178,7 @@ async fn test_list_functions_detailed_search_narrows_payload() {
         .expect("list_functions");
 
     let keys: Vec<String> = response
-        .functions
+        .entries
         .as_detailed()
         .expect("detailed")
         .keys()
@@ -3210,7 +3210,7 @@ async fn test_list_functions_detailed_paginates() {
             .list_functions(Some("app".into()), cursor.take(), None, true)
             .await
             .expect("list_functions paginated");
-        let entries = response.functions.as_detailed().expect("detailed");
+        let entries = response.entries.as_detailed().expect("detailed");
         assert!(entries.len() <= 2, "page exceeded page_size: {entries:?}");
         all_keys.extend(entries.keys().cloned());
         cursor = response.next_cursor;
@@ -3224,7 +3224,7 @@ async fn test_list_functions_detailed_paginates() {
         .await
         .expect("single-page list_functions");
     let single_keys: Vec<String> = single
-        .functions
+        .entries
         .as_detailed()
         .expect("detailed")
         .keys()
@@ -3243,7 +3243,7 @@ async fn test_list_functions_excludes_loadable_udfs_and_procedures() {
         .await
         .expect("list_functions");
 
-    let names = response.functions.as_brief().expect("brief").to_vec();
+    let names = response.entries.as_brief().expect("brief").to_vec();
     for proc_name in ["archive_user", "touch_post"] {
         assert!(
             !names.contains(&proc_name.to_string()),
@@ -3265,7 +3265,7 @@ async fn test_list_triggers_and_tables_definer_form_unchanged_after_extraction()
         .await
         .expect("list_triggers detailed");
     let trigger_def = triggers
-        .triggers
+        .entries
         .as_detailed()
         .expect("detailed")
         .get("posts_audit_after_insert")
@@ -3286,7 +3286,7 @@ async fn test_list_triggers_and_tables_definer_form_unchanged_after_extraction()
         .await
         .expect("list_tables detailed");
     let posts = tables
-        .tables
+        .entries
         .as_detailed()
         .expect("detailed")
         .get("posts")
@@ -3314,7 +3314,7 @@ async fn brief_procedures(handler: &MysqlHandler, search: Option<&str>) -> Vec<S
         .list_procedures(Some("app".into()), None, search.map(str::to_owned), false)
         .await
         .expect("brief list_procedures");
-    response.procedures.into_brief().expect("brief mode")
+    response.entries.into_brief().expect("brief mode")
 }
 
 async fn detailed_procedure_entries(handler: &MysqlHandler, search: &str) -> indexmap::IndexMap<String, Value> {
@@ -3322,7 +3322,7 @@ async fn detailed_procedure_entries(handler: &MysqlHandler, search: &str) -> ind
         .list_procedures(Some("app".into()), None, Some(search.into()), true)
         .await
         .expect("detailed list_procedures");
-    response.procedures.as_detailed().expect("detailed mode").clone()
+    response.entries.as_detailed().expect("detailed mode").clone()
 }
 
 #[tokio::test]
@@ -3393,16 +3393,16 @@ async fn test_list_procedures_brief_wire_shape_unchanged() {
         .await
         .expect("list_procedures");
 
-    let names = response.procedures.as_brief().expect("brief mode (Vec<String>)");
+    let names = response.entries.as_brief().expect("brief mode (Vec<String>)");
     assert!(
         names.iter().all(|s| !s.is_empty()),
         "brief mode names must be non-empty strings, got {names:?}"
     );
     let json = serde_json::to_value(&response).expect("serialize");
-    let procedures = json.get("procedures").expect("procedures key");
+    let procedures = json.get("entries").expect("entries key");
     assert!(
         procedures.is_array(),
-        "brief mode `procedures` must be a JSON array, got {procedures:?}"
+        "brief mode `entries` must be a JSON array, got {procedures:?}"
     );
 }
 
@@ -3685,7 +3685,7 @@ async fn brief_views(handler: &MysqlHandler, search: Option<&str>) -> Vec<String
         .list_views(Some("app".into()), None, search.map(str::to_owned), false)
         .await
         .expect("brief list_views");
-    response.views.into_brief().expect("brief mode")
+    response.entries.into_brief().expect("brief mode")
 }
 
 async fn detailed_view_entries(handler: &MysqlHandler, search: &str) -> indexmap::IndexMap<String, Value> {
@@ -3693,7 +3693,7 @@ async fn detailed_view_entries(handler: &MysqlHandler, search: &str) -> indexmap
         .list_views(Some("app".into()), None, Some(search.into()), true)
         .await
         .expect("detailed list_views");
-    response.views.as_detailed().expect("detailed mode").clone()
+    response.entries.as_detailed().expect("detailed mode").clone()
 }
 
 #[tokio::test]
@@ -3759,16 +3759,16 @@ async fn test_list_views_brief_wire_shape_unchanged() {
         .await
         .expect("list_views");
 
-    let names = response.views.as_brief().expect("brief mode (Vec<String>)");
+    let names = response.entries.as_brief().expect("brief mode (Vec<String>)");
     assert!(
         names.iter().all(|s| !s.is_empty()),
         "brief mode names must be non-empty strings, got {names:?}"
     );
     let json = serde_json::to_value(&response).expect("serialize");
-    let views = json.get("views").expect("views key");
+    let views = json.get("entries").expect("entries key");
     assert!(
         views.is_array(),
-        "brief mode `views` must be a JSON array, got {views:?}"
+        "brief mode `entries` must be a JSON array, got {views:?}"
     );
 }
 

--- a/tests/functional/postgres.rs
+++ b/tests/functional/postgres.rs
@@ -178,7 +178,7 @@ async fn test_lists_tables() {
         .list_tables(Some("app".into()), None, None, false)
         .await
         .unwrap();
-    let tables = response.tables.as_brief().expect("brief mode").to_vec();
+    let tables = response.entries.as_brief().expect("brief mode").to_vec();
 
     for expected in ["users", "posts", "tags", "post_tags"] {
         assert!(
@@ -304,7 +304,7 @@ async fn test_lists_tables_cross_database() {
         .list_tables(Some("analytics".into()), None, None, false)
         .await
         .unwrap();
-    let tables = response.tables.as_brief().expect("brief mode").to_vec();
+    let tables = response.entries.as_brief().expect("brief mode").to_vec();
 
     assert!(
         tables.iter().any(|t| t == "events"),
@@ -381,7 +381,7 @@ async fn test_uses_default_pool_for_matching_database() {
         .list_tables(Some("app".into()), None, None, false)
         .await
         .unwrap();
-    let tables = response.tables.as_brief().expect("brief mode").to_vec();
+    let tables = response.entries.as_brief().expect("brief mode").to_vec();
 
     assert!(
         tables.iter().any(|t| t == "users"),
@@ -465,7 +465,7 @@ async fn test_drop_table_success() {
         .list_tables(Some("app".into()), None, None, false)
         .await
         .unwrap();
-    let tables = response.tables.as_brief().expect("brief mode").to_vec();
+    let tables = response.entries.as_brief().expect("brief mode").to_vec();
     assert!(
         !tables.iter().any(|t| t == "drop_test_simple"),
         "Table should not exist after drop"
@@ -668,7 +668,7 @@ async fn test_list_tables_empty_database_falls_back_to_default() {
         .list_tables(Some(String::new()), None, None, false)
         .await
         .expect("empty db should default to --db-name");
-    let names = response.tables.as_brief().expect("brief mode");
+    let names = response.entries.as_brief().expect("brief mode");
     assert!(
         names.iter().any(|t| t == "users"),
         "expected default-database tables, got {names:?}"
@@ -683,7 +683,7 @@ async fn test_list_tables_omitted_database_falls_back_to_default() {
         .list_tables(None, None, None, false)
         .await
         .expect("omitted db should default to --db-name");
-    let names = response.tables.as_brief().expect("brief mode");
+    let names = response.entries.as_brief().expect("brief mode");
     assert!(
         names.iter().any(|t| t == "users"),
         "expected default-database tables, got {names:?}"
@@ -1040,7 +1040,7 @@ async fn collect_all_paged(handler: &PostgresHandler) -> Vec<String> {
             .list_tables(Some(PG_DB.into()), cursor.take(), None, false)
             .await
             .expect("list page");
-        all.extend(response.tables.as_brief().expect("brief mode").iter().cloned());
+        all.extend(response.entries.as_brief().expect("brief mode").iter().cloned());
         match response.next_cursor {
             Some(c) => cursor = Some(c),
             None => break,
@@ -1061,7 +1061,7 @@ async fn test_list_tables_pagination_traverses_pages() {
         .await
         .expect("single page");
 
-    let single_page_names = single_page.tables.as_brief().expect("brief mode").to_vec();
+    let single_page_names = single_page.entries.as_brief().expect("brief mode").to_vec();
     assert_eq!(
         collected, single_page_names,
         "paged traversal must yield identical results (and ordering) to a single full page"
@@ -1090,7 +1090,7 @@ async fn test_list_tables_pagination_boundary_page_size_equals_total() {
         .list_tables(Some(PG_DB.into()), None, None, false)
         .await
         .expect("discover total")
-        .tables
+        .entries
         .len();
     let page_size = u16::try_from(total).expect("seed total fits in u16");
 
@@ -1100,7 +1100,7 @@ async fn test_list_tables_pagination_boundary_page_size_equals_total() {
         .await
         .unwrap();
     assert_eq!(
-        response.tables.len(),
+        response.entries.len(),
         total,
         "page_size equal to total must return everything on one page"
     );
@@ -1121,9 +1121,9 @@ async fn test_list_tables_pagination_off_the_end_cursor_returns_empty_page() {
         .unwrap();
 
     assert!(
-        response.tables.is_empty(),
+        response.entries.is_empty(),
         "off-the-end cursor must return empty tables, got {:?}",
-        response.tables
+        response.entries
     );
     assert!(response.next_cursor.is_none(), "off-the-end must not emit nextCursor");
 }
@@ -1135,7 +1135,7 @@ async fn test_list_tables_respects_configured_page_size() {
         .list_tables(Some(PG_DB.into()), None, None, false)
         .await
         .expect("first page");
-    assert_eq!(first.tables.len(), 2, "configured page_size=2 must cap page 1");
+    assert_eq!(first.entries.len(), 2, "configured page_size=2 must cap page 1");
     assert!(
         first.next_cursor.is_some(),
         "page 1 must emit nextCursor when total > page_size"
@@ -1149,7 +1149,7 @@ async fn test_list_tables_respects_configured_page_size_minimum() {
         .list_tables(Some(PG_DB.into()), None, None, false)
         .await
         .expect("first page");
-    assert_eq!(first.tables.len(), 1, "page_size=1 must return one table per page");
+    assert_eq!(first.entries.len(), 1, "page_size=1 must return one table per page");
     assert!(first.next_cursor.is_some(), "page 1 must emit nextCursor");
 }
 
@@ -1463,7 +1463,7 @@ async fn test_list_views_returns_seeded_views() {
         .await
         .expect("list_views");
 
-    let names = response.views.as_brief().expect("brief mode");
+    let names = response.entries.as_brief().expect("brief mode");
     assert!(
         names.contains(&"active_users".to_string()),
         "expected seeded active_users view, got {names:?}"
@@ -1482,7 +1482,7 @@ async fn test_list_views_excludes_base_tables() {
         .await
         .expect("list_views");
 
-    let names = response.views.as_brief().expect("brief mode");
+    let names = response.entries.as_brief().expect("brief mode");
     for table in ["users", "posts", "tags", "post_tags", "temporal"] {
         assert!(
             !names.contains(&table.to_string()),
@@ -1500,9 +1500,9 @@ async fn test_list_views_empty_for_view_less_database() {
         .expect("list_views");
 
     assert!(
-        response.views.as_brief().expect("brief").is_empty(),
+        response.entries.as_brief().expect("brief").is_empty(),
         "analytics has no views, got {:?}",
-        response.views
+        response.entries
     );
 }
 
@@ -1518,7 +1518,7 @@ async fn test_list_views_pagination_traverses_pages() {
             .list_views(Some("app".into()), cursor.take(), None, false)
             .await
             .expect("paged list_views");
-        all.extend(response.views.as_brief().expect("brief").iter().cloned());
+        all.extend(response.entries.as_brief().expect("brief").iter().cloned());
         match response.next_cursor {
             Some(c) => cursor = Some(c),
             None => break,
@@ -1530,7 +1530,7 @@ async fn test_list_views_pagination_traverses_pages() {
         .await
         .expect("single-page list_views");
 
-    let single_names = single.views.as_brief().expect("brief").to_vec();
+    let single_names = single.entries.as_brief().expect("brief").to_vec();
     assert_eq!(all, single_names, "paginated traversal should equal single page");
 }
 
@@ -1543,7 +1543,7 @@ async fn test_list_views_works_in_read_only_mode() {
         .expect("list_views in read-only mode");
 
     assert!(
-        !response.views.as_brief().expect("brief").is_empty(),
+        !response.entries.as_brief().expect("brief").is_empty(),
         "read-only mode must still allow listViews"
     );
 }
@@ -1555,7 +1555,7 @@ async fn list_views_brief(handler: &PostgresHandler, search: Option<&str>) -> Ve
         .list_views(Some("app".into()), None, search.map(str::to_owned), false)
         .await
         .expect("list_views");
-    response.views.as_brief().expect("brief mode").to_vec()
+    response.entries.as_brief().expect("brief mode").to_vec()
 }
 
 async fn list_views_detailed(handler: &PostgresHandler, search: Option<&str>) -> IndexMap<String, Value> {
@@ -1563,7 +1563,7 @@ async fn list_views_detailed(handler: &PostgresHandler, search: Option<&str>) ->
         .list_views(Some("app".into()), None, search.map(str::to_owned), true)
         .await
         .expect("list_views detailed");
-    response.views.as_detailed().expect("detailed mode").clone()
+    response.entries.as_detailed().expect("detailed mode").clone()
 }
 
 #[tokio::test]
@@ -1619,7 +1619,7 @@ async fn test_list_views_search_sql_meta_payloads_are_safe() {
             .await
             .unwrap_or_else(|e| panic!("search={payload:?} must not raise SQL error: {e:?}"));
         assert!(
-            response.views.as_brief().is_some(),
+            response.entries.as_brief().is_some(),
             "search={payload:?} must return brief mode"
         );
     }
@@ -1637,7 +1637,7 @@ async fn test_list_views_search_paginates_filtered_results() {
             .list_views(Some("app".into()), cursor.take(), Some("active".into()), false)
             .await
             .expect("paged list_views");
-        all.extend(response.views.as_brief().expect("brief").to_vec());
+        all.extend(response.entries.as_brief().expect("brief").to_vec());
         match response.next_cursor {
             Some(c) => cursor = Some(c),
             None => break,
@@ -1648,7 +1648,7 @@ async fn test_list_views_search_paginates_filtered_results() {
         .list_views(Some("app".into()), cursor.take(), Some("active".into()), false)
         .await
         .expect("single-page list_views");
-    let single_names = single.views.as_brief().expect("brief").to_vec();
+    let single_names = single.entries.as_brief().expect("brief").to_vec();
     assert_eq!(all, single_names, "paginated filter must equal single page");
 }
 
@@ -1792,7 +1792,7 @@ async fn test_list_views_detailed_paginates() {
             .expect("paged detailed list_views");
         all.extend(
             response
-                .views
+                .entries
                 .as_detailed()
                 .expect("detailed")
                 .keys()
@@ -1818,7 +1818,7 @@ async fn test_list_views_brief_returns_bare_strings() {
         .await
         .expect("list_views brief");
     let serialized = serde_json::to_value(&response).expect("serialize");
-    let views = serialized.get("views").expect("views field");
+    let views = serialized.get("entries").expect("entries field");
     assert!(views.is_array(), "brief mode views must serialise as bare-string array");
     for entry in views.as_array().expect("array") {
         assert!(
@@ -1879,7 +1879,7 @@ async fn test_list_triggers_returns_seeded_triggers() {
         .await
         .expect("list_triggers");
 
-    let names = response.triggers.as_brief().expect("brief mode");
+    let names = response.entries.as_brief().expect("brief mode");
     assert!(
         names.contains(&"users_before_insert".to_string()),
         "expected seeded users_before_insert trigger, got {names:?}"
@@ -1898,7 +1898,7 @@ async fn test_list_triggers_excludes_internal_triggers() {
         .await
         .expect("list_triggers");
 
-    let names = response.triggers.as_brief().expect("brief mode");
+    let names = response.entries.as_brief().expect("brief mode");
     // RI_ConstraintTrigger_* are the internal triggers backing FK constraints.
     for trg in names {
         assert!(
@@ -1916,7 +1916,7 @@ async fn test_list_triggers_empty_for_trigger_less_database() {
         .await
         .expect("list_triggers");
 
-    let names = response.triggers.as_brief().expect("brief mode");
+    let names = response.entries.as_brief().expect("brief mode");
     assert!(names.is_empty(), "analytics has no user triggers, got {names:?}");
 }
 
@@ -1929,7 +1929,7 @@ async fn test_list_triggers_works_in_read_only_mode() {
         .expect("list_triggers in read-only mode");
 
     assert!(
-        !response.triggers.is_empty(),
+        !response.entries.is_empty(),
         "read-only mode must still allow listTriggers"
     );
 }
@@ -1942,7 +1942,7 @@ async fn test_list_triggers_search_filter_returns_only_matches() {
         .await
         .expect("list_triggers");
 
-    let names = response.triggers.as_brief().expect("brief mode");
+    let names = response.entries.as_brief().expect("brief mode");
     assert_eq!(names, &["orders_audit_trigger".to_string()], "got {names:?}");
 }
 
@@ -1957,7 +1957,7 @@ async fn test_list_triggers_search_is_case_insensitive() {
         .list_triggers(Some("app".into()), None, Some("audit".into()), false)
         .await
         .expect("lower");
-    assert_eq!(upper.triggers.as_brief(), lower.triggers.as_brief());
+    assert_eq!(upper.entries.as_brief(), lower.entries.as_brief());
 }
 
 #[tokio::test]
@@ -1968,7 +1968,7 @@ async fn test_list_triggers_search_no_match_returns_empty() {
         .await
         .expect("list_triggers");
 
-    assert!(response.triggers.as_brief().expect("brief").is_empty());
+    assert!(response.entries.as_brief().expect("brief").is_empty());
     assert!(response.next_cursor.is_none());
 }
 
@@ -1986,7 +1986,7 @@ async fn test_list_triggers_search_supports_wildcard_semantics() {
         .list_triggers(Some("app".into()), None, Some("%audit%".into()), false)
         .await
         .expect("wildcard");
-    assert_eq!(plain.triggers.as_brief(), with_wildcard.triggers.as_brief());
+    assert_eq!(plain.entries.as_brief(), with_wildcard.entries.as_brief());
 }
 
 #[tokio::test]
@@ -1999,7 +1999,7 @@ async fn test_list_triggers_search_sql_meta_payloads_are_safe() {
             .unwrap_or_else(|e| panic!("list_triggers failed for payload {payload:?}: {e:?}"));
 
         assert!(
-            response.triggers.as_brief().is_some(),
+            response.entries.as_brief().is_some(),
             "payload {payload:?} returned non-brief shape"
         );
     }
@@ -2015,7 +2015,7 @@ async fn test_list_triggers_search_paginates_filtered_results() {
             .list_triggers(Some("app".into()), cursor.take(), Some("before".into()), false)
             .await
             .expect("list_triggers paginated");
-        let names = response.triggers.as_brief().expect("brief").to_vec();
+        let names = response.entries.as_brief().expect("brief").to_vec();
         all.extend(names);
         cursor = response.next_cursor;
         if cursor.is_none() {
@@ -2029,7 +2029,7 @@ async fn test_list_triggers_search_paginates_filtered_results() {
         .expect("single-page list_triggers");
     assert_eq!(
         all,
-        single.triggers.as_brief().expect("brief"),
+        single.entries.as_brief().expect("brief"),
         "paginated traversal should equal single-page result"
     );
 }
@@ -2050,8 +2050,8 @@ async fn test_list_triggers_search_empty_is_same_as_no_filter() {
         .await
         .expect("whitespace");
 
-    assert_eq!(no_filter.triggers.as_brief(), empty.triggers.as_brief());
-    assert_eq!(no_filter.triggers.as_brief(), whitespace.triggers.as_brief());
+    assert_eq!(no_filter.entries.as_brief(), empty.entries.as_brief());
+    assert_eq!(no_filter.entries.as_brief(), whitespace.entries.as_brief());
 }
 
 #[tokio::test]
@@ -2062,7 +2062,7 @@ async fn test_list_triggers_brief_without_parameters_returns_bare_strings() {
         .await
         .expect("list_triggers");
     let payload = serde_json::to_value(&response).expect("serialize");
-    let triggers = payload.get("triggers").expect("triggers field");
+    let triggers = payload.get("entries").expect("entries field");
     assert!(triggers.is_array(), "expected array, got {triggers:?}");
     assert!(
         triggers.as_array().unwrap().iter().all(serde_json::Value::is_string),
@@ -2078,7 +2078,7 @@ async fn test_list_triggers_detailed_returns_full_metadata_for_orders_audit() {
         .await
         .expect("list_triggers");
 
-    let map = response.triggers.as_detailed().expect("detailed mode");
+    let map = response.entries.as_detailed().expect("detailed mode");
     let entry = map.get("orders_audit_trigger").expect("orders_audit_trigger entry");
     assert_eq!(entry["schema"], serde_json::json!("public"));
     assert_eq!(entry["table"], serde_json::json!("orders"));
@@ -2104,7 +2104,7 @@ async fn test_list_triggers_detailed_disabled_status() {
         .list_triggers(Some("app".into()), None, Some("block_inventory_delete".into()), true)
         .await
         .expect("list_triggers");
-    let map = response.triggers.as_detailed().expect("detailed mode");
+    let map = response.entries.as_detailed().expect("detailed mode");
     let entry = map.get("block_inventory_delete").expect("entry");
     assert_eq!(entry["status"], serde_json::json!("DISABLED"));
     assert_eq!(entry["timing"], serde_json::json!("BEFORE"));
@@ -2119,7 +2119,7 @@ async fn test_list_triggers_detailed_partitioned_parent() {
         .list_triggers(Some("app".into()), None, Some("logs_redact_before_insert".into()), true)
         .await
         .expect("list_triggers");
-    let map = response.triggers.as_detailed().expect("detailed mode");
+    let map = response.entries.as_detailed().expect("detailed mode");
     let entry = map.get("logs_redact_before_insert").expect("entry");
     assert_eq!(entry["table"], serde_json::json!("logs"));
     assert_eq!(entry["timing"], serde_json::json!("BEFORE"));
@@ -2135,7 +2135,7 @@ async fn test_list_triggers_detailed_with_search_only_includes_filtered() {
         .await
         .expect("list_triggers");
 
-    let map = response.triggers.as_detailed().expect("detailed");
+    let map = response.entries.as_detailed().expect("detailed");
     assert!(map.contains_key("orders_audit_trigger"));
     assert!(!map.contains_key("block_inventory_delete"));
     assert!(!map.contains_key("logs_redact_before_insert"));
@@ -2152,7 +2152,7 @@ async fn test_list_triggers_detailed_paginates() {
             .await
             .expect("list_triggers paginated");
 
-        let map = response.triggers.as_detailed().expect("detailed");
+        let map = response.entries.as_detailed().expect("detailed");
         assert!(map.len() <= 1, "page exceeded page_size=1: {} entries", map.len());
         all.extend(map.keys().cloned());
         cursor = response.next_cursor;
@@ -2167,7 +2167,7 @@ async fn test_list_triggers_detailed_paginates() {
         .expect("single-page brief");
     assert_eq!(
         all,
-        single.triggers.as_brief().expect("brief").to_vec(),
+        single.entries.as_brief().expect("brief").to_vec(),
         "paginated detailed traversal must walk every trigger in brief order"
     );
 }
@@ -2179,7 +2179,7 @@ async fn test_list_triggers_detailed_internal_triggers_excluded() {
         .list_triggers(Some("app".into()), None, None, true)
         .await
         .expect("list_triggers");
-    let map = response.triggers.as_detailed().expect("detailed");
+    let map = response.entries.as_detailed().expect("detailed");
     for name in map.keys() {
         assert!(
             !name.starts_with("RI_ConstraintTrigger"),
@@ -2196,7 +2196,7 @@ async fn test_list_functions_returns_seeded_functions() {
         .await
         .expect("list_functions");
 
-    let names = response.functions.as_brief().expect("brief mode").to_vec();
+    let names = response.entries.as_brief().expect("brief mode").to_vec();
     assert!(
         names.contains(&"calc_total".to_string()),
         "expected calc_total, got {names:?}"
@@ -2215,7 +2215,7 @@ async fn test_list_functions_excludes_procedures() {
         .await
         .expect("list_functions");
 
-    let names = response.functions.as_brief().expect("brief mode").to_vec();
+    let names = response.entries.as_brief().expect("brief mode").to_vec();
     for proc_name in ["archive_user", "touch_post"] {
         assert!(
             !names.contains(&proc_name.to_string()),
@@ -2233,7 +2233,7 @@ async fn list_functions_brief(handler: &PostgresHandler, search: Option<&str>) -
         .list_functions(Some("app".into()), None, search.map(str::to_string), false)
         .await
         .expect("list_functions");
-    response.functions.as_brief().expect("brief mode").to_vec()
+    response.entries.as_brief().expect("brief mode").to_vec()
 }
 
 async fn list_functions_detailed(
@@ -2244,7 +2244,7 @@ async fn list_functions_detailed(
         .list_functions(Some("app".into()), None, Some(search.into()), true)
         .await
         .expect("list_functions detailed");
-    response.functions.as_detailed().expect("detailed mode").clone()
+    response.entries.as_detailed().expect("detailed mode").clone()
 }
 
 #[tokio::test]
@@ -2277,7 +2277,7 @@ async fn test_list_functions_search_no_match_returns_empty() {
         .list_functions(Some("app".into()), None, Some("nonexistent_function_xyz".into()), false)
         .await
         .expect("list_functions");
-    assert!(response.functions.as_brief().expect("brief").is_empty());
+    assert!(response.entries.as_brief().expect("brief").is_empty());
     assert!(response.next_cursor.is_none());
 }
 
@@ -2308,7 +2308,7 @@ async fn test_list_functions_search_sql_meta_payloads_are_safe() {
             .await
             .unwrap_or_else(|e| panic!("list_functions failed for payload {payload:?}: {e:?}"));
         assert!(
-            response.functions.as_brief().is_some(),
+            response.entries.as_brief().is_some(),
             "payload {payload:?} returned non-brief shape"
         );
     }
@@ -2324,7 +2324,7 @@ async fn test_list_functions_search_paginates_filtered_results() {
             .list_functions(Some("app".into()), cursor.take(), Some("calc_order".into()), false)
             .await
             .expect("list_functions paged");
-        all.extend(response.functions.as_brief().expect("brief").to_vec());
+        all.extend(response.entries.as_brief().expect("brief").to_vec());
         cursor = response.next_cursor;
         if cursor.is_none() {
             break;
@@ -2460,7 +2460,7 @@ async fn test_list_functions_brief_returns_bare_strings() {
         .await
         .expect("list_functions");
     let value = serde_json::to_value(&response).expect("serialise");
-    let arr = value["functions"].as_array().expect("functions is array in brief mode");
+    let arr = value["entries"].as_array().expect("entries is array in brief mode");
     for entry in arr {
         assert!(entry.is_string(), "expected string entry, got {entry:?}");
     }
@@ -2495,7 +2495,7 @@ async fn test_list_functions_detailed_paginates() {
             .list_functions(Some("app".into()), cursor.take(), Some("calc_order".into()), true)
             .await
             .expect("list_functions detailed paged");
-        let page = response.functions.as_detailed().expect("detailed").clone();
+        let page = response.entries.as_detailed().expect("detailed").clone();
         assert!(page.len() <= 1, "page size 1 must not exceed 1 entry");
         all_keys.extend(page.into_keys());
         cursor = response.next_cursor;
@@ -2518,7 +2518,7 @@ async fn test_list_procedures_returns_seeded_procedures() {
         .await
         .expect("list_procedures");
 
-    let names = response.procedures.as_brief().expect("brief mode").to_vec();
+    let names = response.entries.as_brief().expect("brief mode").to_vec();
     assert!(
         names.contains(&"archive_user".to_string()),
         "expected seeded archive_user procedure, got {names:?}"
@@ -2537,7 +2537,7 @@ async fn test_list_procedures_excludes_functions() {
         .await
         .expect("list_procedures");
 
-    let names = response.procedures.as_brief().expect("brief mode").to_vec();
+    let names = response.entries.as_brief().expect("brief mode").to_vec();
     for func_name in ["calc_total", "double_it"] {
         assert!(
             !names.contains(&func_name.to_string()),
@@ -2555,7 +2555,7 @@ async fn list_procedures_brief(handler: &PostgresHandler, search: Option<&str>) 
         .list_procedures(Some("app".into()), None, search.map(str::to_string), false)
         .await
         .expect("list_procedures");
-    response.procedures.as_brief().expect("brief mode").to_vec()
+    response.entries.as_brief().expect("brief mode").to_vec()
 }
 
 async fn list_procedures_detailed(
@@ -2566,7 +2566,7 @@ async fn list_procedures_detailed(
         .list_procedures(Some("app".into()), None, Some(search.into()), true)
         .await
         .expect("list_procedures detailed");
-    response.procedures.as_detailed().expect("detailed mode").clone()
+    response.entries.as_detailed().expect("detailed mode").clone()
 }
 
 #[tokio::test]
@@ -2604,7 +2604,7 @@ async fn test_list_procedures_search_no_match_returns_empty() {
         )
         .await
         .expect("list_procedures");
-    assert!(response.procedures.as_brief().expect("brief").is_empty());
+    assert!(response.entries.as_brief().expect("brief").is_empty());
     assert!(response.next_cursor.is_none());
 }
 
@@ -2633,7 +2633,7 @@ async fn test_list_procedures_search_sql_meta_payloads_are_safe() {
             .await
             .unwrap_or_else(|e| panic!("list_procedures failed for payload {payload:?}: {e:?}"));
         assert!(
-            response.procedures.as_brief().is_some(),
+            response.entries.as_brief().is_some(),
             "payload {payload:?} returned non-brief shape"
         );
     }
@@ -2649,7 +2649,7 @@ async fn test_list_procedures_search_paginates_filtered_results() {
             .list_procedures(Some("app".into()), cursor.take(), Some("archive_order".into()), false)
             .await
             .expect("list_procedures paged");
-        all.extend(response.procedures.as_brief().expect("brief").to_vec());
+        all.extend(response.entries.as_brief().expect("brief").to_vec());
         cursor = response.next_cursor;
         if cursor.is_none() {
             break;
@@ -2792,9 +2792,7 @@ async fn test_list_procedures_brief_returns_bare_strings() {
         .await
         .expect("list_procedures");
     let value = serde_json::to_value(&response).expect("serialise");
-    let arr = value["procedures"]
-        .as_array()
-        .expect("procedures is array in brief mode");
+    let arr = value["entries"].as_array().expect("entries is array in brief mode");
     for entry in arr {
         assert!(entry.is_string(), "expected string entry, got {entry:?}");
     }
@@ -2831,7 +2829,7 @@ async fn test_list_procedures_detailed_paginates() {
             .list_procedures(Some("app".into()), cursor.take(), Some("archive_order".into()), true)
             .await
             .expect("list_procedures detailed paged");
-        let page = response.procedures.as_detailed().expect("detailed").clone();
+        let page = response.entries.as_detailed().expect("detailed").clone();
         assert!(page.len() <= 1, "page size 1 must not exceed 1 entry");
         all_keys.extend(page.into_keys());
         cursor = response.next_cursor;
@@ -2879,7 +2877,7 @@ async fn test_list_materialized_views_returns_seeded_matviews() {
         .await
         .expect("list_materialized_views");
 
-    let names = response.materialized_views.as_brief().expect("brief mode");
+    let names = response.entries.as_brief().expect("brief mode");
     assert!(
         names.contains(&"mv_recent_orders".to_string()),
         "expected seeded mv_recent_orders matview, got {names:?}"
@@ -2898,7 +2896,7 @@ async fn test_list_views_excludes_materialized_views() {
         .await
         .expect("list_views");
 
-    let names = response.views.as_brief().expect("brief mode");
+    let names = response.entries.as_brief().expect("brief mode");
     for matview in ["mv_recent_orders", "mv_user_cohort"] {
         assert!(
             !names.contains(&matview.to_string()),
@@ -2915,7 +2913,7 @@ async fn test_list_materialized_views_excludes_regular_views() {
         .await
         .expect("list_materialized_views");
 
-    let names = response.materialized_views.as_brief().expect("brief mode");
+    let names = response.entries.as_brief().expect("brief mode");
     for view in ["active_users", "published_posts"] {
         assert!(
             !names.contains(&view.to_string()),
@@ -2933,9 +2931,9 @@ async fn test_list_materialized_views_empty_for_empty_database() {
         .expect("list_materialized_views");
 
     assert!(
-        response.materialized_views.is_empty(),
+        response.entries.is_empty(),
         "analytics has no matviews, got len={}",
-        response.materialized_views.len()
+        response.entries.len()
     );
 }
 
@@ -2946,7 +2944,7 @@ async fn list_matviews_brief(handler: &PostgresHandler, search: Option<&str>) ->
         .list_materialized_views(Some("app".into()), None, search.map(str::to_owned), false)
         .await
         .expect("list_materialized_views");
-    response.materialized_views.as_brief().expect("brief mode").to_vec()
+    response.entries.as_brief().expect("brief mode").to_vec()
 }
 
 async fn list_matviews_detailed(handler: &PostgresHandler, search: Option<&str>) -> IndexMap<String, Value> {
@@ -2954,11 +2952,7 @@ async fn list_matviews_detailed(handler: &PostgresHandler, search: Option<&str>)
         .list_materialized_views(Some("app".into()), None, search.map(str::to_owned), true)
         .await
         .expect("list_materialized_views detailed");
-    response
-        .materialized_views
-        .as_detailed()
-        .expect("detailed mode")
-        .clone()
+    response.entries.as_detailed().expect("detailed mode").clone()
 }
 
 #[tokio::test]
@@ -3018,7 +3012,7 @@ async fn test_list_materialized_views_search_sql_meta_payloads_are_safe() {
             .await
             .unwrap_or_else(|e| panic!("search={payload:?} must not raise SQL error: {e:?}"));
         assert!(
-            response.materialized_views.as_brief().is_some(),
+            response.entries.as_brief().is_some(),
             "search={payload:?} must return brief mode"
         );
     }
@@ -3036,7 +3030,7 @@ async fn test_list_materialized_views_search_paginates_filtered_results() {
             .list_materialized_views(Some("app".into()), cursor.take(), Some("orders".into()), false)
             .await
             .expect("paged list_materialized_views");
-        all.extend(response.materialized_views.as_brief().expect("brief").to_vec());
+        all.extend(response.entries.as_brief().expect("brief").to_vec());
         match response.next_cursor {
             Some(c) => cursor = Some(c),
             None => break,
@@ -3047,7 +3041,7 @@ async fn test_list_materialized_views_search_paginates_filtered_results() {
         .list_materialized_views(Some("app".into()), cursor.take(), Some("orders".into()), false)
         .await
         .expect("single-page list_materialized_views");
-    let single_names = single.materialized_views.as_brief().expect("brief").to_vec();
+    let single_names = single.entries.as_brief().expect("brief").to_vec();
     assert_eq!(all, single_names, "paginated filter must equal single page");
 }
 
@@ -3240,7 +3234,7 @@ async fn test_list_materialized_views_detailed_paginates() {
             .expect("paged detailed list_materialized_views");
         all.extend(
             response
-                .materialized_views
+                .entries
                 .as_detailed()
                 .expect("detailed")
                 .keys()
@@ -3265,7 +3259,7 @@ async fn test_list_materialized_views_brief_returns_bare_strings() {
         .await
         .expect("list_materialized_views brief");
     let serialized = serde_json::to_value(&response).expect("serialize");
-    let entries = serialized.get("materializedViews").expect("materializedViews field");
+    let entries = serialized.get("entries").expect("entries field");
     assert!(
         entries.is_array(),
         "brief mode materializedViews must serialise as bare-string array"
@@ -3328,7 +3322,7 @@ async fn search_names(handler: &PostgresHandler, search: &str) -> Vec<String> {
         .list_tables(Some(PG_DB.into()), None, Some(search.into()), false)
         .await
         .expect("listTables ok");
-    response.tables.as_brief().expect("brief mode").to_vec()
+    response.entries.as_brief().expect("brief mode").to_vec()
 }
 
 #[tokio::test]
@@ -3376,7 +3370,7 @@ async fn test_list_tables_search_empty_is_same_as_no_filter() {
         .list_tables(Some(PG_DB.into()), None, None, false)
         .await
         .expect("listTables ok")
-        .tables
+        .entries
         .as_brief()
         .expect("brief")
         .to_vec();
@@ -3408,7 +3402,7 @@ async fn test_list_tables_search_paginates_filtered_results() {
             .list_tables(Some(PG_DB.into()), cursor.take(), Some("order".into()), false)
             .await
             .expect("page");
-        collected.extend(response.tables.as_brief().expect("brief mode").iter().cloned());
+        collected.extend(response.entries.as_brief().expect("brief mode").iter().cloned());
         match response.next_cursor {
             Some(c) => cursor = Some(c),
             None => break,
@@ -3427,7 +3421,7 @@ async fn detailed_entries(handler: &PostgresHandler, search: &str) -> IndexMap<S
         .list_tables(Some(PG_DB.into()), None, Some(search.into()), true)
         .await
         .expect("listTables detailed ok");
-    response.tables.as_detailed().expect("detailed mode").clone()
+    response.entries.as_detailed().expect("detailed mode").clone()
 }
 
 #[tokio::test]
@@ -3520,7 +3514,7 @@ async fn test_list_tables_brief_without_parameters_returns_bare_strings() {
         .list_tables(Some(PG_DB.into()), None, None, false)
         .await
         .expect("list");
-    let value = serde_json::to_value(&response.tables).expect("serialize");
+    let value = serde_json::to_value(&response.entries).expect("serialize");
     assert!(
         value
             .as_array()
@@ -3569,7 +3563,7 @@ async fn test_list_tables_detailed_paginates() {
             .list_tables(Some(PG_DB.into()), cursor.take(), Some("order".into()), true)
             .await
             .expect("page");
-        let entries = response.tables.as_detailed().expect("detailed");
+        let entries = response.entries.as_detailed().expect("detailed");
         assert!(entries.len() <= 1, "page_size=1 must cap to 1 per page");
         collected_names.extend(entries.keys().cloned());
         match response.next_cursor {
@@ -3592,7 +3586,7 @@ async fn test_list_tables_detailed_key_order_matches_brief_order() {
         .await
         .expect("listTables brief ok");
     let detailed = detailed_entries(&handler, "order").await;
-    let brief_names: Vec<String> = brief.tables.as_brief().expect("brief mode").to_vec();
+    let brief_names: Vec<String> = brief.entries.as_brief().expect("brief mode").to_vec();
     let detailed_keys: Vec<String> = detailed.keys().cloned().collect();
     assert_eq!(
         brief_names, detailed_keys,

--- a/tests/functional/sqlite.rs
+++ b/tests/functional/sqlite.rs
@@ -132,7 +132,7 @@ async fn test_lists_tables() {
     let handler = handler(false);
 
     let response = handler.list_tables(ListTablesRequest::default()).await.unwrap();
-    let tables = response.tables.as_brief().expect("brief mode");
+    let tables = response.entries.as_brief().expect("brief mode");
 
     for expected in ["users", "posts", "tags", "post_tags"] {
         assert!(
@@ -228,7 +228,7 @@ async fn test_drop_table_success() {
 
     // Verify it's gone
     let response = handler.list_tables(ListTablesRequest::default()).await.unwrap();
-    let tables = response.tables.as_brief().expect("brief mode");
+    let tables = response.entries.as_brief().expect("brief mode");
     assert!(
         !tables.iter().any(|t| t == "drop_test_simple"),
         "Table should not exist after drop"
@@ -364,7 +364,7 @@ async fn test_write_query_create_table() {
 
     // Verify it appears in list_tables
     let response = handler.list_tables(ListTablesRequest::default()).await.unwrap();
-    let tables = response.tables.as_brief().expect("brief mode");
+    let tables = response.entries.as_brief().expect("brief mode");
     assert!(
         tables.iter().any(|t| t == "write_test_create"),
         "Created table should appear in list"
@@ -534,7 +534,7 @@ async fn test_create_drop_table_with_spaces() {
         })
         .await
         .expect("detailed listTables with spaced name");
-    let entries = response.tables.as_detailed().expect("detailed mode");
+    let entries = response.entries.as_detailed().expect("detailed mode");
     assert!(
         entries.contains_key("table with spaces"),
         "spaced-name table must surface as a keyed entry: {entries:?}"
@@ -555,7 +555,7 @@ async fn collect_all_paged(handler: &SqliteHandler) -> Vec<String> {
             ..Default::default()
         };
         let response = handler.list_tables(request).await.expect("list page");
-        let page = response.tables.as_brief().expect("brief mode").to_vec();
+        let page = response.entries.as_brief().expect("brief mode").to_vec();
         all.extend(page);
         match response.next_cursor {
             Some(c) => cursor = Some(c),
@@ -576,7 +576,7 @@ async fn test_list_tables_pagination_traverses_pages() {
         .list_tables(ListTablesRequest::default())
         .await
         .expect("single page");
-    let single_page_vec = single_page.tables.as_brief().expect("brief mode").to_vec();
+    let single_page_vec = single_page.entries.as_brief().expect("brief mode").to_vec();
 
     assert_eq!(
         collected, single_page_vec,
@@ -603,7 +603,7 @@ async fn test_list_tables_pagination_boundary_page_size_equals_total() {
         .list_tables(ListTablesRequest::default())
         .await
         .expect("discover total")
-        .tables
+        .entries
         .len();
     let page_size = u16::try_from(total).expect("seed total fits in u16");
 
@@ -613,7 +613,7 @@ async fn test_list_tables_pagination_boundary_page_size_equals_total() {
         .await
         .unwrap();
     assert_eq!(
-        response.tables.len(),
+        response.entries.len(),
         total,
         "page_size equal to total must return everything on one page"
     );
@@ -635,9 +635,9 @@ async fn test_list_tables_pagination_off_the_end_cursor_returns_empty_page() {
     let response = handler.list_tables(request).await.unwrap();
 
     assert!(
-        response.tables.is_empty(),
+        response.entries.is_empty(),
         "off-the-end cursor must return empty tables, got {:?}",
-        response.tables
+        response.entries
     );
     assert!(response.next_cursor.is_none(), "off-the-end must not emit nextCursor");
 }
@@ -649,7 +649,7 @@ async fn test_list_tables_respects_configured_page_size() {
         .list_tables(ListTablesRequest::default())
         .await
         .expect("first page");
-    assert_eq!(first.tables.len(), 2, "configured page_size=2 must cap page 1");
+    assert_eq!(first.entries.len(), 2, "configured page_size=2 must cap page 1");
     assert!(
         first.next_cursor.is_some(),
         "page 1 must emit nextCursor when total > page_size"
@@ -663,7 +663,7 @@ async fn test_list_tables_respects_configured_page_size_minimum() {
         .list_tables(ListTablesRequest::default())
         .await
         .expect("first page");
-    assert_eq!(first.tables.len(), 1, "page_size=1 must return one table per page");
+    assert_eq!(first.entries.len(), 1, "page_size=1 must return one table per page");
     assert!(first.next_cursor.is_some(), "page 1 must emit nextCursor");
 }
 
@@ -943,7 +943,7 @@ async fn test_list_views_returns_seeded_views() {
         .await
         .expect("list_views");
 
-    let names = response.views.as_brief().expect("brief mode");
+    let names = response.entries.as_brief().expect("brief mode");
     assert!(
         names.contains(&"active_users".to_string()),
         "expected seeded active_users view, got {names:?}"
@@ -962,7 +962,7 @@ async fn test_list_views_excludes_base_tables() {
         .await
         .expect("list_views");
 
-    let names = response.views.as_brief().expect("brief mode");
+    let names = response.entries.as_brief().expect("brief mode");
     for table in ["users", "posts", "tags", "post_tags", "temporal"] {
         assert!(
             !names.contains(&table.to_string()),
@@ -983,7 +983,7 @@ async fn test_list_views_pagination_traverses_pages() {
             .list_views(ListViewsRequest { cursor })
             .await
             .expect("paged list_views");
-        all.extend(response.views.as_brief().expect("brief").iter().cloned());
+        all.extend(response.entries.as_brief().expect("brief").iter().cloned());
         match response.next_cursor {
             Some(c) => cursor = Some(c),
             None => break,
@@ -995,7 +995,7 @@ async fn test_list_views_pagination_traverses_pages() {
         .await
         .expect("single-page list_views");
 
-    let single_names = single.views.as_brief().expect("brief").to_vec();
+    let single_names = single.entries.as_brief().expect("brief").to_vec();
     assert_eq!(all, single_names, "paginated traversal should equal single page");
 }
 
@@ -1008,7 +1008,7 @@ async fn test_list_views_works_in_read_only_mode() {
         .expect("list_views in read-only mode");
 
     assert!(
-        !response.views.as_brief().expect("brief").is_empty(),
+        !response.entries.as_brief().expect("brief").is_empty(),
         "read-only mode must still allow listViews"
     );
 }
@@ -1021,7 +1021,7 @@ async fn test_list_triggers_returns_seeded_triggers() {
         .await
         .expect("list_triggers");
 
-    let names = response.triggers.as_brief().expect("brief mode");
+    let names = response.entries.as_brief().expect("brief mode");
     assert!(
         names.contains(&"users_before_insert".to_string()),
         "expected seeded users_before_insert trigger, got {names:?}"
@@ -1041,7 +1041,7 @@ async fn test_list_triggers_works_in_read_only_mode() {
         .expect("list_triggers in read-only mode");
 
     assert!(
-        !response.triggers.is_empty(),
+        !response.entries.is_empty(),
         "read-only mode must still allow listTriggers"
     );
 }
@@ -1056,7 +1056,7 @@ async fn test_list_tables_search_filter_returns_only_matches() {
         })
         .await
         .expect("brief + search");
-    let names = response.tables.as_brief().expect("brief").to_vec();
+    let names = response.entries.as_brief().expect("brief").to_vec();
     assert_eq!(
         names,
         vec!["post_tags", "posts", "posts_fts"],
@@ -1074,7 +1074,7 @@ async fn test_list_tables_search_is_case_insensitive() {
         })
         .await
         .expect("brief + search");
-    let names = response.tables.as_brief().expect("brief").to_vec();
+    let names = response.entries.as_brief().expect("brief").to_vec();
     assert_eq!(
         names,
         vec!["post_tags", "posts", "posts_fts"],
@@ -1092,7 +1092,7 @@ async fn test_list_tables_search_no_match_returns_empty() {
         })
         .await
         .expect("brief + search");
-    assert!(response.tables.as_brief().expect("brief").is_empty());
+    assert!(response.entries.as_brief().expect("brief").is_empty());
     assert!(response.next_cursor.is_none());
 }
 
@@ -1107,7 +1107,7 @@ async fn test_list_tables_search_supports_like_wildcards() {
         })
         .await
         .expect("brief + search");
-    let names = response.tables.as_brief().expect("brief").to_vec();
+    let names = response.entries.as_brief().expect("brief").to_vec();
     assert!(
         names.iter().any(|n| n == "posts"),
         "'_' wildcard should match 'posts': {names:?}"
@@ -1133,8 +1133,8 @@ async fn test_list_tables_search_empty_is_same_as_no_filter() {
         .await
         .expect("no search");
     assert_eq!(
-        whitespace.tables.as_brief().expect("brief"),
-        unfiltered.tables.as_brief().expect("brief"),
+        whitespace.entries.as_brief().expect("brief"),
+        unfiltered.entries.as_brief().expect("brief"),
         "whitespace-only search must be equivalent to no filter"
     );
 }
@@ -1150,14 +1150,19 @@ async fn test_list_tables_search_sql_meta_payloads_are_safe() {
         })
         .await
         .expect("bound payload must not error");
-    assert!(response.tables.as_brief().expect("brief").is_empty());
+    assert!(response.entries.as_brief().expect("brief").is_empty());
 
     let follow_up = handler
         .list_tables(ListTablesRequest::default())
         .await
         .expect("users still present");
     assert!(
-        follow_up.tables.as_brief().expect("brief").iter().any(|n| n == "users"),
+        follow_up
+            .entries
+            .as_brief()
+            .expect("brief")
+            .iter()
+            .any(|n| n == "users"),
         "users table must survive any bind-based SQL meta payload"
     );
 }
@@ -1176,7 +1181,7 @@ async fn test_list_tables_search_paginates_filtered_results() {
             })
             .await
             .expect("paged brief + search");
-        collected.extend(response.tables.as_brief().expect("brief").to_vec());
+        collected.extend(response.entries.as_brief().expect("brief").to_vec());
         match response.next_cursor {
             Some(c) => cursor = Some(c),
             None => break,
@@ -1198,7 +1203,7 @@ async fn detailed_entries(handler: &SqliteHandler, search: &str) -> indexmap::In
         })
         .await
         .expect("detailed + search");
-    response.tables.as_detailed().expect("detailed mode").clone()
+    response.entries.as_detailed().expect("detailed mode").clone()
 }
 
 #[tokio::test]
@@ -1369,7 +1374,7 @@ async fn test_list_tables_detailed_paginates() {
             })
             .await
             .expect("paged detailed");
-        let page = response.tables.as_detailed().expect("detailed");
+        let page = response.entries.as_detailed().expect("detailed");
         assert!(page.len() <= 1, "page_size=1 caps to 1 per page");
         collected.extend(page.keys().cloned());
         match response.next_cursor {
@@ -1422,7 +1427,7 @@ async fn test_list_tables_detailed_key_order_matches_brief_order() {
         .await
         .expect("brief + search");
     let detailed = detailed_entries(&handler, "post").await;
-    let brief_names: Vec<String> = brief.tables.as_brief().expect("brief mode").to_vec();
+    let brief_names: Vec<String> = brief.entries.as_brief().expect("brief mode").to_vec();
     let detailed_keys: Vec<String> = detailed.keys().cloned().collect();
     assert_eq!(
         brief_names, detailed_keys,
@@ -1451,7 +1456,7 @@ async fn test_list_triggers_search_filter_returns_only_matches() {
         })
         .await
         .expect("brief + search");
-    let names = response.triggers.as_brief().expect("brief mode").to_vec();
+    let names = response.entries.as_brief().expect("brief mode").to_vec();
     let expected: Vec<String> = AUDIT_TRIGGERS.iter().map(|s| (*s).to_string()).collect();
     assert_eq!(
         names, expected,
@@ -1477,8 +1482,8 @@ async fn test_list_triggers_search_is_case_insensitive() {
         .await
         .expect("upper");
     assert_eq!(
-        lower.triggers.as_brief().expect("brief"),
-        upper.triggers.as_brief().expect("brief"),
+        lower.entries.as_brief().expect("brief"),
+        upper.entries.as_brief().expect("brief"),
         "case-insensitive (SQLite `LIKE` is ASCII-case-insensitive by default)"
     );
 }
@@ -1493,7 +1498,7 @@ async fn test_list_triggers_search_no_match_returns_empty() {
         })
         .await
         .expect("brief + search");
-    assert!(response.triggers.as_brief().expect("brief").is_empty());
+    assert!(response.entries.as_brief().expect("brief").is_empty());
     assert!(response.next_cursor.is_none());
 }
 
@@ -1516,8 +1521,8 @@ async fn test_list_triggers_search_supports_wildcard_semantics() {
         .await
         .expect("wildcards");
     assert_eq!(
-        bare.triggers.as_brief().expect("brief"),
-        wildcards.triggers.as_brief().expect("brief"),
+        bare.entries.as_brief().expect("brief"),
+        wildcards.entries.as_brief().expect("brief"),
         "%/_ retain LIKE wildcard semantics consistent with listTables"
     );
 }
@@ -1534,7 +1539,7 @@ async fn test_list_triggers_search_sql_meta_payloads_are_safe() {
             .await
             .unwrap_or_else(|e| panic!("payload {payload:?} must not error: {e:?}"));
         // Bound payload — no SQL parse error, possibly empty result.
-        let _ = response.triggers.as_brief().expect("brief").to_vec();
+        let _ = response.entries.as_brief().expect("brief").to_vec();
     }
     // Users table must survive every adversarial payload.
     let follow_up = handler
@@ -1542,7 +1547,12 @@ async fn test_list_triggers_search_sql_meta_payloads_are_safe() {
         .await
         .expect("users table check");
     assert!(
-        follow_up.tables.as_brief().expect("brief").iter().any(|n| n == "users"),
+        follow_up
+            .entries
+            .as_brief()
+            .expect("brief")
+            .iter()
+            .any(|n| n == "users"),
         "users table must survive every adversarial search payload"
     );
 }
@@ -1561,7 +1571,7 @@ async fn test_list_triggers_search_paginates_filtered_results() {
             })
             .await
             .expect("paged brief + search");
-        let page = response.triggers.as_brief().expect("brief").to_vec();
+        let page = response.entries.as_brief().expect("brief").to_vec();
         assert!(page.len() <= 2, "page exceeds page_size=2: {page:?}");
         collected.extend(page);
         match response.next_cursor {
@@ -1585,7 +1595,7 @@ async fn detailed_trigger_entries(handler: &SqliteHandler, search: &str) -> inde
         })
         .await
         .expect("detailed + search");
-    response.triggers.as_detailed().expect("detailed mode").clone()
+    response.entries.as_detailed().expect("detailed mode").clone()
 }
 
 #[tokio::test]
@@ -1679,7 +1689,7 @@ async fn test_list_triggers_brief_mode_wire_shape_unchanged() {
         .list_triggers(ListTriggersRequest::default())
         .await
         .expect("brief default");
-    let names = response.triggers.as_brief().expect("brief mode");
+    let names = response.entries.as_brief().expect("brief mode");
     assert!(
         names.iter().all(|n| !n.is_empty()),
         "brief response is a flat array of bare strings: {names:?}"
@@ -1723,7 +1733,7 @@ async fn test_list_triggers_detailed_paginates() {
             })
             .await
             .expect("paged detailed + search");
-        let page = response.triggers.as_detailed().expect("detailed mode");
+        let page = response.entries.as_detailed().expect("detailed mode");
         assert!(page.len() <= 2, "page exceeds page_size=2: {page:?}");
         collected.extend(page.keys().cloned());
         match response.next_cursor {
@@ -1772,7 +1782,7 @@ async fn test_list_triggers_detailed_omits_null_sql_rows_brief_lists_them() {
         })
         .await
         .expect("brief search");
-    let names = brief.triggers.as_brief().expect("brief").to_vec();
+    let names = brief.entries.as_brief().expect("brief").to_vec();
     assert_eq!(
         names,
         vec!["orphan_trigger"],
@@ -1787,7 +1797,7 @@ async fn test_list_triggers_detailed_omits_null_sql_rows_brief_lists_them() {
         })
         .await
         .expect("detailed search");
-    let keyed = detailed.triggers.as_detailed().expect("detailed");
+    let keyed = detailed.entries.as_detailed().expect("detailed");
     assert!(
         keyed.is_empty(),
         "detailed mode silently omits NULL-sql triggers (FR-018 / Clarification Q2): {keyed:?}"


### PR DESCRIPTION
## Summary

- Collapses six near-identical response wrappers (`ListTablesResponse`, `ListViewsResponse`, `ListTriggersResponse`, `ListFunctionsResponse`, `ListProceduresResponse`, `ListMaterializedViewsResponse`) into a single shared `ListEntriesResponse` in `crates/server/src/types.rs`. Each wrapper differed only in the JSON payload key and had structurally identical `brief`/`detailed` constructors.
- Every list-style tool (`listTables`, `listViews`, `listTriggers`, `listFunctions`, `listProcedures`, `listMaterializedViews`) now returns its payload under one canonical `entries` key. **Breaking MCP wire change.** Per-entity nested metadata (e.g. the inner `triggers` array on a detailed table entry) is unchanged.
- Integration tests, approval snapshots, and `docs/content/docs/features.mdx` JSON examples updated to the new wire shape.

## Test plan

- [x] `cargo fmt`
- [x] `cargo clippy --workspace --tests -- -D warnings`
- [x] `cargo test --workspace --lib --bins`
- [x] `./tests/run.sh` — 734 tests PASS across mariadb_12, mysql_9, postgres_18, sqlite
- [x] Approval snapshots regenerated and committed