### PR TITLE
refactor(server): unify pinned/unpinned request structs

### DIFF
--- a/crates/mysql/src/tools/create_database.rs
+++ b/crates/mysql/src/tools/create_database.rs
@@ -41,7 +41,7 @@ impl ToolBase for CreateDatabaseTool {
     }
 
     fn input_schema() -> Option<Arc<JsonObject>> {
-        Some(input_schema::<Self::Parameter>())
+        Some(input_schema::<Self::Parameter>(false))
     }
 
     fn output_schema() -> Option<Arc<JsonObject>> {

--- a/crates/mysql/src/tools/drop_database.rs
+++ b/crates/mysql/src/tools/drop_database.rs
@@ -41,7 +41,7 @@ impl ToolBase for DropDatabaseTool {
     }
 
     fn input_schema() -> Option<Arc<JsonObject>> {
-        Some(input_schema::<Self::Parameter>())
+        Some(input_schema::<Self::Parameter>(false))
     }
 
     fn output_schema() -> Option<Arc<JsonObject>> {

--- a/crates/mysql/src/tools/drop_table.rs
+++ b/crates/mysql/src/tools/drop_table.rs
@@ -55,7 +55,7 @@ impl ToolBase for PinnedDropTableTool {
 
 impl AsyncTool<MysqlHandler> for PinnedDropTableTool {
     async fn invoke(handler: &MysqlHandler, params: Self::Parameter) -> Result<Self::Output, Self::Error> {
-        handler.drop_table(params.database, params.table).await
+        handler.drop_table(None, params.table).await
     }
 }
 

--- a/crates/mysql/src/tools/drop_table.rs
+++ b/crates/mysql/src/tools/drop_table.rs
@@ -5,7 +5,7 @@ use dbmcp_sql::SqlError;
 
 use super::prelude::*;
 use crate::connection::quote_ident;
-use crate::types::{PinnedDropTableRequest, UnpinnedDropTableRequest};
+use crate::types::DropTableRequest;
 
 const NAME: &str = "dropTable";
 const TITLE: &str = "Drop Table";
@@ -24,7 +24,7 @@ fn annotations() -> ToolAnnotations {
 pub(crate) struct PinnedDropTableTool;
 
 impl ToolBase for PinnedDropTableTool {
-    type Parameter = PinnedDropTableRequest;
+    type Parameter = DropTableRequest;
     type Output = MessageResponse;
     type Error = ErrorData;
 
@@ -45,7 +45,7 @@ impl ToolBase for PinnedDropTableTool {
     }
 
     fn input_schema() -> Option<Arc<JsonObject>> {
-        Some(input_schema::<Self::Parameter>())
+        Some(input_schema::<Self::Parameter>(true))
     }
 
     fn output_schema() -> Option<Arc<JsonObject>> {
@@ -55,7 +55,7 @@ impl ToolBase for PinnedDropTableTool {
 
 impl AsyncTool<MysqlHandler> for PinnedDropTableTool {
     async fn invoke(handler: &MysqlHandler, params: Self::Parameter) -> Result<Self::Output, Self::Error> {
-        handler.drop_table(None, params.table).await
+        handler.drop_table(params.database, params.table).await
     }
 }
 
@@ -63,7 +63,7 @@ impl AsyncTool<MysqlHandler> for PinnedDropTableTool {
 pub(crate) struct UnpinnedDropTableTool;
 
 impl ToolBase for UnpinnedDropTableTool {
-    type Parameter = UnpinnedDropTableRequest;
+    type Parameter = DropTableRequest;
     type Output = MessageResponse;
     type Error = ErrorData;
 
@@ -84,7 +84,7 @@ impl ToolBase for UnpinnedDropTableTool {
     }
 
     fn input_schema() -> Option<Arc<JsonObject>> {
-        Some(input_schema::<Self::Parameter>())
+        Some(input_schema::<Self::Parameter>(false))
     }
 
     fn output_schema() -> Option<Arc<JsonObject>> {
@@ -94,7 +94,7 @@ impl ToolBase for UnpinnedDropTableTool {
 
 impl AsyncTool<MysqlHandler> for UnpinnedDropTableTool {
     async fn invoke(handler: &MysqlHandler, params: Self::Parameter) -> Result<Self::Output, Self::Error> {
-        handler.drop_table(params.database, params.inner.table).await
+        handler.drop_table(params.database, params.table).await
     }
 }
 

--- a/crates/mysql/src/tools/explain_query.rs
+++ b/crates/mysql/src/tools/explain_query.rs
@@ -1,7 +1,7 @@
 //! MCP tool: `explainQuery`.
 
 use dbmcp_pii::MaybeRedact as _;
-use dbmcp_server::types::{PinnedExplainQueryRequest, QueryResponse, UnpinnedExplainQueryRequest};
+use dbmcp_server::types::{ExplainQueryRequest, QueryResponse};
 use dbmcp_sql::validation::validate_read_only;
 
 use super::prelude::*;
@@ -23,7 +23,7 @@ fn annotations() -> ToolAnnotations {
 pub(crate) struct PinnedExplainQueryTool;
 
 impl ToolBase for PinnedExplainQueryTool {
-    type Parameter = PinnedExplainQueryRequest;
+    type Parameter = ExplainQueryRequest;
     type Output = QueryResponse;
     type Error = ErrorData;
 
@@ -44,7 +44,7 @@ impl ToolBase for PinnedExplainQueryTool {
     }
 
     fn input_schema() -> Option<Arc<JsonObject>> {
-        Some(input_schema::<Self::Parameter>())
+        Some(input_schema::<Self::Parameter>(true))
     }
 
     fn output_schema() -> Option<Arc<JsonObject>> {
@@ -54,7 +54,9 @@ impl ToolBase for PinnedExplainQueryTool {
 
 impl AsyncTool<MysqlHandler> for PinnedExplainQueryTool {
     async fn invoke(handler: &MysqlHandler, params: Self::Parameter) -> Result<Self::Output, Self::Error> {
-        handler.explain_query(None, params.query, params.analyze).await
+        handler
+            .explain_query(params.database, params.query, params.analyze)
+            .await
     }
 }
 
@@ -62,7 +64,7 @@ impl AsyncTool<MysqlHandler> for PinnedExplainQueryTool {
 pub(crate) struct UnpinnedExplainQueryTool;
 
 impl ToolBase for UnpinnedExplainQueryTool {
-    type Parameter = UnpinnedExplainQueryRequest;
+    type Parameter = ExplainQueryRequest;
     type Output = QueryResponse;
     type Error = ErrorData;
 
@@ -83,7 +85,7 @@ impl ToolBase for UnpinnedExplainQueryTool {
     }
 
     fn input_schema() -> Option<Arc<JsonObject>> {
-        Some(input_schema::<Self::Parameter>())
+        Some(input_schema::<Self::Parameter>(false))
     }
 
     fn output_schema() -> Option<Arc<JsonObject>> {
@@ -94,7 +96,7 @@ impl ToolBase for UnpinnedExplainQueryTool {
 impl AsyncTool<MysqlHandler> for UnpinnedExplainQueryTool {
     async fn invoke(handler: &MysqlHandler, params: Self::Parameter) -> Result<Self::Output, Self::Error> {
         handler
-            .explain_query(params.database, params.inner.query, params.inner.analyze)
+            .explain_query(params.database, params.query, params.analyze)
             .await
     }
 }

--- a/crates/mysql/src/tools/explain_query.rs
+++ b/crates/mysql/src/tools/explain_query.rs
@@ -54,9 +54,7 @@ impl ToolBase for PinnedExplainQueryTool {
 
 impl AsyncTool<MysqlHandler> for PinnedExplainQueryTool {
     async fn invoke(handler: &MysqlHandler, params: Self::Parameter) -> Result<Self::Output, Self::Error> {
-        handler
-            .explain_query(params.database, params.query, params.analyze)
-            .await
+        handler.explain_query(None, params.query, params.analyze).await
     }
 }
 

--- a/crates/mysql/src/tools/list_databases.rs
+++ b/crates/mysql/src/tools/list_databases.rs
@@ -40,7 +40,7 @@ impl ToolBase for ListDatabasesTool {
     }
 
     fn input_schema() -> Option<Arc<JsonObject>> {
-        Some(input_schema::<Self::Parameter>())
+        Some(input_schema::<Self::Parameter>(false))
     }
 
     fn output_schema() -> Option<Arc<JsonObject>> {

--- a/crates/mysql/src/tools/list_functions.rs
+++ b/crates/mysql/src/tools/list_functions.rs
@@ -55,7 +55,7 @@ impl ToolBase for PinnedListFunctionsTool {
 impl AsyncTool<MysqlHandler> for PinnedListFunctionsTool {
     async fn invoke(handler: &MysqlHandler, params: Self::Parameter) -> Result<Self::Output, Self::Error> {
         handler
-            .list_functions(params.database, params.cursor, params.search, params.detailed)
+            .list_functions(None, params.cursor, params.search, params.detailed)
             .await
     }
 }

--- a/crates/mysql/src/tools/list_functions.rs
+++ b/crates/mysql/src/tools/list_functions.rs
@@ -4,7 +4,7 @@ use dbmcp_server::pagination::{Cursor, Pager};
 use dbmcp_server::types::ListEntriesResponse;
 
 use super::prelude::*;
-use crate::types::{PinnedListFunctionsRequest, UnpinnedListFunctionsRequest};
+use crate::types::ListFunctionsRequest;
 
 const NAME: &str = "listFunctions";
 const TITLE: &str = "List Functions";
@@ -23,7 +23,7 @@ fn annotations() -> ToolAnnotations {
 pub(crate) struct PinnedListFunctionsTool;
 
 impl ToolBase for PinnedListFunctionsTool {
-    type Parameter = PinnedListFunctionsRequest;
+    type Parameter = ListFunctionsRequest;
     type Output = ListEntriesResponse;
     type Error = ErrorData;
 
@@ -44,7 +44,7 @@ impl ToolBase for PinnedListFunctionsTool {
     }
 
     fn input_schema() -> Option<Arc<JsonObject>> {
-        Some(input_schema::<Self::Parameter>())
+        Some(input_schema::<Self::Parameter>(true))
     }
 
     fn output_schema() -> Option<Arc<JsonObject>> {
@@ -55,7 +55,7 @@ impl ToolBase for PinnedListFunctionsTool {
 impl AsyncTool<MysqlHandler> for PinnedListFunctionsTool {
     async fn invoke(handler: &MysqlHandler, params: Self::Parameter) -> Result<Self::Output, Self::Error> {
         handler
-            .list_functions(None, params.cursor, params.search, params.detailed)
+            .list_functions(params.database, params.cursor, params.search, params.detailed)
             .await
     }
 }
@@ -64,7 +64,7 @@ impl AsyncTool<MysqlHandler> for PinnedListFunctionsTool {
 pub(crate) struct UnpinnedListFunctionsTool;
 
 impl ToolBase for UnpinnedListFunctionsTool {
-    type Parameter = UnpinnedListFunctionsRequest;
+    type Parameter = ListFunctionsRequest;
     type Output = ListEntriesResponse;
     type Error = ErrorData;
 
@@ -85,7 +85,7 @@ impl ToolBase for UnpinnedListFunctionsTool {
     }
 
     fn input_schema() -> Option<Arc<JsonObject>> {
-        Some(input_schema::<Self::Parameter>())
+        Some(input_schema::<Self::Parameter>(false))
     }
 
     fn output_schema() -> Option<Arc<JsonObject>> {
@@ -96,12 +96,7 @@ impl ToolBase for UnpinnedListFunctionsTool {
 impl AsyncTool<MysqlHandler> for UnpinnedListFunctionsTool {
     async fn invoke(handler: &MysqlHandler, params: Self::Parameter) -> Result<Self::Output, Self::Error> {
         handler
-            .list_functions(
-                params.database,
-                params.inner.cursor,
-                params.inner.search,
-                params.inner.detailed,
-            )
+            .list_functions(params.database, params.cursor, params.search, params.detailed)
             .await
     }
 }

--- a/crates/mysql/src/tools/list_procedures.rs
+++ b/crates/mysql/src/tools/list_procedures.rs
@@ -3,7 +3,7 @@
 use dbmcp_server::pagination::{Cursor, Pager};
 
 use super::prelude::*;
-use crate::types::{ListEntriesResponse, PinnedListProceduresRequest, UnpinnedListProceduresRequest};
+use crate::types::{ListEntriesResponse, ListProceduresRequest};
 
 const NAME: &str = "listProcedures";
 const TITLE: &str = "List Procedures";
@@ -22,7 +22,7 @@ fn annotations() -> ToolAnnotations {
 pub(crate) struct PinnedListProceduresTool;
 
 impl ToolBase for PinnedListProceduresTool {
-    type Parameter = PinnedListProceduresRequest;
+    type Parameter = ListProceduresRequest;
     type Output = ListEntriesResponse;
     type Error = ErrorData;
 
@@ -43,7 +43,7 @@ impl ToolBase for PinnedListProceduresTool {
     }
 
     fn input_schema() -> Option<Arc<JsonObject>> {
-        Some(input_schema::<Self::Parameter>())
+        Some(input_schema::<Self::Parameter>(true))
     }
 
     fn output_schema() -> Option<Arc<JsonObject>> {
@@ -54,7 +54,7 @@ impl ToolBase for PinnedListProceduresTool {
 impl AsyncTool<MysqlHandler> for PinnedListProceduresTool {
     async fn invoke(handler: &MysqlHandler, params: Self::Parameter) -> Result<Self::Output, Self::Error> {
         handler
-            .list_procedures(None, params.cursor, params.search, params.detailed)
+            .list_procedures(params.database, params.cursor, params.search, params.detailed)
             .await
     }
 }
@@ -63,7 +63,7 @@ impl AsyncTool<MysqlHandler> for PinnedListProceduresTool {
 pub(crate) struct UnpinnedListProceduresTool;
 
 impl ToolBase for UnpinnedListProceduresTool {
-    type Parameter = UnpinnedListProceduresRequest;
+    type Parameter = ListProceduresRequest;
     type Output = ListEntriesResponse;
     type Error = ErrorData;
 
@@ -84,7 +84,7 @@ impl ToolBase for UnpinnedListProceduresTool {
     }
 
     fn input_schema() -> Option<Arc<JsonObject>> {
-        Some(input_schema::<Self::Parameter>())
+        Some(input_schema::<Self::Parameter>(false))
     }
 
     fn output_schema() -> Option<Arc<JsonObject>> {
@@ -95,12 +95,7 @@ impl ToolBase for UnpinnedListProceduresTool {
 impl AsyncTool<MysqlHandler> for UnpinnedListProceduresTool {
     async fn invoke(handler: &MysqlHandler, params: Self::Parameter) -> Result<Self::Output, Self::Error> {
         handler
-            .list_procedures(
-                params.database,
-                params.inner.cursor,
-                params.inner.search,
-                params.inner.detailed,
-            )
+            .list_procedures(params.database, params.cursor, params.search, params.detailed)
             .await
     }
 }

--- a/crates/mysql/src/tools/list_procedures.rs
+++ b/crates/mysql/src/tools/list_procedures.rs
@@ -54,7 +54,7 @@ impl ToolBase for PinnedListProceduresTool {
 impl AsyncTool<MysqlHandler> for PinnedListProceduresTool {
     async fn invoke(handler: &MysqlHandler, params: Self::Parameter) -> Result<Self::Output, Self::Error> {
         handler
-            .list_procedures(params.database, params.cursor, params.search, params.detailed)
+            .list_procedures(None, params.cursor, params.search, params.detailed)
             .await
     }
 }

--- a/crates/mysql/src/tools/list_tables.rs
+++ b/crates/mysql/src/tools/list_tables.rs
@@ -333,7 +333,7 @@ impl ToolBase for PinnedListTablesTool {
 impl AsyncTool<MysqlHandler> for PinnedListTablesTool {
     async fn invoke(handler: &MysqlHandler, params: Self::Parameter) -> Result<Self::Output, Self::Error> {
         handler
-            .list_tables(params.database, params.cursor, params.search, params.detailed)
+            .list_tables(None, params.cursor, params.search, params.detailed)
             .await
     }
 }

--- a/crates/mysql/src/tools/list_tables.rs
+++ b/crates/mysql/src/tools/list_tables.rs
@@ -3,7 +3,7 @@
 use dbmcp_server::pagination::{Cursor, Pager};
 
 use super::prelude::*;
-use crate::types::{ListEntriesResponse, PinnedListTablesRequest, UnpinnedListTablesRequest};
+use crate::types::{ListEntriesResponse, ListTablesRequest};
 
 /// Brief-mode SQL: `information_schema.TABLES` filtered to `BASE TABLE` rows.
 ///
@@ -301,7 +301,7 @@ fn annotations() -> ToolAnnotations {
 pub(crate) struct PinnedListTablesTool;
 
 impl ToolBase for PinnedListTablesTool {
-    type Parameter = PinnedListTablesRequest;
+    type Parameter = ListTablesRequest;
     type Output = ListEntriesResponse;
     type Error = ErrorData;
 
@@ -322,7 +322,7 @@ impl ToolBase for PinnedListTablesTool {
     }
 
     fn input_schema() -> Option<Arc<JsonObject>> {
-        Some(input_schema::<Self::Parameter>())
+        Some(input_schema::<Self::Parameter>(true))
     }
 
     fn output_schema() -> Option<Arc<JsonObject>> {
@@ -333,7 +333,7 @@ impl ToolBase for PinnedListTablesTool {
 impl AsyncTool<MysqlHandler> for PinnedListTablesTool {
     async fn invoke(handler: &MysqlHandler, params: Self::Parameter) -> Result<Self::Output, Self::Error> {
         handler
-            .list_tables(None, params.cursor, params.search, params.detailed)
+            .list_tables(params.database, params.cursor, params.search, params.detailed)
             .await
     }
 }
@@ -342,7 +342,7 @@ impl AsyncTool<MysqlHandler> for PinnedListTablesTool {
 pub(crate) struct UnpinnedListTablesTool;
 
 impl ToolBase for UnpinnedListTablesTool {
-    type Parameter = UnpinnedListTablesRequest;
+    type Parameter = ListTablesRequest;
     type Output = ListEntriesResponse;
     type Error = ErrorData;
 
@@ -363,7 +363,7 @@ impl ToolBase for UnpinnedListTablesTool {
     }
 
     fn input_schema() -> Option<Arc<JsonObject>> {
-        Some(input_schema::<Self::Parameter>())
+        Some(input_schema::<Self::Parameter>(false))
     }
 
     fn output_schema() -> Option<Arc<JsonObject>> {
@@ -374,12 +374,7 @@ impl ToolBase for UnpinnedListTablesTool {
 impl AsyncTool<MysqlHandler> for UnpinnedListTablesTool {
     async fn invoke(handler: &MysqlHandler, params: Self::Parameter) -> Result<Self::Output, Self::Error> {
         handler
-            .list_tables(
-                params.database,
-                params.inner.cursor,
-                params.inner.search,
-                params.inner.detailed,
-            )
+            .list_tables(params.database, params.cursor, params.search, params.detailed)
             .await
     }
 }

--- a/crates/mysql/src/tools/list_triggers.rs
+++ b/crates/mysql/src/tools/list_triggers.rs
@@ -1,7 +1,7 @@
 //! MCP tool: `listTriggers`.
 
 use dbmcp_server::pagination::{Cursor, Pager};
-use dbmcp_server::types::{ListEntriesResponse, PinnedListTriggersRequest, UnpinnedListTriggersRequest};
+use dbmcp_server::types::{ListEntriesResponse, ListTriggersRequest};
 
 use super::prelude::*;
 
@@ -22,7 +22,7 @@ fn annotations() -> ToolAnnotations {
 pub(crate) struct PinnedListTriggersTool;
 
 impl ToolBase for PinnedListTriggersTool {
-    type Parameter = PinnedListTriggersRequest;
+    type Parameter = ListTriggersRequest;
     type Output = ListEntriesResponse;
     type Error = ErrorData;
 
@@ -43,7 +43,7 @@ impl ToolBase for PinnedListTriggersTool {
     }
 
     fn input_schema() -> Option<Arc<JsonObject>> {
-        Some(input_schema::<Self::Parameter>())
+        Some(input_schema::<Self::Parameter>(true))
     }
 
     fn output_schema() -> Option<Arc<JsonObject>> {
@@ -54,7 +54,7 @@ impl ToolBase for PinnedListTriggersTool {
 impl AsyncTool<MysqlHandler> for PinnedListTriggersTool {
     async fn invoke(handler: &MysqlHandler, params: Self::Parameter) -> Result<Self::Output, Self::Error> {
         handler
-            .list_triggers(None, params.cursor, params.search, params.detailed)
+            .list_triggers(params.database, params.cursor, params.search, params.detailed)
             .await
     }
 }
@@ -63,7 +63,7 @@ impl AsyncTool<MysqlHandler> for PinnedListTriggersTool {
 pub(crate) struct UnpinnedListTriggersTool;
 
 impl ToolBase for UnpinnedListTriggersTool {
-    type Parameter = UnpinnedListTriggersRequest;
+    type Parameter = ListTriggersRequest;
     type Output = ListEntriesResponse;
     type Error = ErrorData;
 
@@ -84,7 +84,7 @@ impl ToolBase for UnpinnedListTriggersTool {
     }
 
     fn input_schema() -> Option<Arc<JsonObject>> {
-        Some(input_schema::<Self::Parameter>())
+        Some(input_schema::<Self::Parameter>(false))
     }
 
     fn output_schema() -> Option<Arc<JsonObject>> {
@@ -95,12 +95,7 @@ impl ToolBase for UnpinnedListTriggersTool {
 impl AsyncTool<MysqlHandler> for UnpinnedListTriggersTool {
     async fn invoke(handler: &MysqlHandler, params: Self::Parameter) -> Result<Self::Output, Self::Error> {
         handler
-            .list_triggers(
-                params.database,
-                params.inner.cursor,
-                params.inner.search,
-                params.inner.detailed,
-            )
+            .list_triggers(params.database, params.cursor, params.search, params.detailed)
             .await
     }
 }

--- a/crates/mysql/src/tools/list_triggers.rs
+++ b/crates/mysql/src/tools/list_triggers.rs
@@ -54,7 +54,7 @@ impl ToolBase for PinnedListTriggersTool {
 impl AsyncTool<MysqlHandler> for PinnedListTriggersTool {
     async fn invoke(handler: &MysqlHandler, params: Self::Parameter) -> Result<Self::Output, Self::Error> {
         handler
-            .list_triggers(params.database, params.cursor, params.search, params.detailed)
+            .list_triggers(None, params.cursor, params.search, params.detailed)
             .await
     }
 }

--- a/crates/mysql/src/tools/list_views.rs
+++ b/crates/mysql/src/tools/list_views.rs
@@ -3,7 +3,7 @@
 use dbmcp_server::pagination::{Cursor, Pager};
 
 use super::prelude::*;
-use crate::types::{ListEntriesResponse, PinnedListViewsRequest, UnpinnedListViewsRequest};
+use crate::types::{ListEntriesResponse, ListViewsRequest};
 
 const NAME: &str = "listViews";
 const TITLE: &str = "List Views";
@@ -22,7 +22,7 @@ fn annotations() -> ToolAnnotations {
 pub(crate) struct PinnedListViewsTool;
 
 impl ToolBase for PinnedListViewsTool {
-    type Parameter = PinnedListViewsRequest;
+    type Parameter = ListViewsRequest;
     type Output = ListEntriesResponse;
     type Error = ErrorData;
 
@@ -43,7 +43,7 @@ impl ToolBase for PinnedListViewsTool {
     }
 
     fn input_schema() -> Option<Arc<JsonObject>> {
-        Some(input_schema::<Self::Parameter>())
+        Some(input_schema::<Self::Parameter>(true))
     }
 
     fn output_schema() -> Option<Arc<JsonObject>> {
@@ -54,7 +54,7 @@ impl ToolBase for PinnedListViewsTool {
 impl AsyncTool<MysqlHandler> for PinnedListViewsTool {
     async fn invoke(handler: &MysqlHandler, params: Self::Parameter) -> Result<Self::Output, Self::Error> {
         handler
-            .list_views(None, params.cursor, params.search, params.detailed)
+            .list_views(params.database, params.cursor, params.search, params.detailed)
             .await
     }
 }
@@ -63,7 +63,7 @@ impl AsyncTool<MysqlHandler> for PinnedListViewsTool {
 pub(crate) struct UnpinnedListViewsTool;
 
 impl ToolBase for UnpinnedListViewsTool {
-    type Parameter = UnpinnedListViewsRequest;
+    type Parameter = ListViewsRequest;
     type Output = ListEntriesResponse;
     type Error = ErrorData;
 
@@ -84,7 +84,7 @@ impl ToolBase for UnpinnedListViewsTool {
     }
 
     fn input_schema() -> Option<Arc<JsonObject>> {
-        Some(input_schema::<Self::Parameter>())
+        Some(input_schema::<Self::Parameter>(false))
     }
 
     fn output_schema() -> Option<Arc<JsonObject>> {
@@ -95,12 +95,7 @@ impl ToolBase for UnpinnedListViewsTool {
 impl AsyncTool<MysqlHandler> for UnpinnedListViewsTool {
     async fn invoke(handler: &MysqlHandler, params: Self::Parameter) -> Result<Self::Output, Self::Error> {
         handler
-            .list_views(
-                params.database,
-                params.inner.cursor,
-                params.inner.search,
-                params.inner.detailed,
-            )
+            .list_views(params.database, params.cursor, params.search, params.detailed)
             .await
     }
 }

--- a/crates/mysql/src/tools/list_views.rs
+++ b/crates/mysql/src/tools/list_views.rs
@@ -54,7 +54,7 @@ impl ToolBase for PinnedListViewsTool {
 impl AsyncTool<MysqlHandler> for PinnedListViewsTool {
     async fn invoke(handler: &MysqlHandler, params: Self::Parameter) -> Result<Self::Output, Self::Error> {
         handler
-            .list_views(params.database, params.cursor, params.search, params.detailed)
+            .list_views(None, params.cursor, params.search, params.detailed)
             .await
     }
 }

--- a/crates/mysql/src/tools/read_query.rs
+++ b/crates/mysql/src/tools/read_query.rs
@@ -2,7 +2,7 @@
 
 use dbmcp_pii::MaybeRedact as _;
 use dbmcp_server::pagination::{Cursor, Pager};
-use dbmcp_server::types::{PinnedReadQueryRequest, ReadQueryResponse, UnpinnedReadQueryRequest};
+use dbmcp_server::types::{ReadQueryRequest, ReadQueryResponse};
 use dbmcp_sql::StatementKind;
 use dbmcp_sql::pagination::with_limit_offset;
 use dbmcp_sql::validation::validate_read_only;
@@ -26,7 +26,7 @@ fn annotations() -> ToolAnnotations {
 pub(crate) struct PinnedReadQueryTool;
 
 impl ToolBase for PinnedReadQueryTool {
-    type Parameter = PinnedReadQueryRequest;
+    type Parameter = ReadQueryRequest;
     type Output = ReadQueryResponse;
     type Error = ErrorData;
 
@@ -47,7 +47,7 @@ impl ToolBase for PinnedReadQueryTool {
     }
 
     fn input_schema() -> Option<Arc<JsonObject>> {
-        Some(input_schema::<Self::Parameter>())
+        Some(input_schema::<Self::Parameter>(true))
     }
 
     fn output_schema() -> Option<Arc<JsonObject>> {
@@ -57,7 +57,7 @@ impl ToolBase for PinnedReadQueryTool {
 
 impl AsyncTool<MysqlHandler> for PinnedReadQueryTool {
     async fn invoke(handler: &MysqlHandler, params: Self::Parameter) -> Result<Self::Output, Self::Error> {
-        handler.read_query(params.query, None, params.cursor).await
+        handler.read_query(params.query, params.database, params.cursor).await
     }
 }
 
@@ -65,7 +65,7 @@ impl AsyncTool<MysqlHandler> for PinnedReadQueryTool {
 pub(crate) struct UnpinnedReadQueryTool;
 
 impl ToolBase for UnpinnedReadQueryTool {
-    type Parameter = UnpinnedReadQueryRequest;
+    type Parameter = ReadQueryRequest;
     type Output = ReadQueryResponse;
     type Error = ErrorData;
 
@@ -86,7 +86,7 @@ impl ToolBase for UnpinnedReadQueryTool {
     }
 
     fn input_schema() -> Option<Arc<JsonObject>> {
-        Some(input_schema::<Self::Parameter>())
+        Some(input_schema::<Self::Parameter>(false))
     }
 
     fn output_schema() -> Option<Arc<JsonObject>> {
@@ -96,9 +96,7 @@ impl ToolBase for UnpinnedReadQueryTool {
 
 impl AsyncTool<MysqlHandler> for UnpinnedReadQueryTool {
     async fn invoke(handler: &MysqlHandler, params: Self::Parameter) -> Result<Self::Output, Self::Error> {
-        handler
-            .read_query(params.inner.query, params.database, params.inner.cursor)
-            .await
+        handler.read_query(params.query, params.database, params.cursor).await
     }
 }
 

--- a/crates/mysql/src/tools/read_query.rs
+++ b/crates/mysql/src/tools/read_query.rs
@@ -57,7 +57,7 @@ impl ToolBase for PinnedReadQueryTool {
 
 impl AsyncTool<MysqlHandler> for PinnedReadQueryTool {
     async fn invoke(handler: &MysqlHandler, params: Self::Parameter) -> Result<Self::Output, Self::Error> {
-        handler.read_query(params.query, params.database, params.cursor).await
+        handler.read_query(params.query, None, params.cursor).await
     }
 }
 

--- a/crates/mysql/src/tools/write_query.rs
+++ b/crates/mysql/src/tools/write_query.rs
@@ -1,7 +1,7 @@
 //! MCP tool: `writeQuery`.
 
 use dbmcp_pii::MaybeRedact as _;
-use dbmcp_server::types::{PinnedQueryRequest, QueryResponse, UnpinnedQueryRequest};
+use dbmcp_server::types::{QueryRequest, QueryResponse};
 
 use super::prelude::*;
 
@@ -22,7 +22,7 @@ fn annotations() -> ToolAnnotations {
 pub(crate) struct PinnedWriteQueryTool;
 
 impl ToolBase for PinnedWriteQueryTool {
-    type Parameter = PinnedQueryRequest;
+    type Parameter = QueryRequest;
     type Output = QueryResponse;
     type Error = ErrorData;
 
@@ -43,7 +43,7 @@ impl ToolBase for PinnedWriteQueryTool {
     }
 
     fn input_schema() -> Option<Arc<JsonObject>> {
-        Some(input_schema::<Self::Parameter>())
+        Some(input_schema::<Self::Parameter>(true))
     }
 
     fn output_schema() -> Option<Arc<JsonObject>> {
@@ -53,7 +53,7 @@ impl ToolBase for PinnedWriteQueryTool {
 
 impl AsyncTool<MysqlHandler> for PinnedWriteQueryTool {
     async fn invoke(handler: &MysqlHandler, params: Self::Parameter) -> Result<Self::Output, Self::Error> {
-        handler.write_query(params.query, None).await
+        handler.write_query(params.query, params.database).await
     }
 }
 
@@ -61,7 +61,7 @@ impl AsyncTool<MysqlHandler> for PinnedWriteQueryTool {
 pub(crate) struct UnpinnedWriteQueryTool;
 
 impl ToolBase for UnpinnedWriteQueryTool {
-    type Parameter = UnpinnedQueryRequest;
+    type Parameter = QueryRequest;
     type Output = QueryResponse;
     type Error = ErrorData;
 
@@ -82,7 +82,7 @@ impl ToolBase for UnpinnedWriteQueryTool {
     }
 
     fn input_schema() -> Option<Arc<JsonObject>> {
-        Some(input_schema::<Self::Parameter>())
+        Some(input_schema::<Self::Parameter>(false))
     }
 
     fn output_schema() -> Option<Arc<JsonObject>> {
@@ -92,7 +92,7 @@ impl ToolBase for UnpinnedWriteQueryTool {
 
 impl AsyncTool<MysqlHandler> for UnpinnedWriteQueryTool {
     async fn invoke(handler: &MysqlHandler, params: Self::Parameter) -> Result<Self::Output, Self::Error> {
-        handler.write_query(params.inner.query, params.database).await
+        handler.write_query(params.query, params.database).await
     }
 }
 

--- a/crates/mysql/src/tools/write_query.rs
+++ b/crates/mysql/src/tools/write_query.rs
@@ -53,7 +53,7 @@ impl ToolBase for PinnedWriteQueryTool {
 
 impl AsyncTool<MysqlHandler> for PinnedWriteQueryTool {
     async fn invoke(handler: &MysqlHandler, params: Self::Parameter) -> Result<Self::Output, Self::Error> {
-        handler.write_query(params.query, params.database).await
+        handler.write_query(params.query, None).await
     }
 }
 

--- a/crates/mysql/src/types.rs
+++ b/crates/mysql/src/types.rs
@@ -12,16 +12,9 @@ pub use dbmcp_server::types::{ListEntries, ListEntriesResponse};
 
 /// Request for the `dropTable` tool.
 #[derive(Debug, Default, Deserialize, JsonSchema)]
-pub struct PinnedDropTableRequest {
+pub struct DropTableRequest {
     /// Name of the table to drop. Must be non-empty.
     pub table: String,
-}
-
-/// Request for the `dropTable` tool.
-#[derive(Debug, Default, Deserialize, JsonSchema)]
-pub struct UnpinnedDropTableRequest {
-    #[serde(flatten)]
-    pub inner: PinnedDropTableRequest,
     /// Database containing the table. Defaults to the active database.
     #[serde(default)]
     pub database: Option<String>,
@@ -29,7 +22,7 @@ pub struct UnpinnedDropTableRequest {
 
 /// Request for the MySQL/MariaDB `listTables` tool — supports search + detailed mode.
 #[derive(Debug, Default, Deserialize, JsonSchema)]
-pub struct PinnedListTablesRequest {
+pub struct ListTablesRequest {
     /// Opaque cursor from a prior response's `nextCursor`; omit for the first page.
     #[serde(default)]
     pub cursor: Option<Cursor>,
@@ -42,13 +35,6 @@ pub struct PinnedListTablesRequest {
     /// omitted, each entry is the bare table-name string.
     #[serde(default)]
     pub detailed: bool,
-}
-
-/// Request for the MySQL/MariaDB `listTables` tool — supports search + detailed mode.
-#[derive(Debug, Default, Deserialize, JsonSchema)]
-pub struct UnpinnedListTablesRequest {
-    #[serde(flatten)]
-    pub inner: PinnedListTablesRequest,
     /// Database to list tables from. Defaults to the active database.
     #[serde(default)]
     pub database: Option<String>,
@@ -56,7 +42,7 @@ pub struct UnpinnedListTablesRequest {
 
 /// Request for the MySQL/MariaDB `listFunctions` tool — supports search + detailed mode.
 #[derive(Debug, Default, Deserialize, JsonSchema)]
-pub struct PinnedListFunctionsRequest {
+pub struct ListFunctionsRequest {
     /// Opaque cursor from a prior response's `nextCursor`; omit for the first page.
     #[serde(default)]
     pub cursor: Option<Cursor>,
@@ -71,13 +57,6 @@ pub struct PinnedListFunctionsRequest {
     /// function-name string.
     #[serde(default)]
     pub detailed: bool,
-}
-
-/// Request for the MySQL/MariaDB `listFunctions` tool — supports search + detailed mode.
-#[derive(Debug, Default, Deserialize, JsonSchema)]
-pub struct UnpinnedListFunctionsRequest {
-    #[serde(flatten)]
-    pub inner: PinnedListFunctionsRequest,
     /// Database to list functions from. Defaults to the active database.
     #[serde(default)]
     pub database: Option<String>,
@@ -85,7 +64,7 @@ pub struct UnpinnedListFunctionsRequest {
 
 /// Request for the MySQL/MariaDB `listProcedures` tool — supports search + detailed mode.
 #[derive(Debug, Default, Deserialize, JsonSchema)]
-pub struct PinnedListProceduresRequest {
+pub struct ListProceduresRequest {
     /// Opaque cursor from a prior response's `nextCursor`; omit for the first page.
     #[serde(default)]
     pub cursor: Option<Cursor>,
@@ -100,13 +79,6 @@ pub struct PinnedListProceduresRequest {
     /// is the bare procedure-name string.
     #[serde(default)]
     pub detailed: bool,
-}
-
-/// Request for the MySQL/MariaDB `listProcedures` tool — supports search + detailed mode.
-#[derive(Debug, Default, Deserialize, JsonSchema)]
-pub struct UnpinnedListProceduresRequest {
-    #[serde(flatten)]
-    pub inner: PinnedListProceduresRequest,
     /// Database to list procedures from. Defaults to the active database.
     #[serde(default)]
     pub database: Option<String>,
@@ -114,7 +86,7 @@ pub struct UnpinnedListProceduresRequest {
 
 /// Request for the MySQL/MariaDB `listViews` tool — supports search + detailed mode.
 #[derive(Debug, Default, Deserialize, JsonSchema)]
-pub struct PinnedListViewsRequest {
+pub struct ListViewsRequest {
     /// Opaque cursor from a prior response's `nextCursor`; omit for the first page.
     #[serde(default)]
     pub cursor: Option<Cursor>,
@@ -127,13 +99,6 @@ pub struct PinnedListViewsRequest {
     /// definition); when `false` or omitted, each entry is the bare view-name string.
     #[serde(default)]
     pub detailed: bool,
-}
-
-/// Request for the MySQL/MariaDB `listViews` tool — supports search + detailed mode.
-#[derive(Debug, Default, Deserialize, JsonSchema)]
-pub struct UnpinnedListViewsRequest {
-    #[serde(flatten)]
-    pub inner: PinnedListViewsRequest,
     /// Database to list views from. Defaults to the active database.
     #[serde(default)]
     pub database: Option<String>,
@@ -141,93 +106,91 @@ pub struct UnpinnedListViewsRequest {
 
 #[cfg(test)]
 mod tests {
-    use super::{
-        PinnedListFunctionsRequest, PinnedListProceduresRequest, PinnedListTablesRequest, PinnedListViewsRequest,
-        UnpinnedListFunctionsRequest, UnpinnedListProceduresRequest, UnpinnedListTablesRequest,
-        UnpinnedListViewsRequest,
-    };
+    use super::{ListFunctionsRequest, ListProceduresRequest, ListTablesRequest, ListViewsRequest};
 
     #[test]
-    fn unpinned_list_tables_request_defaults_to_brief_mode_without_search() {
-        let req: PinnedListTablesRequest = serde_json::from_str("{}").expect("empty object should parse");
+    fn list_tables_request_defaults_to_brief_mode_without_search() {
+        let req: ListTablesRequest = serde_json::from_str("{}").expect("empty object should parse");
         assert!(req.search.is_none());
         assert!(!req.detailed, "detailed must default to false");
+        assert!(req.database.is_none());
     }
 
     #[test]
-    fn unpinned_list_tables_request_accepts_search_and_detailed() {
-        let req: PinnedListTablesRequest =
+    fn list_tables_request_accepts_search_and_detailed() {
+        let req: ListTablesRequest = serde_json::from_str(r#"{"search": "order", "detailed": true}"#).expect("parse");
+        assert_eq!(req.search.as_deref(), Some("order"));
+        assert!(req.detailed);
+    }
+
+    #[test]
+    fn list_tables_request_accepts_database() {
+        let req: ListTablesRequest = serde_json::from_str(r#"{"database": "mydb"}"#).expect("parse");
+        assert_eq!(req.database.as_deref(), Some("mydb"));
+    }
+
+    #[test]
+    fn list_functions_request_defaults_to_brief_mode_without_search() {
+        let req: ListFunctionsRequest = serde_json::from_str("{}").expect("empty object should parse");
+        assert!(req.search.is_none());
+        assert!(!req.detailed, "detailed must default to false");
+        assert!(req.database.is_none());
+    }
+
+    #[test]
+    fn list_functions_request_accepts_search_and_detailed() {
+        let req: ListFunctionsRequest =
             serde_json::from_str(r#"{"search": "order", "detailed": true}"#).expect("parse");
         assert_eq!(req.search.as_deref(), Some("order"));
         assert!(req.detailed);
     }
 
     #[test]
-    fn pinned_list_tables_request_accepts_database() {
-        let req: UnpinnedListTablesRequest = serde_json::from_str(r#"{"database": "mydb"}"#).expect("parse");
+    fn list_functions_request_accepts_database() {
+        let req: ListFunctionsRequest = serde_json::from_str(r#"{"database": "mydb"}"#).expect("parse");
         assert_eq!(req.database.as_deref(), Some("mydb"));
     }
 
     #[test]
-    fn unpinned_list_functions_request_defaults_to_brief_mode_without_search() {
-        let req: PinnedListFunctionsRequest = serde_json::from_str("{}").expect("empty object should parse");
+    fn list_procedures_request_defaults_to_brief_mode_without_search() {
+        let req: ListProceduresRequest = serde_json::from_str("{}").expect("empty object should parse");
         assert!(req.search.is_none());
         assert!(!req.detailed, "detailed must default to false");
+        assert!(req.database.is_none());
     }
 
     #[test]
-    fn unpinned_list_functions_request_accepts_search_and_detailed() {
-        let req: PinnedListFunctionsRequest =
-            serde_json::from_str(r#"{"search": "order", "detailed": true}"#).expect("parse");
-        assert_eq!(req.search.as_deref(), Some("order"));
-        assert!(req.detailed);
-    }
-
-    #[test]
-    fn pinned_list_functions_request_accepts_database() {
-        let req: UnpinnedListFunctionsRequest = serde_json::from_str(r#"{"database": "mydb"}"#).expect("parse");
-        assert_eq!(req.database.as_deref(), Some("mydb"));
-    }
-
-    #[test]
-    fn unpinned_list_procedures_request_defaults_to_brief_mode_without_search() {
-        let req: PinnedListProceduresRequest = serde_json::from_str("{}").expect("empty object should parse");
-        assert!(req.search.is_none());
-        assert!(!req.detailed, "detailed must default to false");
-    }
-
-    #[test]
-    fn unpinned_list_procedures_request_accepts_search_and_detailed() {
-        let req: PinnedListProceduresRequest =
+    fn list_procedures_request_accepts_search_and_detailed() {
+        let req: ListProceduresRequest =
             serde_json::from_str(r#"{"search": "archive", "detailed": true}"#).expect("parse");
         assert_eq!(req.search.as_deref(), Some("archive"));
         assert!(req.detailed);
     }
 
     #[test]
-    fn pinned_list_procedures_request_accepts_database() {
-        let req: UnpinnedListProceduresRequest = serde_json::from_str(r#"{"database": "mydb"}"#).expect("parse");
+    fn list_procedures_request_accepts_database() {
+        let req: ListProceduresRequest = serde_json::from_str(r#"{"database": "mydb"}"#).expect("parse");
         assert_eq!(req.database.as_deref(), Some("mydb"));
     }
 
     #[test]
-    fn unpinned_list_views_request_defaults_to_brief_mode_without_search() {
-        let req: PinnedListViewsRequest = serde_json::from_str("{}").expect("empty object should parse");
+    fn list_views_request_defaults_to_brief_mode_without_search() {
+        let req: ListViewsRequest = serde_json::from_str("{}").expect("empty object should parse");
         assert!(req.search.is_none());
         assert!(!req.detailed, "detailed must default to false");
+        assert!(req.database.is_none());
     }
 
     #[test]
-    fn unpinned_list_views_request_accepts_search_and_detailed() {
-        let req: PinnedListViewsRequest =
-            serde_json::from_str(r#"{"search": "active", "detailed": true}"#).expect("parse");
+    fn list_views_request_accepts_search_and_detailed() {
+        let req: ListViewsRequest = serde_json::from_str(r#"{"search": "active", "detailed": true}"#).expect("parse");
         assert_eq!(req.search.as_deref(), Some("active"));
         assert!(req.detailed);
     }
 
     #[test]
-    fn pinned_list_views_request_accepts_database() {
-        let req: UnpinnedListViewsRequest = serde_json::from_str(r#"{"database": "mydb"}"#).expect("parse");
+    fn list_views_request_accepts_database() {
+        let req: ListViewsRequest = serde_json::from_str(r#"{"database": "mydb"}"#).expect("parse");
         assert_eq!(req.database.as_deref(), Some("mydb"));
     }
 }

--- a/crates/postgres/src/tools/create_database.rs
+++ b/crates/postgres/src/tools/create_database.rs
@@ -41,7 +41,7 @@ impl ToolBase for CreateDatabaseTool {
     }
 
     fn input_schema() -> Option<Arc<JsonObject>> {
-        Some(input_schema::<Self::Parameter>())
+        Some(input_schema::<Self::Parameter>(false))
     }
 
     fn output_schema() -> Option<Arc<JsonObject>> {

--- a/crates/postgres/src/tools/drop_database.rs
+++ b/crates/postgres/src/tools/drop_database.rs
@@ -41,7 +41,7 @@ impl ToolBase for DropDatabaseTool {
     }
 
     fn input_schema() -> Option<Arc<JsonObject>> {
-        Some(input_schema::<Self::Parameter>())
+        Some(input_schema::<Self::Parameter>(false))
     }
 
     fn output_schema() -> Option<Arc<JsonObject>> {

--- a/crates/postgres/src/tools/drop_table.rs
+++ b/crates/postgres/src/tools/drop_table.rs
@@ -5,7 +5,7 @@ use dbmcp_sql::SqlError;
 
 use super::prelude::*;
 use crate::connection::quote_ident;
-use crate::types::{PinnedDropTableRequest, UnpinnedDropTableRequest};
+use crate::types::DropTableRequest;
 
 const NAME: &str = "dropTable";
 const TITLE: &str = "Drop Table";
@@ -24,7 +24,7 @@ fn annotations() -> ToolAnnotations {
 pub(crate) struct PinnedDropTableTool;
 
 impl ToolBase for PinnedDropTableTool {
-    type Parameter = PinnedDropTableRequest;
+    type Parameter = DropTableRequest;
     type Output = MessageResponse;
     type Error = ErrorData;
 
@@ -45,7 +45,7 @@ impl ToolBase for PinnedDropTableTool {
     }
 
     fn input_schema() -> Option<Arc<JsonObject>> {
-        Some(input_schema::<Self::Parameter>())
+        Some(input_schema::<Self::Parameter>(true))
     }
 
     fn output_schema() -> Option<Arc<JsonObject>> {
@@ -55,7 +55,7 @@ impl ToolBase for PinnedDropTableTool {
 
 impl AsyncTool<PostgresHandler> for PinnedDropTableTool {
     async fn invoke(handler: &PostgresHandler, params: Self::Parameter) -> Result<Self::Output, Self::Error> {
-        handler.drop_table(None, params.table, params.cascade).await
+        handler.drop_table(params.database, params.table, params.cascade).await
     }
 }
 
@@ -63,7 +63,7 @@ impl AsyncTool<PostgresHandler> for PinnedDropTableTool {
 pub(crate) struct UnpinnedDropTableTool;
 
 impl ToolBase for UnpinnedDropTableTool {
-    type Parameter = UnpinnedDropTableRequest;
+    type Parameter = DropTableRequest;
     type Output = MessageResponse;
     type Error = ErrorData;
 
@@ -84,7 +84,7 @@ impl ToolBase for UnpinnedDropTableTool {
     }
 
     fn input_schema() -> Option<Arc<JsonObject>> {
-        Some(input_schema::<Self::Parameter>())
+        Some(input_schema::<Self::Parameter>(false))
     }
 
     fn output_schema() -> Option<Arc<JsonObject>> {
@@ -94,9 +94,7 @@ impl ToolBase for UnpinnedDropTableTool {
 
 impl AsyncTool<PostgresHandler> for UnpinnedDropTableTool {
     async fn invoke(handler: &PostgresHandler, params: Self::Parameter) -> Result<Self::Output, Self::Error> {
-        handler
-            .drop_table(params.database, params.inner.table, params.inner.cascade)
-            .await
+        handler.drop_table(params.database, params.table, params.cascade).await
     }
 }
 

--- a/crates/postgres/src/tools/drop_table.rs
+++ b/crates/postgres/src/tools/drop_table.rs
@@ -55,7 +55,7 @@ impl ToolBase for PinnedDropTableTool {
 
 impl AsyncTool<PostgresHandler> for PinnedDropTableTool {
     async fn invoke(handler: &PostgresHandler, params: Self::Parameter) -> Result<Self::Output, Self::Error> {
-        handler.drop_table(params.database, params.table, params.cascade).await
+        handler.drop_table(None, params.table, params.cascade).await
     }
 }
 

--- a/crates/postgres/src/tools/explain_query.rs
+++ b/crates/postgres/src/tools/explain_query.rs
@@ -54,9 +54,7 @@ impl ToolBase for PinnedExplainQueryTool {
 
 impl AsyncTool<PostgresHandler> for PinnedExplainQueryTool {
     async fn invoke(handler: &PostgresHandler, params: Self::Parameter) -> Result<Self::Output, Self::Error> {
-        handler
-            .explain_query(params.database, params.query, params.analyze)
-            .await
+        handler.explain_query(None, params.query, params.analyze).await
     }
 }
 

--- a/crates/postgres/src/tools/explain_query.rs
+++ b/crates/postgres/src/tools/explain_query.rs
@@ -1,7 +1,7 @@
 //! MCP tool: `explainQuery`.
 
 use dbmcp_pii::MaybeRedact as _;
-use dbmcp_server::types::{PinnedExplainQueryRequest, QueryResponse, UnpinnedExplainQueryRequest};
+use dbmcp_server::types::{ExplainQueryRequest, QueryResponse};
 use dbmcp_sql::validation::validate_read_only;
 
 use super::prelude::*;
@@ -23,7 +23,7 @@ fn annotations() -> ToolAnnotations {
 pub(crate) struct PinnedExplainQueryTool;
 
 impl ToolBase for PinnedExplainQueryTool {
-    type Parameter = PinnedExplainQueryRequest;
+    type Parameter = ExplainQueryRequest;
     type Output = QueryResponse;
     type Error = ErrorData;
 
@@ -44,7 +44,7 @@ impl ToolBase for PinnedExplainQueryTool {
     }
 
     fn input_schema() -> Option<Arc<JsonObject>> {
-        Some(input_schema::<Self::Parameter>())
+        Some(input_schema::<Self::Parameter>(true))
     }
 
     fn output_schema() -> Option<Arc<JsonObject>> {
@@ -54,7 +54,9 @@ impl ToolBase for PinnedExplainQueryTool {
 
 impl AsyncTool<PostgresHandler> for PinnedExplainQueryTool {
     async fn invoke(handler: &PostgresHandler, params: Self::Parameter) -> Result<Self::Output, Self::Error> {
-        handler.explain_query(None, params.query, params.analyze).await
+        handler
+            .explain_query(params.database, params.query, params.analyze)
+            .await
     }
 }
 
@@ -62,7 +64,7 @@ impl AsyncTool<PostgresHandler> for PinnedExplainQueryTool {
 pub(crate) struct UnpinnedExplainQueryTool;
 
 impl ToolBase for UnpinnedExplainQueryTool {
-    type Parameter = UnpinnedExplainQueryRequest;
+    type Parameter = ExplainQueryRequest;
     type Output = QueryResponse;
     type Error = ErrorData;
 
@@ -83,7 +85,7 @@ impl ToolBase for UnpinnedExplainQueryTool {
     }
 
     fn input_schema() -> Option<Arc<JsonObject>> {
-        Some(input_schema::<Self::Parameter>())
+        Some(input_schema::<Self::Parameter>(false))
     }
 
     fn output_schema() -> Option<Arc<JsonObject>> {
@@ -94,7 +96,7 @@ impl ToolBase for UnpinnedExplainQueryTool {
 impl AsyncTool<PostgresHandler> for UnpinnedExplainQueryTool {
     async fn invoke(handler: &PostgresHandler, params: Self::Parameter) -> Result<Self::Output, Self::Error> {
         handler
-            .explain_query(params.database, params.inner.query, params.inner.analyze)
+            .explain_query(params.database, params.query, params.analyze)
             .await
     }
 }

--- a/crates/postgres/src/tools/list_databases.rs
+++ b/crates/postgres/src/tools/list_databases.rs
@@ -40,7 +40,7 @@ impl ToolBase for ListDatabasesTool {
     }
 
     fn input_schema() -> Option<Arc<JsonObject>> {
-        Some(input_schema::<Self::Parameter>())
+        Some(input_schema::<Self::Parameter>(false))
     }
 
     fn output_schema() -> Option<Arc<JsonObject>> {

--- a/crates/postgres/src/tools/list_functions.rs
+++ b/crates/postgres/src/tools/list_functions.rs
@@ -3,7 +3,7 @@
 use dbmcp_server::pagination::{Cursor, Pager};
 
 use super::prelude::*;
-use crate::types::{ListEntriesResponse, PinnedListFunctionsRequest, UnpinnedListFunctionsRequest};
+use crate::types::{ListEntriesResponse, ListFunctionsRequest};
 
 const NAME: &str = "listFunctions";
 const TITLE: &str = "List Functions";
@@ -22,7 +22,7 @@ fn annotations() -> ToolAnnotations {
 pub(crate) struct PinnedListFunctionsTool;
 
 impl ToolBase for PinnedListFunctionsTool {
-    type Parameter = PinnedListFunctionsRequest;
+    type Parameter = ListFunctionsRequest;
     type Output = ListEntriesResponse;
     type Error = ErrorData;
 
@@ -43,7 +43,7 @@ impl ToolBase for PinnedListFunctionsTool {
     }
 
     fn input_schema() -> Option<Arc<JsonObject>> {
-        Some(input_schema::<Self::Parameter>())
+        Some(input_schema::<Self::Parameter>(true))
     }
 
     fn output_schema() -> Option<Arc<JsonObject>> {
@@ -54,7 +54,7 @@ impl ToolBase for PinnedListFunctionsTool {
 impl AsyncTool<PostgresHandler> for PinnedListFunctionsTool {
     async fn invoke(handler: &PostgresHandler, params: Self::Parameter) -> Result<Self::Output, Self::Error> {
         handler
-            .list_functions(None, params.cursor, params.search, params.detailed)
+            .list_functions(params.database, params.cursor, params.search, params.detailed)
             .await
     }
 }
@@ -63,7 +63,7 @@ impl AsyncTool<PostgresHandler> for PinnedListFunctionsTool {
 pub(crate) struct UnpinnedListFunctionsTool;
 
 impl ToolBase for UnpinnedListFunctionsTool {
-    type Parameter = UnpinnedListFunctionsRequest;
+    type Parameter = ListFunctionsRequest;
     type Output = ListEntriesResponse;
     type Error = ErrorData;
 
@@ -84,7 +84,7 @@ impl ToolBase for UnpinnedListFunctionsTool {
     }
 
     fn input_schema() -> Option<Arc<JsonObject>> {
-        Some(input_schema::<Self::Parameter>())
+        Some(input_schema::<Self::Parameter>(false))
     }
 
     fn output_schema() -> Option<Arc<JsonObject>> {
@@ -95,12 +95,7 @@ impl ToolBase for UnpinnedListFunctionsTool {
 impl AsyncTool<PostgresHandler> for UnpinnedListFunctionsTool {
     async fn invoke(handler: &PostgresHandler, params: Self::Parameter) -> Result<Self::Output, Self::Error> {
         handler
-            .list_functions(
-                params.database,
-                params.inner.cursor,
-                params.inner.search,
-                params.inner.detailed,
-            )
+            .list_functions(params.database, params.cursor, params.search, params.detailed)
             .await
     }
 }

--- a/crates/postgres/src/tools/list_functions.rs
+++ b/crates/postgres/src/tools/list_functions.rs
@@ -54,7 +54,7 @@ impl ToolBase for PinnedListFunctionsTool {
 impl AsyncTool<PostgresHandler> for PinnedListFunctionsTool {
     async fn invoke(handler: &PostgresHandler, params: Self::Parameter) -> Result<Self::Output, Self::Error> {
         handler
-            .list_functions(params.database, params.cursor, params.search, params.detailed)
+            .list_functions(None, params.cursor, params.search, params.detailed)
             .await
     }
 }

--- a/crates/postgres/src/tools/list_materialized_views.rs
+++ b/crates/postgres/src/tools/list_materialized_views.rs
@@ -3,7 +3,7 @@
 use dbmcp_server::pagination::{Cursor, Pager};
 
 use super::prelude::*;
-use crate::types::{ListEntriesResponse, PinnedListMaterializedViewsRequest, UnpinnedListMaterializedViewsRequest};
+use crate::types::{ListEntriesResponse, ListMaterializedViewsRequest};
 
 const NAME: &str = "listMaterializedViews";
 const TITLE: &str = "List Materialized Views";
@@ -22,7 +22,7 @@ fn annotations() -> ToolAnnotations {
 pub(crate) struct PinnedListMaterializedViewsTool;
 
 impl ToolBase for PinnedListMaterializedViewsTool {
-    type Parameter = PinnedListMaterializedViewsRequest;
+    type Parameter = ListMaterializedViewsRequest;
     type Output = ListEntriesResponse;
     type Error = ErrorData;
 
@@ -43,7 +43,7 @@ impl ToolBase for PinnedListMaterializedViewsTool {
     }
 
     fn input_schema() -> Option<Arc<JsonObject>> {
-        Some(input_schema::<Self::Parameter>())
+        Some(input_schema::<Self::Parameter>(true))
     }
 
     fn output_schema() -> Option<Arc<JsonObject>> {
@@ -54,7 +54,7 @@ impl ToolBase for PinnedListMaterializedViewsTool {
 impl AsyncTool<PostgresHandler> for PinnedListMaterializedViewsTool {
     async fn invoke(handler: &PostgresHandler, params: Self::Parameter) -> Result<Self::Output, Self::Error> {
         handler
-            .list_materialized_views(None, params.cursor, params.search, params.detailed)
+            .list_materialized_views(params.database, params.cursor, params.search, params.detailed)
             .await
     }
 }
@@ -63,7 +63,7 @@ impl AsyncTool<PostgresHandler> for PinnedListMaterializedViewsTool {
 pub(crate) struct UnpinnedListMaterializedViewsTool;
 
 impl ToolBase for UnpinnedListMaterializedViewsTool {
-    type Parameter = UnpinnedListMaterializedViewsRequest;
+    type Parameter = ListMaterializedViewsRequest;
     type Output = ListEntriesResponse;
     type Error = ErrorData;
 
@@ -84,7 +84,7 @@ impl ToolBase for UnpinnedListMaterializedViewsTool {
     }
 
     fn input_schema() -> Option<Arc<JsonObject>> {
-        Some(input_schema::<Self::Parameter>())
+        Some(input_schema::<Self::Parameter>(false))
     }
 
     fn output_schema() -> Option<Arc<JsonObject>> {
@@ -95,12 +95,7 @@ impl ToolBase for UnpinnedListMaterializedViewsTool {
 impl AsyncTool<PostgresHandler> for UnpinnedListMaterializedViewsTool {
     async fn invoke(handler: &PostgresHandler, params: Self::Parameter) -> Result<Self::Output, Self::Error> {
         handler
-            .list_materialized_views(
-                params.database,
-                params.inner.cursor,
-                params.inner.search,
-                params.inner.detailed,
-            )
+            .list_materialized_views(params.database, params.cursor, params.search, params.detailed)
             .await
     }
 }

--- a/crates/postgres/src/tools/list_materialized_views.rs
+++ b/crates/postgres/src/tools/list_materialized_views.rs
@@ -54,7 +54,7 @@ impl ToolBase for PinnedListMaterializedViewsTool {
 impl AsyncTool<PostgresHandler> for PinnedListMaterializedViewsTool {
     async fn invoke(handler: &PostgresHandler, params: Self::Parameter) -> Result<Self::Output, Self::Error> {
         handler
-            .list_materialized_views(params.database, params.cursor, params.search, params.detailed)
+            .list_materialized_views(None, params.cursor, params.search, params.detailed)
             .await
     }
 }

--- a/crates/postgres/src/tools/list_procedures.rs
+++ b/crates/postgres/src/tools/list_procedures.rs
@@ -3,7 +3,7 @@
 use dbmcp_server::pagination::{Cursor, Pager};
 
 use super::prelude::*;
-use crate::types::{ListEntriesResponse, PinnedListProceduresRequest, UnpinnedListProceduresRequest};
+use crate::types::{ListEntriesResponse, ListProceduresRequest};
 
 const NAME: &str = "listProcedures";
 const TITLE: &str = "List Procedures";
@@ -22,7 +22,7 @@ fn annotations() -> ToolAnnotations {
 pub(crate) struct PinnedListProceduresTool;
 
 impl ToolBase for PinnedListProceduresTool {
-    type Parameter = PinnedListProceduresRequest;
+    type Parameter = ListProceduresRequest;
     type Output = ListEntriesResponse;
     type Error = ErrorData;
 
@@ -43,7 +43,7 @@ impl ToolBase for PinnedListProceduresTool {
     }
 
     fn input_schema() -> Option<Arc<JsonObject>> {
-        Some(input_schema::<Self::Parameter>())
+        Some(input_schema::<Self::Parameter>(true))
     }
 
     fn output_schema() -> Option<Arc<JsonObject>> {
@@ -54,7 +54,7 @@ impl ToolBase for PinnedListProceduresTool {
 impl AsyncTool<PostgresHandler> for PinnedListProceduresTool {
     async fn invoke(handler: &PostgresHandler, params: Self::Parameter) -> Result<Self::Output, Self::Error> {
         handler
-            .list_procedures(None, params.cursor, params.search, params.detailed)
+            .list_procedures(params.database, params.cursor, params.search, params.detailed)
             .await
     }
 }
@@ -63,7 +63,7 @@ impl AsyncTool<PostgresHandler> for PinnedListProceduresTool {
 pub(crate) struct UnpinnedListProceduresTool;
 
 impl ToolBase for UnpinnedListProceduresTool {
-    type Parameter = UnpinnedListProceduresRequest;
+    type Parameter = ListProceduresRequest;
     type Output = ListEntriesResponse;
     type Error = ErrorData;
 
@@ -84,7 +84,7 @@ impl ToolBase for UnpinnedListProceduresTool {
     }
 
     fn input_schema() -> Option<Arc<JsonObject>> {
-        Some(input_schema::<Self::Parameter>())
+        Some(input_schema::<Self::Parameter>(false))
     }
 
     fn output_schema() -> Option<Arc<JsonObject>> {
@@ -95,12 +95,7 @@ impl ToolBase for UnpinnedListProceduresTool {
 impl AsyncTool<PostgresHandler> for UnpinnedListProceduresTool {
     async fn invoke(handler: &PostgresHandler, params: Self::Parameter) -> Result<Self::Output, Self::Error> {
         handler
-            .list_procedures(
-                params.database,
-                params.inner.cursor,
-                params.inner.search,
-                params.inner.detailed,
-            )
+            .list_procedures(params.database, params.cursor, params.search, params.detailed)
             .await
     }
 }

--- a/crates/postgres/src/tools/list_procedures.rs
+++ b/crates/postgres/src/tools/list_procedures.rs
@@ -54,7 +54,7 @@ impl ToolBase for PinnedListProceduresTool {
 impl AsyncTool<PostgresHandler> for PinnedListProceduresTool {
     async fn invoke(handler: &PostgresHandler, params: Self::Parameter) -> Result<Self::Output, Self::Error> {
         handler
-            .list_procedures(params.database, params.cursor, params.search, params.detailed)
+            .list_procedures(None, params.cursor, params.search, params.detailed)
             .await
     }
 }

--- a/crates/postgres/src/tools/list_tables.rs
+++ b/crates/postgres/src/tools/list_tables.rs
@@ -3,7 +3,7 @@
 use dbmcp_server::pagination::{Cursor, Pager};
 
 use super::prelude::*;
-use crate::types::{ListEntriesResponse, PinnedListTablesRequest, UnpinnedListTablesRequest};
+use crate::types::{ListEntriesResponse, ListTablesRequest};
 
 const NAME: &str = "listTables";
 const TITLE: &str = "List Tables";
@@ -22,7 +22,7 @@ fn annotations() -> ToolAnnotations {
 pub(crate) struct PinnedListTablesTool;
 
 impl ToolBase for PinnedListTablesTool {
-    type Parameter = PinnedListTablesRequest;
+    type Parameter = ListTablesRequest;
     type Output = ListEntriesResponse;
     type Error = ErrorData;
 
@@ -43,7 +43,7 @@ impl ToolBase for PinnedListTablesTool {
     }
 
     fn input_schema() -> Option<Arc<JsonObject>> {
-        Some(input_schema::<Self::Parameter>())
+        Some(input_schema::<Self::Parameter>(true))
     }
 
     fn output_schema() -> Option<Arc<JsonObject>> {
@@ -54,7 +54,7 @@ impl ToolBase for PinnedListTablesTool {
 impl AsyncTool<PostgresHandler> for PinnedListTablesTool {
     async fn invoke(handler: &PostgresHandler, params: Self::Parameter) -> Result<Self::Output, Self::Error> {
         handler
-            .list_tables(None, params.cursor, params.search, params.detailed)
+            .list_tables(params.database, params.cursor, params.search, params.detailed)
             .await
     }
 }
@@ -63,7 +63,7 @@ impl AsyncTool<PostgresHandler> for PinnedListTablesTool {
 pub(crate) struct UnpinnedListTablesTool;
 
 impl ToolBase for UnpinnedListTablesTool {
-    type Parameter = UnpinnedListTablesRequest;
+    type Parameter = ListTablesRequest;
     type Output = ListEntriesResponse;
     type Error = ErrorData;
 
@@ -84,7 +84,7 @@ impl ToolBase for UnpinnedListTablesTool {
     }
 
     fn input_schema() -> Option<Arc<JsonObject>> {
-        Some(input_schema::<Self::Parameter>())
+        Some(input_schema::<Self::Parameter>(false))
     }
 
     fn output_schema() -> Option<Arc<JsonObject>> {
@@ -95,12 +95,7 @@ impl ToolBase for UnpinnedListTablesTool {
 impl AsyncTool<PostgresHandler> for UnpinnedListTablesTool {
     async fn invoke(handler: &PostgresHandler, params: Self::Parameter) -> Result<Self::Output, Self::Error> {
         handler
-            .list_tables(
-                params.database,
-                params.inner.cursor,
-                params.inner.search,
-                params.inner.detailed,
-            )
+            .list_tables(params.database, params.cursor, params.search, params.detailed)
             .await
     }
 }

--- a/crates/postgres/src/tools/list_tables.rs
+++ b/crates/postgres/src/tools/list_tables.rs
@@ -54,7 +54,7 @@ impl ToolBase for PinnedListTablesTool {
 impl AsyncTool<PostgresHandler> for PinnedListTablesTool {
     async fn invoke(handler: &PostgresHandler, params: Self::Parameter) -> Result<Self::Output, Self::Error> {
         handler
-            .list_tables(params.database, params.cursor, params.search, params.detailed)
+            .list_tables(None, params.cursor, params.search, params.detailed)
             .await
     }
 }

--- a/crates/postgres/src/tools/list_triggers.rs
+++ b/crates/postgres/src/tools/list_triggers.rs
@@ -54,7 +54,7 @@ impl ToolBase for PinnedListTriggersTool {
 impl AsyncTool<PostgresHandler> for PinnedListTriggersTool {
     async fn invoke(handler: &PostgresHandler, params: Self::Parameter) -> Result<Self::Output, Self::Error> {
         handler
-            .list_triggers(params.database, params.cursor, params.search, params.detailed)
+            .list_triggers(None, params.cursor, params.search, params.detailed)
             .await
     }
 }

--- a/crates/postgres/src/tools/list_triggers.rs
+++ b/crates/postgres/src/tools/list_triggers.rs
@@ -3,7 +3,7 @@
 use dbmcp_server::pagination::{Cursor, Pager};
 
 use super::prelude::*;
-use crate::types::{ListEntriesResponse, PinnedListTriggersRequest, UnpinnedListTriggersRequest};
+use crate::types::{ListEntriesResponse, ListTriggersRequest};
 
 const NAME: &str = "listTriggers";
 const TITLE: &str = "List Triggers";
@@ -22,7 +22,7 @@ fn annotations() -> ToolAnnotations {
 pub(crate) struct PinnedListTriggersTool;
 
 impl ToolBase for PinnedListTriggersTool {
-    type Parameter = PinnedListTriggersRequest;
+    type Parameter = ListTriggersRequest;
     type Output = ListEntriesResponse;
     type Error = ErrorData;
 
@@ -43,7 +43,7 @@ impl ToolBase for PinnedListTriggersTool {
     }
 
     fn input_schema() -> Option<Arc<JsonObject>> {
-        Some(input_schema::<Self::Parameter>())
+        Some(input_schema::<Self::Parameter>(true))
     }
 
     fn output_schema() -> Option<Arc<JsonObject>> {
@@ -54,7 +54,7 @@ impl ToolBase for PinnedListTriggersTool {
 impl AsyncTool<PostgresHandler> for PinnedListTriggersTool {
     async fn invoke(handler: &PostgresHandler, params: Self::Parameter) -> Result<Self::Output, Self::Error> {
         handler
-            .list_triggers(None, params.cursor, params.search, params.detailed)
+            .list_triggers(params.database, params.cursor, params.search, params.detailed)
             .await
     }
 }
@@ -63,7 +63,7 @@ impl AsyncTool<PostgresHandler> for PinnedListTriggersTool {
 pub(crate) struct UnpinnedListTriggersTool;
 
 impl ToolBase for UnpinnedListTriggersTool {
-    type Parameter = UnpinnedListTriggersRequest;
+    type Parameter = ListTriggersRequest;
     type Output = ListEntriesResponse;
     type Error = ErrorData;
 
@@ -84,7 +84,7 @@ impl ToolBase for UnpinnedListTriggersTool {
     }
 
     fn input_schema() -> Option<Arc<JsonObject>> {
-        Some(input_schema::<Self::Parameter>())
+        Some(input_schema::<Self::Parameter>(false))
     }
 
     fn output_schema() -> Option<Arc<JsonObject>> {
@@ -95,12 +95,7 @@ impl ToolBase for UnpinnedListTriggersTool {
 impl AsyncTool<PostgresHandler> for UnpinnedListTriggersTool {
     async fn invoke(handler: &PostgresHandler, params: Self::Parameter) -> Result<Self::Output, Self::Error> {
         handler
-            .list_triggers(
-                params.database,
-                params.inner.cursor,
-                params.inner.search,
-                params.inner.detailed,
-            )
+            .list_triggers(params.database, params.cursor, params.search, params.detailed)
             .await
     }
 }

--- a/crates/postgres/src/tools/list_views.rs
+++ b/crates/postgres/src/tools/list_views.rs
@@ -3,7 +3,7 @@
 use dbmcp_server::pagination::{Cursor, Pager};
 
 use super::prelude::*;
-use crate::types::{ListEntriesResponse, PinnedListViewsRequest, UnpinnedListViewsRequest};
+use crate::types::{ListEntriesResponse, ListViewsRequest};
 
 const NAME: &str = "listViews";
 const TITLE: &str = "List Views";
@@ -22,7 +22,7 @@ fn annotations() -> ToolAnnotations {
 pub(crate) struct PinnedListViewsTool;
 
 impl ToolBase for PinnedListViewsTool {
-    type Parameter = PinnedListViewsRequest;
+    type Parameter = ListViewsRequest;
     type Output = ListEntriesResponse;
     type Error = ErrorData;
 
@@ -43,7 +43,7 @@ impl ToolBase for PinnedListViewsTool {
     }
 
     fn input_schema() -> Option<Arc<JsonObject>> {
-        Some(input_schema::<Self::Parameter>())
+        Some(input_schema::<Self::Parameter>(true))
     }
 
     fn output_schema() -> Option<Arc<JsonObject>> {
@@ -54,7 +54,7 @@ impl ToolBase for PinnedListViewsTool {
 impl AsyncTool<PostgresHandler> for PinnedListViewsTool {
     async fn invoke(handler: &PostgresHandler, params: Self::Parameter) -> Result<Self::Output, Self::Error> {
         handler
-            .list_views(None, params.cursor, params.search, params.detailed)
+            .list_views(params.database, params.cursor, params.search, params.detailed)
             .await
     }
 }
@@ -63,7 +63,7 @@ impl AsyncTool<PostgresHandler> for PinnedListViewsTool {
 pub(crate) struct UnpinnedListViewsTool;
 
 impl ToolBase for UnpinnedListViewsTool {
-    type Parameter = UnpinnedListViewsRequest;
+    type Parameter = ListViewsRequest;
     type Output = ListEntriesResponse;
     type Error = ErrorData;
 
@@ -84,7 +84,7 @@ impl ToolBase for UnpinnedListViewsTool {
     }
 
     fn input_schema() -> Option<Arc<JsonObject>> {
-        Some(input_schema::<Self::Parameter>())
+        Some(input_schema::<Self::Parameter>(false))
     }
 
     fn output_schema() -> Option<Arc<JsonObject>> {
@@ -95,12 +95,7 @@ impl ToolBase for UnpinnedListViewsTool {
 impl AsyncTool<PostgresHandler> for UnpinnedListViewsTool {
     async fn invoke(handler: &PostgresHandler, params: Self::Parameter) -> Result<Self::Output, Self::Error> {
         handler
-            .list_views(
-                params.database,
-                params.inner.cursor,
-                params.inner.search,
-                params.inner.detailed,
-            )
+            .list_views(params.database, params.cursor, params.search, params.detailed)
             .await
     }
 }

--- a/crates/postgres/src/tools/list_views.rs
+++ b/crates/postgres/src/tools/list_views.rs
@@ -54,7 +54,7 @@ impl ToolBase for PinnedListViewsTool {
 impl AsyncTool<PostgresHandler> for PinnedListViewsTool {
     async fn invoke(handler: &PostgresHandler, params: Self::Parameter) -> Result<Self::Output, Self::Error> {
         handler
-            .list_views(params.database, params.cursor, params.search, params.detailed)
+            .list_views(None, params.cursor, params.search, params.detailed)
             .await
     }
 }

--- a/crates/postgres/src/tools/read_query.rs
+++ b/crates/postgres/src/tools/read_query.rs
@@ -57,7 +57,7 @@ impl ToolBase for PinnedReadQueryTool {
 
 impl AsyncTool<PostgresHandler> for PinnedReadQueryTool {
     async fn invoke(handler: &PostgresHandler, params: Self::Parameter) -> Result<Self::Output, Self::Error> {
-        handler.read_query(params.query, params.database, params.cursor).await
+        handler.read_query(params.query, None, params.cursor).await
     }
 }
 

--- a/crates/postgres/src/tools/read_query.rs
+++ b/crates/postgres/src/tools/read_query.rs
@@ -2,7 +2,7 @@
 
 use dbmcp_pii::MaybeRedact as _;
 use dbmcp_server::pagination::{Cursor, Pager};
-use dbmcp_server::types::{PinnedReadQueryRequest, ReadQueryResponse, UnpinnedReadQueryRequest};
+use dbmcp_server::types::{ReadQueryRequest, ReadQueryResponse};
 use dbmcp_sql::StatementKind;
 use dbmcp_sql::pagination::with_limit_offset;
 use dbmcp_sql::validation::validate_read_only;
@@ -26,7 +26,7 @@ fn annotations() -> ToolAnnotations {
 pub(crate) struct PinnedReadQueryTool;
 
 impl ToolBase for PinnedReadQueryTool {
-    type Parameter = PinnedReadQueryRequest;
+    type Parameter = ReadQueryRequest;
     type Output = ReadQueryResponse;
     type Error = ErrorData;
 
@@ -47,7 +47,7 @@ impl ToolBase for PinnedReadQueryTool {
     }
 
     fn input_schema() -> Option<Arc<JsonObject>> {
-        Some(input_schema::<Self::Parameter>())
+        Some(input_schema::<Self::Parameter>(true))
     }
 
     fn output_schema() -> Option<Arc<JsonObject>> {
@@ -57,7 +57,7 @@ impl ToolBase for PinnedReadQueryTool {
 
 impl AsyncTool<PostgresHandler> for PinnedReadQueryTool {
     async fn invoke(handler: &PostgresHandler, params: Self::Parameter) -> Result<Self::Output, Self::Error> {
-        handler.read_query(params.query, None, params.cursor).await
+        handler.read_query(params.query, params.database, params.cursor).await
     }
 }
 
@@ -65,7 +65,7 @@ impl AsyncTool<PostgresHandler> for PinnedReadQueryTool {
 pub(crate) struct UnpinnedReadQueryTool;
 
 impl ToolBase for UnpinnedReadQueryTool {
-    type Parameter = UnpinnedReadQueryRequest;
+    type Parameter = ReadQueryRequest;
     type Output = ReadQueryResponse;
     type Error = ErrorData;
 
@@ -86,7 +86,7 @@ impl ToolBase for UnpinnedReadQueryTool {
     }
 
     fn input_schema() -> Option<Arc<JsonObject>> {
-        Some(input_schema::<Self::Parameter>())
+        Some(input_schema::<Self::Parameter>(false))
     }
 
     fn output_schema() -> Option<Arc<JsonObject>> {
@@ -96,9 +96,7 @@ impl ToolBase for UnpinnedReadQueryTool {
 
 impl AsyncTool<PostgresHandler> for UnpinnedReadQueryTool {
     async fn invoke(handler: &PostgresHandler, params: Self::Parameter) -> Result<Self::Output, Self::Error> {
-        handler
-            .read_query(params.inner.query, params.database, params.inner.cursor)
-            .await
+        handler.read_query(params.query, params.database, params.cursor).await
     }
 }
 

--- a/crates/postgres/src/tools/write_query.rs
+++ b/crates/postgres/src/tools/write_query.rs
@@ -1,7 +1,7 @@
 //! MCP tool: `writeQuery`.
 
 use dbmcp_pii::MaybeRedact as _;
-use dbmcp_server::types::{PinnedQueryRequest, QueryResponse, UnpinnedQueryRequest};
+use dbmcp_server::types::{QueryRequest, QueryResponse};
 
 use super::prelude::*;
 
@@ -22,7 +22,7 @@ fn annotations() -> ToolAnnotations {
 pub(crate) struct PinnedWriteQueryTool;
 
 impl ToolBase for PinnedWriteQueryTool {
-    type Parameter = PinnedQueryRequest;
+    type Parameter = QueryRequest;
     type Output = QueryResponse;
     type Error = ErrorData;
 
@@ -43,7 +43,7 @@ impl ToolBase for PinnedWriteQueryTool {
     }
 
     fn input_schema() -> Option<Arc<JsonObject>> {
-        Some(input_schema::<Self::Parameter>())
+        Some(input_schema::<Self::Parameter>(true))
     }
 
     fn output_schema() -> Option<Arc<JsonObject>> {
@@ -53,7 +53,7 @@ impl ToolBase for PinnedWriteQueryTool {
 
 impl AsyncTool<PostgresHandler> for PinnedWriteQueryTool {
     async fn invoke(handler: &PostgresHandler, params: Self::Parameter) -> Result<Self::Output, Self::Error> {
-        handler.write_query(params.query, None).await
+        handler.write_query(params.query, params.database).await
     }
 }
 
@@ -61,7 +61,7 @@ impl AsyncTool<PostgresHandler> for PinnedWriteQueryTool {
 pub(crate) struct UnpinnedWriteQueryTool;
 
 impl ToolBase for UnpinnedWriteQueryTool {
-    type Parameter = UnpinnedQueryRequest;
+    type Parameter = QueryRequest;
     type Output = QueryResponse;
     type Error = ErrorData;
 
@@ -82,7 +82,7 @@ impl ToolBase for UnpinnedWriteQueryTool {
     }
 
     fn input_schema() -> Option<Arc<JsonObject>> {
-        Some(input_schema::<Self::Parameter>())
+        Some(input_schema::<Self::Parameter>(false))
     }
 
     fn output_schema() -> Option<Arc<JsonObject>> {
@@ -92,7 +92,7 @@ impl ToolBase for UnpinnedWriteQueryTool {
 
 impl AsyncTool<PostgresHandler> for UnpinnedWriteQueryTool {
     async fn invoke(handler: &PostgresHandler, params: Self::Parameter) -> Result<Self::Output, Self::Error> {
-        handler.write_query(params.inner.query, params.database).await
+        handler.write_query(params.query, params.database).await
     }
 }
 

--- a/crates/postgres/src/tools/write_query.rs
+++ b/crates/postgres/src/tools/write_query.rs
@@ -53,7 +53,7 @@ impl ToolBase for PinnedWriteQueryTool {
 
 impl AsyncTool<PostgresHandler> for PinnedWriteQueryTool {
     async fn invoke(handler: &PostgresHandler, params: Self::Parameter) -> Result<Self::Output, Self::Error> {
-        handler.write_query(params.query, params.database).await
+        handler.write_query(params.query, None).await
     }
 }
 

--- a/crates/postgres/src/types.rs
+++ b/crates/postgres/src/types.rs
@@ -1,33 +1,24 @@
 //! PostgreSQL-specific MCP tool request types.
 //!
-//! Shared `listTriggers` types (`UnpinnedListTriggersRequest`, `PinnedListTriggersRequest`)
-//! and the shared brief/detailed payload (`ListEntries`, `ListEntriesResponse`) live in
-//! the `dbmcp-server` crate; they are re-exported here so call sites can keep importing
-//! them from `crate::types`.
+//! Shared `ListTriggersRequest` and the shared brief/detailed payload
+//! (`ListEntries`, `ListEntriesResponse`) live in the `dbmcp-server` crate;
+//! they are re-exported here so call sites can keep importing them from
+//! `crate::types`.
 
 use dbmcp_server::pagination::Cursor;
 use schemars::JsonSchema;
 use serde::Deserialize;
 
-pub use dbmcp_server::types::{
-    ListEntries, ListEntriesResponse, PinnedListTriggersRequest, UnpinnedListTriggersRequest,
-};
+pub use dbmcp_server::types::{ListEntries, ListEntriesResponse, ListTriggersRequest};
 
 /// Request for the `dropTable` tool.
 #[derive(Debug, Default, Deserialize, JsonSchema)]
-pub struct PinnedDropTableRequest {
+pub struct DropTableRequest {
     /// Name of the table to drop. Must be non-empty.
     pub table: String,
     /// If true, use CASCADE to also drop dependent foreign key constraints. Defaults to false.
     #[serde(default)]
     pub cascade: bool,
-}
-
-/// Request for the `dropTable` tool.
-#[derive(Debug, Default, Deserialize, JsonSchema)]
-pub struct UnpinnedDropTableRequest {
-    #[serde(flatten)]
-    pub inner: PinnedDropTableRequest,
     /// Database containing the table. Defaults to the active database.
     #[serde(default)]
     pub database: Option<String>,
@@ -35,7 +26,7 @@ pub struct UnpinnedDropTableRequest {
 
 /// Request for the Postgres `listTables` tool — extends the shared shape with `search` and `detailed`.
 #[derive(Debug, Default, Deserialize, JsonSchema)]
-pub struct PinnedListTablesRequest {
+pub struct ListTablesRequest {
     /// Opaque cursor from a prior response's `nextCursor`; omit for the first page.
     #[serde(default)]
     pub cursor: Option<Cursor>,
@@ -48,13 +39,6 @@ pub struct PinnedListTablesRequest {
     /// omitted, each entry is the bare table-name string.
     #[serde(default)]
     pub detailed: bool,
-}
-
-/// Request for the Postgres `listTables` tool — extends the shared shape with `search` and `detailed`.
-#[derive(Debug, Default, Deserialize, JsonSchema)]
-pub struct UnpinnedListTablesRequest {
-    #[serde(flatten)]
-    pub inner: PinnedListTablesRequest,
     /// Database to list tables from. Defaults to the active database.
     #[serde(default)]
     pub database: Option<String>,
@@ -62,7 +46,7 @@ pub struct UnpinnedListTablesRequest {
 
 /// Request for the Postgres `listFunctions` tool — extends the shared shape with `search` and `detailed`.
 #[derive(Debug, Default, Deserialize, JsonSchema)]
-pub struct PinnedListFunctionsRequest {
+pub struct ListFunctionsRequest {
     /// Opaque cursor from a prior response's `nextCursor`; omit for the first page.
     #[serde(default)]
     pub cursor: Option<Cursor>,
@@ -76,13 +60,6 @@ pub struct PinnedListFunctionsRequest {
     /// each entry is the bare function-name string.
     #[serde(default)]
     pub detailed: bool,
-}
-
-/// Request for the Postgres `listFunctions` tool — extends the shared shape with `search` and `detailed`.
-#[derive(Debug, Default, Deserialize, JsonSchema)]
-pub struct UnpinnedListFunctionsRequest {
-    #[serde(flatten)]
-    pub inner: PinnedListFunctionsRequest,
     /// Database to list functions from. Defaults to the active database.
     #[serde(default)]
     pub database: Option<String>,
@@ -90,7 +67,7 @@ pub struct UnpinnedListFunctionsRequest {
 
 /// Request for the Postgres `listViews` tool — extends the shared shape with `search` and `detailed`.
 #[derive(Debug, Default, Deserialize, JsonSchema)]
-pub struct PinnedListViewsRequest {
+pub struct ListViewsRequest {
     /// Opaque cursor from a prior response's `nextCursor`; omit for the first page.
     #[serde(default)]
     pub cursor: Option<Cursor>,
@@ -103,13 +80,6 @@ pub struct PinnedListViewsRequest {
     /// view-name string.
     #[serde(default)]
     pub detailed: bool,
-}
-
-/// Request for the Postgres `listViews` tool — extends the shared shape with `search` and `detailed`.
-#[derive(Debug, Default, Deserialize, JsonSchema)]
-pub struct UnpinnedListViewsRequest {
-    #[serde(flatten)]
-    pub inner: PinnedListViewsRequest,
     /// Database to list views from. Defaults to the active database.
     #[serde(default)]
     pub database: Option<String>,
@@ -117,7 +87,7 @@ pub struct UnpinnedListViewsRequest {
 
 /// Request for the Postgres `listMaterializedViews` tool — extends the shared shape with `search` and `detailed`.
 #[derive(Debug, Default, Deserialize, JsonSchema)]
-pub struct PinnedListMaterializedViewsRequest {
+pub struct ListMaterializedViewsRequest {
     /// Opaque cursor from a prior response's `nextCursor`; omit for the first page.
     #[serde(default)]
     pub cursor: Option<Cursor>,
@@ -130,13 +100,6 @@ pub struct PinnedListMaterializedViewsRequest {
     /// entry is the bare matview-name string.
     #[serde(default)]
     pub detailed: bool,
-}
-
-/// Request for the Postgres `listMaterializedViews` tool — extends the shared shape with `search` and `detailed`.
-#[derive(Debug, Default, Deserialize, JsonSchema)]
-pub struct UnpinnedListMaterializedViewsRequest {
-    #[serde(flatten)]
-    pub inner: PinnedListMaterializedViewsRequest,
     /// Database to list materialized views from. Defaults to the active database.
     #[serde(default)]
     pub database: Option<String>,
@@ -144,7 +107,7 @@ pub struct UnpinnedListMaterializedViewsRequest {
 
 /// Request for the Postgres `listProcedures` tool — extends the shared shape with `search` and `detailed`.
 #[derive(Debug, Default, Deserialize, JsonSchema)]
-pub struct PinnedListProceduresRequest {
+pub struct ListProceduresRequest {
     /// Opaque cursor from a prior response's `nextCursor`; omit for the first page.
     #[serde(default)]
     pub cursor: Option<Cursor>,
@@ -157,13 +120,6 @@ pub struct PinnedListProceduresRequest {
     /// or omitted, each entry is the bare procedure-name string.
     #[serde(default)]
     pub detailed: bool,
-}
-
-/// Request for the Postgres `listProcedures` tool — extends the shared shape with `search` and `detailed`.
-#[derive(Debug, Default, Deserialize, JsonSchema)]
-pub struct UnpinnedListProceduresRequest {
-    #[serde(flatten)]
-    pub inner: PinnedListProceduresRequest,
     /// Database to list procedures from. Defaults to the active database.
     #[serde(default)]
     pub database: Option<String>,
@@ -172,118 +128,117 @@ pub struct UnpinnedListProceduresRequest {
 #[cfg(test)]
 mod tests {
     use super::{
-        PinnedListFunctionsRequest, PinnedListMaterializedViewsRequest, PinnedListProceduresRequest,
-        PinnedListTablesRequest, PinnedListViewsRequest, UnpinnedListFunctionsRequest,
-        UnpinnedListMaterializedViewsRequest, UnpinnedListProceduresRequest, UnpinnedListTablesRequest,
-        UnpinnedListViewsRequest,
+        ListFunctionsRequest, ListMaterializedViewsRequest, ListProceduresRequest, ListTablesRequest, ListViewsRequest,
     };
 
     #[test]
-    fn unpinned_list_tables_request_defaults_to_brief_mode_without_search() {
-        let req: PinnedListTablesRequest = serde_json::from_str("{}").expect("empty object should parse");
+    fn list_tables_request_defaults_to_brief_mode_without_search() {
+        let req: ListTablesRequest = serde_json::from_str("{}").expect("empty object should parse");
         assert!(req.search.is_none());
         assert!(!req.detailed, "detailed must default to false");
+        assert!(req.database.is_none());
     }
 
     #[test]
-    fn unpinned_list_tables_request_accepts_search_and_detailed() {
-        let req: PinnedListTablesRequest =
-            serde_json::from_str(r#"{"search": "order", "detailed": true}"#).expect("parse");
+    fn list_tables_request_accepts_search_and_detailed() {
+        let req: ListTablesRequest = serde_json::from_str(r#"{"search": "order", "detailed": true}"#).expect("parse");
         assert_eq!(req.search.as_deref(), Some("order"));
         assert!(req.detailed);
     }
 
     #[test]
-    fn pinned_list_tables_request_accepts_database_and_inner_fields() {
-        let req: UnpinnedListTablesRequest =
-            serde_json::from_str(r#"{"database": "mydb", "search": "order"}"#).expect("parse");
+    fn list_tables_request_accepts_database_and_other_fields() {
+        let req: ListTablesRequest = serde_json::from_str(r#"{"database": "mydb", "search": "order"}"#).expect("parse");
         assert_eq!(req.database.as_deref(), Some("mydb"));
-        assert_eq!(req.inner.search.as_deref(), Some("order"));
+        assert_eq!(req.search.as_deref(), Some("order"));
     }
 
     #[test]
-    fn unpinned_list_functions_request_defaults_to_brief_mode_without_search() {
-        let req: PinnedListFunctionsRequest = serde_json::from_str("{}").expect("empty object should parse");
+    fn list_functions_request_defaults_to_brief_mode_without_search() {
+        let req: ListFunctionsRequest = serde_json::from_str("{}").expect("empty object should parse");
         assert!(req.search.is_none());
         assert!(!req.detailed, "detailed must default to false");
+        assert!(req.database.is_none());
     }
 
     #[test]
-    fn unpinned_list_functions_request_accepts_search_and_detailed() {
-        let req: PinnedListFunctionsRequest =
+    fn list_functions_request_accepts_search_and_detailed() {
+        let req: ListFunctionsRequest =
             serde_json::from_str(r#"{"search": "order", "detailed": true}"#).expect("parse");
         assert_eq!(req.search.as_deref(), Some("order"));
         assert!(req.detailed);
     }
 
     #[test]
-    fn pinned_list_functions_request_accepts_database() {
-        let req: UnpinnedListFunctionsRequest =
+    fn list_functions_request_accepts_database() {
+        let req: ListFunctionsRequest =
             serde_json::from_str(r#"{"database": "mydb", "search": "calc"}"#).expect("parse");
         assert_eq!(req.database.as_deref(), Some("mydb"));
-        assert_eq!(req.inner.search.as_deref(), Some("calc"));
+        assert_eq!(req.search.as_deref(), Some("calc"));
     }
 
     #[test]
-    fn unpinned_list_procedures_request_defaults_to_brief_mode_without_search() {
-        let req: PinnedListProceduresRequest = serde_json::from_str("{}").expect("empty object should parse");
+    fn list_procedures_request_defaults_to_brief_mode_without_search() {
+        let req: ListProceduresRequest = serde_json::from_str("{}").expect("empty object should parse");
         assert!(req.search.is_none());
         assert!(!req.detailed, "detailed must default to false");
+        assert!(req.database.is_none());
     }
 
     #[test]
-    fn unpinned_list_procedures_request_accepts_search_and_detailed() {
-        let req: PinnedListProceduresRequest =
+    fn list_procedures_request_accepts_search_and_detailed() {
+        let req: ListProceduresRequest =
             serde_json::from_str(r#"{"search": "archive", "detailed": true}"#).expect("parse");
         assert_eq!(req.search.as_deref(), Some("archive"));
         assert!(req.detailed);
     }
 
     #[test]
-    fn pinned_list_procedures_request_accepts_database() {
-        let req: UnpinnedListProceduresRequest = serde_json::from_str(r#"{"database": "mydb"}"#).expect("parse");
+    fn list_procedures_request_accepts_database() {
+        let req: ListProceduresRequest = serde_json::from_str(r#"{"database": "mydb"}"#).expect("parse");
         assert_eq!(req.database.as_deref(), Some("mydb"));
     }
 
     #[test]
-    fn unpinned_list_views_request_defaults_to_brief_mode_without_search() {
-        let req: PinnedListViewsRequest = serde_json::from_str("{}").expect("empty object should parse");
+    fn list_views_request_defaults_to_brief_mode_without_search() {
+        let req: ListViewsRequest = serde_json::from_str("{}").expect("empty object should parse");
         assert!(req.search.is_none());
         assert!(!req.detailed, "detailed must default to false");
+        assert!(req.database.is_none());
     }
 
     #[test]
-    fn unpinned_list_views_request_accepts_search_and_detailed() {
-        let req: PinnedListViewsRequest =
-            serde_json::from_str(r#"{"search": "active", "detailed": true}"#).expect("parse");
+    fn list_views_request_accepts_search_and_detailed() {
+        let req: ListViewsRequest = serde_json::from_str(r#"{"search": "active", "detailed": true}"#).expect("parse");
         assert_eq!(req.search.as_deref(), Some("active"));
         assert!(req.detailed);
     }
 
     #[test]
-    fn pinned_list_views_request_accepts_database() {
-        let req: UnpinnedListViewsRequest = serde_json::from_str(r#"{"database": "mydb"}"#).expect("parse");
+    fn list_views_request_accepts_database() {
+        let req: ListViewsRequest = serde_json::from_str(r#"{"database": "mydb"}"#).expect("parse");
         assert_eq!(req.database.as_deref(), Some("mydb"));
     }
 
     #[test]
-    fn unpinned_list_materialized_views_request_defaults_to_brief_mode_without_search() {
-        let req: PinnedListMaterializedViewsRequest = serde_json::from_str("{}").expect("empty object should parse");
+    fn list_materialized_views_request_defaults_to_brief_mode_without_search() {
+        let req: ListMaterializedViewsRequest = serde_json::from_str("{}").expect("empty object should parse");
         assert!(req.search.is_none());
         assert!(!req.detailed, "detailed must default to false");
+        assert!(req.database.is_none());
     }
 
     #[test]
-    fn unpinned_list_materialized_views_request_accepts_search_and_detailed() {
-        let req: PinnedListMaterializedViewsRequest =
+    fn list_materialized_views_request_accepts_search_and_detailed() {
+        let req: ListMaterializedViewsRequest =
             serde_json::from_str(r#"{"search": "orders", "detailed": true}"#).expect("parse");
         assert_eq!(req.search.as_deref(), Some("orders"));
         assert!(req.detailed);
     }
 
     #[test]
-    fn pinned_list_materialized_views_request_accepts_database() {
-        let req: UnpinnedListMaterializedViewsRequest = serde_json::from_str(r#"{"database": "mydb"}"#).expect("parse");
+    fn list_materialized_views_request_accepts_database() {
+        let req: ListMaterializedViewsRequest = serde_json::from_str(r#"{"database": "mydb"}"#).expect("parse");
         assert_eq!(req.database.as_deref(), Some("mydb"));
     }
 }

--- a/crates/server/src/schema.rs
+++ b/crates/server/src/schema.rs
@@ -23,28 +23,31 @@ use schemars::generate::SchemaSettings;
 use serde_json::Value;
 
 thread_local! {
-    static SCHEMA_CACHE: Mutex<HashMap<TypeId, Arc<JsonObject>>> = Mutex::new(HashMap::new());
+    static SCHEMA_CACHE: Mutex<HashMap<(TypeId, bool), Arc<JsonObject>>> = Mutex::new(HashMap::new());
 }
 
 /// Returns the input JSON schema for the tool parameter type `T`.
 ///
 /// Strips root `$schema`, `title`, and `description`, and inlines every
-/// `$defs` / `$ref` indirection. Results are cached per [`TypeId`] in a
-/// thread-local map, so repeated calls for the same `T` return the same
-/// [`Arc`].
+/// `$defs` / `$ref` indirection. When `pinned` is `true`, also strips the
+/// root `database` property and removes it from `required` — used for tools
+/// registered against a database name pinned in config, where the field is
+/// not part of the client-facing input. Results are cached per
+/// `(TypeId, pinned)` in a thread-local map, so repeated calls for the same
+/// `T` and `pinned` return the same [`Arc`].
 ///
 /// # Panics
 ///
 /// Panics if `T`'s `JsonSchema` impl produces a non-object JSON value, which
 /// would indicate a broken derive.
 #[must_use]
-pub fn input_schema<T: JsonSchema + Any>() -> Arc<JsonObject> {
+pub fn input_schema<T: JsonSchema + Any>(pinned: bool) -> Arc<JsonObject> {
     SCHEMA_CACHE.with(|cache| {
         cache
             .lock()
             .expect("schema cache poisoned")
-            .entry(TypeId::of::<T>())
-            .or_insert_with(|| Arc::new(build::<T>()))
+            .entry((TypeId::of::<T>(), pinned))
+            .or_insert_with(|| Arc::new(build::<T>(pinned)))
             .clone()
     })
 }
@@ -53,6 +56,8 @@ pub fn input_schema<T: JsonSchema + Any>() -> Arc<JsonObject> {
 ///
 /// Delegates to [`input_schema`] (same cache, same generation pipeline) and
 /// enforces the MCP-spec invariant that the schema's root `type` is `"object"`.
+/// Output schemas never carry a pinned/unpinned variant, so the cache key is
+/// fixed at `pinned = false`.
 ///
 /// # Panics
 ///
@@ -60,7 +65,7 @@ pub fn input_schema<T: JsonSchema + Any>() -> Arc<JsonObject> {
 /// when `T`'s `JsonSchema` impl produces a non-object JSON value.
 #[must_use]
 pub fn output_schema<T: JsonSchema + Any>() -> Arc<JsonObject> {
-    let schema = input_schema::<T>();
+    let schema = input_schema::<T>(false);
     match schema.get("type") {
         Some(Value::String(t)) if t == "object" => schema,
         other => panic!(
@@ -75,16 +80,22 @@ pub fn output_schema<T: JsonSchema + Any>() -> Arc<JsonObject> {
 ///
 /// Configures `inline_subschemas = true` to fold every `$defs` / `$ref` into
 /// the parent, `meta_schema = None` to suppress the root `$schema` key
-/// natively (schemars only inserts it when this is `Some`), and a root-only
-/// transform that strips the `title` and `description` schemars derives from
-/// the type's name and doc-comment.
-fn build<T: JsonSchema>() -> JsonObject {
+/// natively (schemars only inserts it when this is `Some`), and root-only
+/// transforms that strip the `title`/`description` schemars derives from the
+/// type's name and doc-comment, and — when `pinned` is `true` — strip the
+/// root `database` property and remove it from the `required` array.
+fn build<T: JsonSchema>(pinned: bool) -> JsonObject {
     let value = SchemaSettings::draft2020_12()
         .with(|s| {
             s.inline_subschemas = true;
             s.meta_schema = None;
         })
         .with_transform(strip_root_metadata)
+        .with_transform(move |schema: &mut Schema| {
+            if pinned {
+                strip_root_database(schema);
+            }
+        })
         .into_generator()
         .into_root_schema_for::<T>()
         .to_value();
@@ -106,6 +117,26 @@ fn strip_root_metadata(schema: &mut Schema) {
     if let Some(object) = schema.as_object_mut() {
         object.remove("title");
         object.remove("description");
+    }
+}
+
+/// Removes the root `database` property and its entry in `required`.
+///
+/// Applied only for tools registered against a pinned database, where the
+/// runtime always passes `None` for `database` and the client never supplies
+/// it. Root-only — see [`strip_root_metadata`].
+fn strip_root_database(schema: &mut Schema) {
+    let Some(object) = schema.as_object_mut() else {
+        return;
+    };
+    if let Some(Value::Object(properties)) = object.get_mut("properties") {
+        properties.remove("database");
+    }
+    if let Some(Value::Array(required)) = object.get_mut("required") {
+        required.retain(|value| value.as_str() != Some("database"));
+        if required.is_empty() {
+            object.remove("required");
+        }
     }
 }
 
@@ -144,9 +175,17 @@ mod tests {
         }
     }
 
+    /// Fixture with a `database` property to exercise the pinned-strip transform.
+    #[derive(Deserialize, Serialize, JsonSchema)]
+    struct PinnedFixture {
+        query: String,
+        #[serde(default)]
+        database: Option<String>,
+    }
+
     #[test]
     fn input_schema_strips_dollar_schema_title_and_description() {
-        let schema = input_schema::<Fixture>();
+        let schema = input_schema::<Fixture>(false);
         assert!(!schema.contains_key("$schema"), "root $schema not stripped: {schema:?}");
         assert!(!schema.contains_key("title"), "root title not stripped: {schema:?}");
         assert!(
@@ -158,24 +197,30 @@ mod tests {
 
     #[test]
     fn input_schema_inlines_nested_subschemas() {
-        let schema = input_schema::<Fixture>();
+        let schema = input_schema::<Fixture>(false);
         let value = Value::Object((*schema).clone());
         assert!(!contains_key(&value, "$defs"), "$defs not inlined: {value}");
         assert!(!contains_key(&value, "$ref"), "$ref not inlined: {value}");
     }
 
     #[test]
-    fn input_schema_caches_by_type() {
-        let first = input_schema::<Fixture>();
-        let second = input_schema::<Fixture>();
+    fn input_schema_caches_by_type_and_pinned() {
+        let first = input_schema::<Fixture>(false);
+        let second = input_schema::<Fixture>(false);
         assert!(
             std::sync::Arc::ptr_eq(&first, &second),
-            "same type should return cached Arc"
+            "same (type, pinned) should return cached Arc"
         );
-        let other = input_schema::<OtherFixture>();
+        let other = input_schema::<OtherFixture>(false);
         assert!(
             !std::sync::Arc::ptr_eq(&first, &other),
             "different types must not share cache entry"
+        );
+        let pinned = input_schema::<PinnedFixture>(true);
+        let unpinned = input_schema::<PinnedFixture>(false);
+        assert!(
+            !std::sync::Arc::ptr_eq(&pinned, &unpinned),
+            "same type with different pinned flags must not share cache entry"
         );
     }
 
@@ -195,7 +240,7 @@ mod tests {
 
     #[test]
     fn build_preserves_properties() {
-        let schema = build::<Fixture>();
+        let schema = build::<Fixture>(false);
         let properties = schema
             .get("properties")
             .and_then(Value::as_object)
@@ -208,5 +253,32 @@ mod tests {
             Some("Doc-comment kept on the property — must survive schema generation."),
             "per-property descriptions must survive schema generation"
         );
+    }
+
+    #[test]
+    fn pinned_input_schema_strips_database_property_and_required() {
+        let unpinned = input_schema::<PinnedFixture>(false);
+        let unpinned_props = unpinned.get("properties").and_then(Value::as_object).unwrap();
+        assert!(unpinned_props.contains_key("database"));
+        assert!(unpinned_props.contains_key("query"));
+
+        let pinned = input_schema::<PinnedFixture>(true);
+        let pinned_props = pinned.get("properties").and_then(Value::as_object).unwrap();
+        assert!(
+            !pinned_props.contains_key("database"),
+            "pinned schema must drop `database`: {pinned:?}"
+        );
+        assert!(
+            pinned_props.contains_key("query"),
+            "pinned schema preserves other props"
+        );
+
+        let required = pinned.get("required").and_then(Value::as_array);
+        if let Some(required) = required {
+            assert!(
+                !required.iter().any(|v| v.as_str() == Some("database")),
+                "pinned schema must drop `database` from required: {required:?}"
+            );
+        }
     }
 }

--- a/crates/server/src/types.rs
+++ b/crates/server/src/types.rs
@@ -133,17 +133,10 @@ pub struct DropDatabaseRequest {
 
 /// Request for the `listViews` tool.
 #[derive(Debug, Default, Deserialize, JsonSchema)]
-pub struct PinnedListViewsRequest {
+pub struct ListViewsRequest {
     /// Opaque cursor from a prior response's `nextCursor`; omit for the first page.
     #[serde(default)]
     pub cursor: Option<Cursor>,
-}
-
-/// Request for the `listViews` tool.
-#[derive(Debug, Default, Deserialize, JsonSchema)]
-pub struct UnpinnedListViewsRequest {
-    #[serde(flatten)]
-    pub inner: PinnedListViewsRequest,
     /// Database to list views from. Defaults to the active database.
     #[serde(default)]
     pub database: Option<String>,
@@ -151,7 +144,7 @@ pub struct UnpinnedListViewsRequest {
 
 /// Request for the `listTriggers` tool.
 #[derive(Debug, Default, Deserialize, JsonSchema)]
-pub struct PinnedListTriggersRequest {
+pub struct ListTriggersRequest {
     /// Opaque cursor from a prior response's `nextCursor`; omit for the first page.
     #[serde(default)]
     pub cursor: Option<Cursor>,
@@ -164,13 +157,6 @@ pub struct PinnedListTriggersRequest {
     /// omitted, each entry is the bare trigger-name string.
     #[serde(default)]
     pub detailed: bool,
-}
-
-/// Request for the `listTriggers` tool.
-#[derive(Debug, Default, Deserialize, JsonSchema)]
-pub struct UnpinnedListTriggersRequest {
-    #[serde(flatten)]
-    pub inner: PinnedListTriggersRequest,
     /// Database to list triggers from. Defaults to the active database.
     #[serde(default)]
     pub database: Option<String>,
@@ -178,17 +164,10 @@ pub struct UnpinnedListTriggersRequest {
 
 /// Request for the `listFunctions` tool.
 #[derive(Debug, Default, Deserialize, JsonSchema)]
-pub struct PinnedListFunctionsRequest {
+pub struct ListFunctionsRequest {
     /// Opaque cursor from a prior response's `nextCursor`; omit for the first page.
     #[serde(default)]
     pub cursor: Option<Cursor>,
-}
-
-/// Request for the `listFunctions` tool.
-#[derive(Debug, Default, Deserialize, JsonSchema)]
-pub struct UnpinnedListFunctionsRequest {
-    #[serde(flatten)]
-    pub inner: PinnedListFunctionsRequest,
     /// Database to list functions from. Defaults to the active database.
     #[serde(default)]
     pub database: Option<String>,
@@ -196,16 +175,9 @@ pub struct UnpinnedListFunctionsRequest {
 
 /// Request for the `writeQuery` tool.
 #[derive(Debug, Default, Deserialize, JsonSchema)]
-pub struct PinnedQueryRequest {
+pub struct QueryRequest {
     /// The SQL query to execute.
     pub query: String,
-}
-
-/// Request for the `writeQuery` tool.
-#[derive(Debug, Default, Deserialize, JsonSchema)]
-pub struct UnpinnedQueryRequest {
-    #[serde(flatten)]
-    pub inner: PinnedQueryRequest,
     /// Database to run the query against. Defaults to the active database.
     #[serde(default)]
     pub database: Option<String>,
@@ -213,19 +185,12 @@ pub struct UnpinnedQueryRequest {
 
 /// Request for the `readQuery` tool.
 #[derive(Debug, Default, Deserialize, JsonSchema)]
-pub struct PinnedReadQueryRequest {
+pub struct ReadQueryRequest {
     /// The SQL query to execute.
     pub query: String,
     /// Opaque cursor from a prior response's `nextCursor`; omit for the first page.
     #[serde(default)]
     pub cursor: Option<Cursor>,
-}
-
-/// Request for the `readQuery` tool.
-#[derive(Debug, Default, Deserialize, JsonSchema)]
-pub struct UnpinnedReadQueryRequest {
-    #[serde(flatten)]
-    pub inner: PinnedReadQueryRequest,
     /// Database to run the query against. Defaults to the active database.
     #[serde(default)]
     pub database: Option<String>,
@@ -252,19 +217,12 @@ pub struct ReadQueryResponse {
 
 /// Request for the `explainQuery` tool.
 #[derive(Debug, Default, Deserialize, JsonSchema)]
-pub struct PinnedExplainQueryRequest {
+pub struct ExplainQueryRequest {
     /// The SQL query to explain.
     pub query: String,
     /// If true, use EXPLAIN ANALYZE for actual execution statistics. In read-only mode, only allowed for read-only statements. Defaults to false.
     #[serde(default)]
     pub analyze: bool,
-}
-
-/// Request for the `explainQuery` tool.
-#[derive(Debug, Default, Deserialize, JsonSchema)]
-pub struct UnpinnedExplainQueryRequest {
-    #[serde(flatten)]
-    pub inner: PinnedExplainQueryRequest,
     /// Database to explain against. Defaults to the active database.
     #[serde(default)]
     pub database: Option<String>,
@@ -272,31 +230,31 @@ pub struct UnpinnedExplainQueryRequest {
 
 #[cfg(test)]
 mod tests {
-    use super::{IndexMap, ListEntries, ListEntriesResponse, PinnedListTriggersRequest, UnpinnedListTriggersRequest};
+    use super::{IndexMap, ListEntries, ListEntriesResponse, ListTriggersRequest};
     use serde_json::{Value, json};
 
     #[test]
-    fn unpinned_list_triggers_request_defaults_to_brief_mode_without_search() {
-        let req: PinnedListTriggersRequest = serde_json::from_str("{}").expect("empty object should parse");
+    fn list_triggers_request_defaults_to_brief_mode_without_search() {
+        let req: ListTriggersRequest = serde_json::from_str("{}").expect("empty object should parse");
         assert!(req.search.is_none());
         assert!(!req.detailed, "detailed must default to false");
+        assert!(req.database.is_none());
     }
 
     #[test]
-    fn unpinned_list_triggers_request_accepts_search_and_detailed() {
-        let req: PinnedListTriggersRequest =
-            serde_json::from_str(r#"{"search": "audit", "detailed": true}"#).expect("parse");
+    fn list_triggers_request_accepts_search_and_detailed() {
+        let req: ListTriggersRequest = serde_json::from_str(r#"{"search": "audit", "detailed": true}"#).expect("parse");
         assert_eq!(req.search.as_deref(), Some("audit"));
         assert!(req.detailed);
     }
 
     #[test]
-    fn pinned_list_triggers_request_accepts_database_and_inner_fields() {
-        let req: UnpinnedListTriggersRequest =
+    fn list_triggers_request_accepts_database_and_inner_fields() {
+        let req: ListTriggersRequest =
             serde_json::from_str(r#"{"database": "mydb", "search": "audit", "detailed": true}"#).expect("parse");
         assert_eq!(req.database.as_deref(), Some("mydb"));
-        assert_eq!(req.inner.search.as_deref(), Some("audit"));
-        assert!(req.inner.detailed);
+        assert_eq!(req.search.as_deref(), Some("audit"));
+        assert!(req.detailed);
     }
 
     #[test]

--- a/crates/sqlite/src/tools/drop_table.rs
+++ b/crates/sqlite/src/tools/drop_table.rs
@@ -42,7 +42,7 @@ impl ToolBase for DropTableTool {
     }
 
     fn input_schema() -> Option<Arc<JsonObject>> {
-        Some(input_schema::<Self::Parameter>())
+        Some(input_schema::<Self::Parameter>(true))
     }
 
     fn output_schema() -> Option<Arc<JsonObject>> {

--- a/crates/sqlite/src/tools/explain_query.rs
+++ b/crates/sqlite/src/tools/explain_query.rs
@@ -41,7 +41,7 @@ impl ToolBase for ExplainQueryTool {
     }
 
     fn input_schema() -> Option<Arc<JsonObject>> {
-        Some(input_schema::<Self::Parameter>())
+        Some(input_schema::<Self::Parameter>(true))
     }
 
     fn output_schema() -> Option<Arc<JsonObject>> {

--- a/crates/sqlite/src/tools/list_tables.rs
+++ b/crates/sqlite/src/tools/list_tables.rs
@@ -40,7 +40,7 @@ impl ToolBase for ListTablesTool {
     }
 
     fn input_schema() -> Option<Arc<JsonObject>> {
-        Some(input_schema::<Self::Parameter>())
+        Some(input_schema::<Self::Parameter>(true))
     }
 
     fn output_schema() -> Option<Arc<JsonObject>> {

--- a/crates/sqlite/src/tools/list_triggers.rs
+++ b/crates/sqlite/src/tools/list_triggers.rs
@@ -41,7 +41,7 @@ impl ToolBase for ListTriggersTool {
     }
 
     fn input_schema() -> Option<Arc<JsonObject>> {
-        Some(input_schema::<Self::Parameter>())
+        Some(input_schema::<Self::Parameter>(true))
     }
 
     fn output_schema() -> Option<Arc<JsonObject>> {

--- a/crates/sqlite/src/tools/read_query.rs
+++ b/crates/sqlite/src/tools/read_query.rs
@@ -46,7 +46,7 @@ impl ToolBase for ReadQueryTool {
     }
 
     fn input_schema() -> Option<Arc<JsonObject>> {
-        Some(input_schema::<Self::Parameter>())
+        Some(input_schema::<Self::Parameter>(true))
     }
 
     fn output_schema() -> Option<Arc<JsonObject>> {

--- a/crates/sqlite/src/tools/write_query.rs
+++ b/crates/sqlite/src/tools/write_query.rs
@@ -41,7 +41,7 @@ impl ToolBase for WriteQueryTool {
     }
 
     fn input_schema() -> Option<Arc<JsonObject>> {
-        Some(input_schema::<Self::Parameter>())
+        Some(input_schema::<Self::Parameter>(true))
     }
 
     fn output_schema() -> Option<Arc<JsonObject>> {

--- a/tests/functional/mysql.rs
+++ b/tests/functional/mysql.rs
@@ -1463,7 +1463,7 @@ async fn test_read_query_pagination_invalid_cursor_rejected_at_deserialize() {
     let bad_cursors = ["!!!not-base64", "bm90LWpzb24", "eyJ4IjoxfQ", "eyJvZmZzZXQiOi0xfQ"];
 
     for bad in bad_cursors {
-        let err = serde_json::from_value::<dbmcp_server::types::UnpinnedReadQueryRequest>(json!({
+        let err = serde_json::from_value::<dbmcp_server::types::ReadQueryRequest>(json!({
             "query": "SELECT 1",
             "database": "app",
             "cursor": bad,

--- a/tests/functional/postgres.rs
+++ b/tests/functional/postgres.rs
@@ -1370,7 +1370,7 @@ async fn test_read_query_pagination_invalid_cursor_rejected_at_deserialize() {
     let bad_cursors = ["!!!not-base64", "bm90LWpzb24", "eyJ4IjoxfQ", "eyJvZmZzZXQiOi0xfQ"];
 
     for bad in bad_cursors {
-        let err = serde_json::from_value::<dbmcp_server::types::UnpinnedReadQueryRequest>(json!({
+        let err = serde_json::from_value::<dbmcp_server::types::ReadQueryRequest>(json!({
             "query": "SELECT 1",
             "database": "app",
             "cursor": bad,


### PR DESCRIPTION
## Summary

- Collapse 17 `Pinned<Tool>Request`/`Unpinned<Tool>Request` pairs across `crates/server`, `crates/mysql`, `crates/postgres` into single structs that always carry `database: Option<String>`. Drops the `#[serde(flatten)] inner: ...` indirection.
- Extend `input_schema<T>(pinned: bool)` (`crates/server/src/schema.rs`) with a schemars `Transform` that, when `pinned == true`, strips `database` from the root `properties` and `required`. Cache key changes from `TypeId` to `(TypeId, pinned)`.
- Tool struct pairs (`Pinned<Tool>Tool` / `Unpinned<Tool>Tool`) stay — they still carry distinct description strings and the `ToolSpec` registry filters them by the `pinned` gate. Their `invoke` bodies converge on the unified Parameter type.
- Wire shape unchanged in pinned mode: serde silently accepts a client-supplied `database` field and the handler ignores it (`Option<String>` defaults to `None`).

## Test plan

- [x] `cargo fmt`
- [x] `cargo clippy --workspace --tests -- -D warnings`
- [x] `cargo test --workspace --lib --bins`
- [x] `./tests/run.sh` — 734/734 pass across mariadb_12, mysql_9, postgres_18, sqlite
- [x] Approval snapshots (`tests/approval/{mysql,postgres,sqlite}.rs`) — pinned/unpinned `tools/list` schemas unchanged from prior shape