### PR TITLE
feat(server): drain connection pools on graceful shutdown

### DIFF
--- a/crates/mysql/src/connection.rs
+++ b/crates/mysql/src/connection.rs
@@ -69,6 +69,15 @@ impl MysqlConnection {
         self.pools.invalidate(name).await;
     }
 
+    /// Closes every cached pool, awaiting each clean shutdown.
+    ///
+    /// Idempotent — `MySqlPool::close` is safe to call more than once.
+    pub(crate) async fn shutdown(&self) {
+        for (_name, pool) in &self.pools {
+            pool.close().await;
+        }
+    }
+
     /// Resolves the cached pool for `target`, creating it lazily on miss.
     ///
     /// Kept crate-private so every tool path goes through the unified
@@ -248,6 +257,15 @@ mod tests {
             .pool(Some("any_db"))
             .await
             .expect("any database should be permitted");
+    }
+
+    #[tokio::test]
+    async fn shutdown_is_noop_and_idempotent_on_lazy_pools() {
+        let connection = MysqlConnection::new(&base_config());
+        connection.pool(Some("a")).await.expect("pool a");
+        connection.pool(Some("b")).await.expect("pool b");
+        connection.shutdown().await;
+        connection.shutdown().await;
     }
 
     #[tokio::test]

--- a/crates/mysql/src/connection.rs
+++ b/crates/mysql/src/connection.rs
@@ -73,7 +73,7 @@ impl MysqlConnection {
     ///
     /// Idempotent — `MySqlPool::close` is safe to call more than once.
     pub(crate) async fn shutdown(&self) {
-        for (_name, pool) in &self.pools {
+        for (_, pool) in &self.pools {
             pool.close().await;
         }
     }

--- a/crates/mysql/src/handler.rs
+++ b/crates/mysql/src/handler.rs
@@ -7,7 +7,7 @@
 
 use dbmcp_config::{Config, DatabaseConfig};
 use dbmcp_pii::Redactor;
-use dbmcp_server::{Server, ToolRouterExt, ToolSpec, server_info};
+use dbmcp_server::{Server, Shutdown, ShutdownFuture, ToolRouterExt, ToolSpec, server_info};
 use rmcp::RoleServer;
 use rmcp::handler::server::router::tool::ToolRouter;
 use rmcp::handler::server::tool::ToolCallContext;
@@ -115,6 +115,12 @@ impl From<MysqlHandler> for Server {
     /// Wraps a [`MysqlHandler`] in the type-erased MCP server.
     fn from(handler: MysqlHandler) -> Self {
         Self::new(handler)
+    }
+}
+
+impl Shutdown for MysqlHandler {
+    fn shutdown(&self) -> ShutdownFuture<'_> {
+        Box::pin(async move { self.connection.shutdown().await })
     }
 }
 

--- a/crates/postgres/src/connection.rs
+++ b/crates/postgres/src/connection.rs
@@ -77,7 +77,7 @@ impl PostgresConnection {
     ///
     /// Idempotent — `PgPool::close` is safe to call more than once.
     pub(crate) async fn shutdown(&self) {
-        for (_name, pool) in &self.pools {
+        for (_, pool) in &self.pools {
             pool.close().await;
         }
     }

--- a/crates/postgres/src/connection.rs
+++ b/crates/postgres/src/connection.rs
@@ -73,6 +73,15 @@ impl PostgresConnection {
         self.pools.invalidate(name).await;
     }
 
+    /// Closes every cached pool, awaiting each clean shutdown.
+    ///
+    /// Idempotent — `PgPool::close` is safe to call more than once.
+    pub(crate) async fn shutdown(&self) {
+        for (_name, pool) in &self.pools {
+            pool.close().await;
+        }
+    }
+
     /// Resolves the cached pool for `target`, creating it lazily on miss.
     ///
     /// Kept crate-private so every tool path goes through the unified
@@ -240,6 +249,15 @@ mod tests {
             .pool(Some("any_db"))
             .await
             .expect("any database should be permitted");
+    }
+
+    #[tokio::test]
+    async fn shutdown_is_noop_and_idempotent_on_lazy_pools() {
+        let connection = PostgresConnection::new(&base_config());
+        connection.pool(Some("a")).await.expect("pool a");
+        connection.pool(Some("b")).await.expect("pool b");
+        connection.shutdown().await;
+        connection.shutdown().await;
     }
 
     #[tokio::test]

--- a/crates/postgres/src/handler.rs
+++ b/crates/postgres/src/handler.rs
@@ -7,7 +7,7 @@
 
 use dbmcp_config::{Config, DatabaseConfig};
 use dbmcp_pii::Redactor;
-use dbmcp_server::{Server, ToolRouterExt, ToolSpec, server_info};
+use dbmcp_server::{Server, Shutdown, ShutdownFuture, ToolRouterExt, ToolSpec, server_info};
 use rmcp::RoleServer;
 use rmcp::handler::server::router::tool::ToolRouter;
 use rmcp::handler::server::tool::ToolCallContext;
@@ -121,6 +121,12 @@ impl From<PostgresHandler> for Server {
     /// Wraps a [`PostgresHandler`] in the type-erased MCP server.
     fn from(handler: PostgresHandler) -> Self {
         Self::new(handler)
+    }
+}
+
+impl Shutdown for PostgresHandler {
+    fn shutdown(&self) -> ShutdownFuture<'_> {
+        Box::pin(async move { self.connection.shutdown().await })
     }
 }
 

--- a/crates/server/src/lib.rs
+++ b/crates/server/src/lib.rs
@@ -13,5 +13,5 @@ pub mod types;
 
 pub use pagination::{Cursor, Pager};
 pub use schema::{input_schema, output_schema};
-pub use server::{Server, server_info};
+pub use server::{Server, Shutdown, ShutdownFuture, server_info};
 pub use tool::{ToolRouterExt, ToolSpec};

--- a/crates/server/src/server.rs
+++ b/crates/server/src/server.rs
@@ -5,12 +5,13 @@
 //! [`ServerHandler`](rmcp::ServerHandler) implementations.
 
 use std::fmt;
+use std::pin::Pin;
 use std::sync::Arc;
 
 use rmcp::RoleServer;
 use rmcp::Service;
 use rmcp::model::{Implementation, ServerCapabilities, ServerInfo};
-use rmcp::service::{DynService, NotificationContext, RequestContext, ServiceExt};
+use rmcp::service::{DynService, NotificationContext, RequestContext};
 
 /// Hardcoded product name matching the root binary crate.
 const NAME: &str = "dbmcp";
@@ -28,9 +29,26 @@ const HOMEPAGE: &str = env!("CARGO_PKG_HOMEPAGE");
 ///
 /// Wraps any backend adapter behind an [`Arc`] using rmcp's [`DynService`]
 /// for type erasure. All database backends produce the same concrete
-/// type, eliminating the need for enum dispatch.
+/// type, eliminating the need for enum dispatch. The same `Arc` is held
+/// a second time as a [`Shutdown`] view so transports can drain pools
+/// via [`Server::shutdown`].
 #[derive(Clone)]
-pub struct Server(Arc<dyn DynService<RoleServer>>);
+pub struct Server {
+    service: Arc<dyn DynService<RoleServer>>,
+    shutdown: Arc<dyn Shutdown>,
+}
+
+/// Boxed `Send` future returned by [`Shutdown::shutdown`].
+pub type ShutdownFuture<'a> = Pin<Box<dyn Future<Output = ()> + Send + 'a>>;
+
+/// Closes every live connection pool the server owns.
+///
+/// Implemented by each backend handler so transports can drain pools
+/// gracefully on shutdown, separate from the type-erased [`Server`].
+pub trait Shutdown: Send + Sync {
+    /// Awaits a clean close of all pools. Idempotent.
+    fn shutdown(&self) -> ShutdownFuture<'_>;
+}
 
 impl fmt::Debug for Server {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
@@ -40,8 +58,24 @@ impl fmt::Debug for Server {
 
 impl Server {
     /// Creates a new server from any backend adapter.
-    pub fn new(server: impl ServiceExt<RoleServer>) -> Self {
-        Self(Arc::from(server.into_dyn()))
+    ///
+    /// One [`Arc`] is shared as two trait-object views — [`DynService`]
+    /// for request handling and [`Shutdown`] for pool draining — so the
+    /// adapter itself is never cloned.
+    pub fn new<S>(handler: S) -> Self
+    where
+        S: Service<RoleServer> + Shutdown + 'static,
+    {
+        let handler = Arc::new(handler);
+        Self {
+            service: handler.clone(),
+            shutdown: handler,
+        }
+    }
+
+    /// Closes every live connection pool. Idempotent.
+    pub async fn shutdown(&self) {
+        self.shutdown.shutdown().await;
     }
 }
 
@@ -52,7 +86,7 @@ impl Service<RoleServer> for Server {
         context: RequestContext<RoleServer>,
     ) -> impl Future<Output = Result<<RoleServer as rmcp::service::ServiceRole>::Resp, rmcp::ErrorData>> + Send + '_
     {
-        DynService::handle_request(self.0.as_ref(), request, context)
+        DynService::handle_request(self.service.as_ref(), request, context)
     }
 
     fn handle_notification(
@@ -60,11 +94,11 @@ impl Service<RoleServer> for Server {
         notification: <RoleServer as rmcp::service::ServiceRole>::PeerNot,
         context: NotificationContext<RoleServer>,
     ) -> impl Future<Output = Result<(), rmcp::ErrorData>> + Send + '_ {
-        DynService::handle_notification(self.0.as_ref(), notification, context)
+        DynService::handle_notification(self.service.as_ref(), notification, context)
     }
 
     fn get_info(&self) -> <RoleServer as rmcp::service::ServiceRole>::Info {
-        DynService::get_info(self.0.as_ref())
+        DynService::get_info(self.service.as_ref())
     }
 }
 

--- a/crates/sqlite/src/connection.rs
+++ b/crates/sqlite/src/connection.rs
@@ -44,6 +44,13 @@ impl SqliteConnection {
     pub(crate) async fn pool(&self, _target: Option<&str>) -> Result<SqlitePool, SqlError> {
         Ok(self.pool.clone())
     }
+
+    /// Closes the single pool, awaiting a clean shutdown.
+    ///
+    /// Idempotent — `SqlitePool::close` is safe to call more than once.
+    pub(crate) async fn shutdown(&self) {
+        self.pool.close().await;
+    }
 }
 
 impl Connection for SqliteConnection {
@@ -123,5 +130,12 @@ mod tests {
             .pool(Some("anything"))
             .await
             .expect("any target should return the same single pool");
+    }
+
+    #[tokio::test]
+    async fn shutdown_is_noop_and_idempotent_on_lazy_pool() {
+        let connection = SqliteConnection::new(&base_config());
+        connection.shutdown().await;
+        connection.shutdown().await;
     }
 }

--- a/crates/sqlite/src/handler.rs
+++ b/crates/sqlite/src/handler.rs
@@ -7,7 +7,7 @@
 
 use dbmcp_config::{Config, DatabaseConfig};
 use dbmcp_pii::Redactor;
-use dbmcp_server::{Server, ToolRouterExt, ToolSpec, server_info};
+use dbmcp_server::{Server, Shutdown, ShutdownFuture, ToolRouterExt, ToolSpec, server_info};
 use rmcp::RoleServer;
 use rmcp::handler::server::router::tool::ToolRouter;
 use rmcp::handler::server::tool::ToolCallContext;
@@ -89,6 +89,12 @@ impl From<SqliteHandler> for Server {
     /// Wraps a [`SqliteHandler`] in the type-erased MCP server.
     fn from(handler: SqliteHandler) -> Self {
         Self::new(handler)
+    }
+}
+
+impl Shutdown for SqliteHandler {
+    fn shutdown(&self) -> ShutdownFuture<'_> {
+        Box::pin(async move { self.connection.shutdown().await })
     }
 }
 

--- a/src/commands/common.rs
+++ b/src/commands/common.rs
@@ -249,6 +249,34 @@ where
         .map_err(|e| crate::error::Error::Init(e.to_string()))
 }
 
+/// Future that resolves when the process should shut down.
+///
+/// Listens for Ctrl-C on all platforms and `SIGTERM` on Unix, which
+/// is the signal `docker stop`, `systemctl stop`, and Kubernetes
+/// send to request graceful termination. Whichever arrives first
+/// wins. Shared by both transports.
+pub(crate) async fn shutdown_signal() {
+    let ctrl_c = async {
+        tokio::signal::ctrl_c().await.expect("failed to install Ctrl-C handler");
+    };
+
+    #[cfg(unix)]
+    let terminate = async {
+        tokio::signal::unix::signal(tokio::signal::unix::SignalKind::terminate())
+            .expect("failed to install SIGTERM handler")
+            .recv()
+            .await;
+    };
+
+    #[cfg(not(unix))]
+    let terminate = std::future::pending::<()>();
+
+    tokio::select! {
+        () = ctrl_c => info!("Ctrl-C received, shutting down..."),
+        () = terminate => info!("SIGTERM received, shutting down..."),
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use clap::{CommandFactory, Parser};

--- a/src/commands/http.rs
+++ b/src/commands/http.rs
@@ -150,7 +150,7 @@ impl HttpCommand {
         let server = common::create_server(&config)?;
         let cancel_token = CancellationToken::new();
 
-        let router = build_http_router(http_config, server, &cancel_token);
+        let router = build_http_router(http_config, server.clone(), &cancel_token);
 
         let bind_addr = format!("{}:{}", http_config.host, http_config.port);
         info!("Starting MCP server via HTTP transport on {bind_addr}...");
@@ -160,10 +160,13 @@ impl HttpCommand {
 
         axum::serve(listener, router)
             .with_graceful_shutdown(async move {
-                shutdown_signal().await;
+                common::shutdown_signal().await;
                 cancel_token.cancel();
             })
             .await?;
+
+        server.shutdown().await;
+        info!("All connection pools closed.");
 
         Ok(())
     }
@@ -211,34 +214,6 @@ fn build_cors_layer(http_config: &HttpConfig) -> CorsLayer {
             axum::http::Method::OPTIONS,
         ])
         .allow_headers([axum::http::header::CONTENT_TYPE, axum::http::header::ACCEPT])
-}
-
-/// Future that resolves when the process should shut down.
-///
-/// Listens for Ctrl-C on all platforms and `SIGTERM` on Unix, which
-/// is the signal `docker stop`, `systemctl stop`, and Kubernetes
-/// send to request graceful termination. Whichever arrives first
-/// wins.
-async fn shutdown_signal() {
-    let ctrl_c = async {
-        tokio::signal::ctrl_c().await.expect("failed to install Ctrl-C handler");
-    };
-
-    #[cfg(unix)]
-    let terminate = async {
-        tokio::signal::unix::signal(tokio::signal::unix::SignalKind::terminate())
-            .expect("failed to install SIGTERM handler")
-            .recv()
-            .await;
-    };
-
-    #[cfg(not(unix))]
-    let terminate = std::future::pending::<()>();
-
-    tokio::select! {
-        () = ctrl_c => info!("Ctrl-C received, shutting down..."),
-        () = terminate => info!("SIGTERM received, shutting down..."),
-    }
 }
 
 #[cfg(test)]

--- a/src/commands/stdio.rs
+++ b/src/commands/stdio.rs
@@ -63,10 +63,22 @@ impl StdioCommand {
 
         info!("Starting MCP server via stdio transport...");
         let transport = rmcp::transport::io::stdio();
-        let running = server.serve(transport).await?;
-        if let Err(join_error) = running.waiting().await {
-            error!("stdio server task terminated abnormally: {join_error}");
+        let running = server.clone().serve(transport).await?;
+
+        // Exit on stdin EOF (client disconnect) or Ctrl-C/SIGTERM. On a
+        // signal the losing `waiting()` future drops, cancelling the
+        // service via `RunningService`'s `Drop`.
+        tokio::select! {
+            res = running.waiting() => {
+                if let Err(join_error) = res {
+                    error!("stdio server task terminated abnormally: {join_error}");
+                }
+            }
+            () = common::shutdown_signal() => {}
         }
+
+        server.shutdown().await;
+        info!("All connection pools closed.");
         Ok(())
     }
 }


### PR DESCRIPTION
## Summary

Gracefully close every live sqlx pool when the process shuts down, so MySQL/PostgreSQL servers see a clean disconnect instead of waiting on TCP keepalive timeouts (the [documented sqlx best practice](https://docs.rs/sqlx/latest/sqlx/struct.Pool.html)).

## Changes

- **`Shutdown` trait + `ShutdownFuture` alias** in the server crate. `Server` holds a second trait-object view of the same `Arc` (`DynService` for requests, `Shutdown` for draining) — the adapter is shared, never cloned, and `Server::new` needs no `Clone` bound.
- **Per-backend pool draining** via the connection: MySQL/PostgreSQL drain the per-database moka cache; SQLite closes its single pool. All three named `shutdown` for consistency.
- **Shared `shutdown_signal`** (Ctrl-C on all platforms, SIGTERM on Unix) deduplicated into `commands/common.rs`. HTTP closes pools after axum's graceful drain; stdio exits on stdin EOF or signal, then closes pools.

## Testing

- `cargo fmt --check`, `cargo clippy --workspace --tests -- -D warnings`
- `cargo test --workspace --lib --bins` — green, incl. new pool-shutdown idempotency tests
- `./tests/run.sh` — 734 integration tests pass across mariadb / mysql / postgres / sqlite