### PR TITLE
feat(sql-lineage): add column-level SQL lineage extraction crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -888,6 +888,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "dbmcp-sql-lineage"
+version = "0.13.2"
+dependencies = [
+ "serde",
+ "sqlparser",
+ "thiserror",
+]
+
+[[package]]
 name = "dbmcp-sqlite"
 version = "0.13.2"
 dependencies = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,6 +28,7 @@ dbmcp-pii = { path = "crates/pii", version = "0.13.2" }
 dbmcp-postgres = { path = "crates/postgres", version = "0.13.2" }
 dbmcp-server = { path = "crates/server", version = "0.13.2" }
 dbmcp-sql = { path = "crates/sql", version = "0.13.2" }
+dbmcp-sql-lineage = { path = "crates/sql-lineage", version = "0.13.2" }
 dbmcp-sqlite = { path = "crates/sqlite", version = "0.13.2" }
 sqlx-json = { path = "crates/sqlx-json", version = "0.13.2" }
 

--- a/crates/sql-lineage/Cargo.toml
+++ b/crates/sql-lineage/Cargo.toml
@@ -1,0 +1,16 @@
+[package]
+name = "dbmcp-sql-lineage"
+description = "Column-level SQL lineage extraction for dbmcp"
+version.workspace = true
+edition.workspace = true
+homepage.workspace = true
+license.workspace = true
+repository.workspace = true
+
+[dependencies]
+serde = { workspace = true }
+sqlparser = { workspace = true }
+thiserror = { workspace = true }
+
+[lints]
+workspace = true

--- a/crates/sql-lineage/README.md
+++ b/crates/sql-lineage/README.md
@@ -1,0 +1,19 @@
+# dbmcp-sql-lineage
+
+[![Crates.io](https://img.shields.io/crates/v/dbmcp-sql-lineage.svg)](https://crates.io/crates/dbmcp-sql-lineage)
+[![Docs.rs](https://docs.rs/dbmcp-sql-lineage/badge.svg)](https://docs.rs/dbmcp-sql-lineage)
+[![CI](https://github.com/haymon-ai/dbmcp/actions/workflows/ci.yml/badge.svg)](https://github.com/haymon-ai/dbmcp/actions/workflows/ci.yml)
+[![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](https://github.com/haymon-ai/dbmcp/blob/master/LICENSE)
+
+Column-level SQL lineage extraction powering [dbmcp](https://dbmcp.haymon.ai) — the single-binary MCP server for MySQL, MariaDB, PostgreSQL, and SQLite.
+
+## What you get
+
+- `extract()` maps each output column to its physical `table.column` sources
+- AST-based via `sqlparser` — accepts any `Dialect`
+- Reads (`SELECT`) and writes (`INSERT`, `UPDATE`, `DELETE`, `CREATE TABLE AS SELECT`, `MERGE`); writes also record a target
+- Resolves CTEs, derived tables, joins, and qualified references
+- Fail-closed — unresolvable columns (`SELECT *` over base tables, ambiguous unqualified columns in joins) abort the whole extraction
+- Never connects to or executes against a database — analyzes SQL text only
+
+See the main crate: **[dbmcp](https://dbmcp.haymon.ai)** · [Website](https://dbmcp.haymon.ai) · [Docs](https://dbmcp.haymon.ai/docs/)

--- a/crates/sql-lineage/src/error.rs
+++ b/crates/sql-lineage/src/error.rs
@@ -1,0 +1,56 @@
+//! Error type for lineage extraction.
+
+use thiserror::Error;
+
+/// Failure raised while extracting column lineage from SQL.
+///
+/// Resolution is fail-closed: any projected column that cannot be bound to a
+/// concrete source aborts the whole extraction (see [`LineageError::UnresolvedColumn`]).
+#[derive(Debug, Clone, PartialEq, Eq, Error)]
+pub enum LineageError {
+    /// The SQL string could not be parsed by the selected dialect.
+    #[error("SQL parse error: {0}")]
+    Parse(String),
+
+    /// More than one statement was supplied; only single statements are analyzed.
+    #[error("multi-statement SQL is not supported")]
+    MultiStatement,
+
+    /// A projected column could not be resolved to a concrete source column.
+    #[error("unresolved column `{column}`: {reason}")]
+    UnresolvedColumn {
+        /// The column reference that could not be resolved.
+        column: String,
+        /// Why it could not be resolved (e.g. ambiguous, no catalog).
+        reason: String,
+    },
+
+    /// A referenced table is not present in the supplied schema catalog.
+    #[error("unknown table `{table}`")]
+    UnknownTable {
+        /// The table name that could not be found.
+        table: String,
+    },
+
+    /// Query nesting exceeded the recursion-depth guard.
+    #[error("query nesting depth limit exceeded")]
+    DepthLimitExceeded,
+
+    /// A CTE references itself directly or transitively; lineage is undefined.
+    #[error("circular CTE reference: `{cte}`")]
+    CircularReference {
+        /// The CTE name that re-entered resolution.
+        cte: String,
+    },
+
+    /// A write target's column list does not match its source projection.
+    #[error("column count mismatch for `{target}`: expected {expected}, found {found}")]
+    ColumnCountMismatch {
+        /// The write target table name.
+        target: String,
+        /// Number of explicit target columns.
+        expected: usize,
+        /// Number of source-projection columns.
+        found: usize,
+    },
+}

--- a/crates/sql-lineage/src/extract.rs
+++ b/crates/sql-lineage/src/extract.rs
@@ -1,0 +1,40 @@
+//! Entry point: parse a SQL statement and resolve its column lineage.
+
+use sqlparser::ast::Statement;
+use sqlparser::dialect::Dialect;
+use sqlparser::parser::Parser;
+
+use crate::error::LineageError;
+use crate::model::Lineage;
+use crate::{resolve, statement};
+
+/// Extracts column lineage from a single SQL statement.
+///
+/// Handles read queries (`SELECT`) and write statements (`INSERT`, `UPDATE`,
+/// `DELETE`, `CREATE TABLE AS SELECT`, `MERGE`); writes set [`Lineage::target`].
+/// Other statements (`SHOW`, `DESCRIBE`, `USE`, `EXPLAIN`) succeed empty.
+///
+/// # Errors
+/// Returns [`LineageError`] if the SQL fails to parse, contains more than one
+/// statement, or any projected column cannot be resolved to a concrete source
+/// (fail closed — no partial result).
+pub fn extract(sql: &str, dialect: &dyn Dialect) -> Result<Lineage, LineageError> {
+    let statements = Parser::parse_sql(dialect, sql).map_err(|e| LineageError::Parse(e.to_string()))?;
+
+    if statements.len() > 1 {
+        return Err(LineageError::MultiStatement);
+    }
+    let Some(stmt) = statements.first() else {
+        return Ok(Lineage::empty());
+    };
+
+    match stmt {
+        Statement::Query(query) => Ok(Lineage::from_columns(resolve::resolve(query)?)),
+        Statement::Insert(insert) => statement::extract_insert(insert),
+        Statement::Update(update) => statement::extract_update(update),
+        Statement::Delete(delete) => statement::extract_delete(delete),
+        Statement::CreateTable(ct) => statement::extract_create_table(ct),
+        Statement::Merge(merge) => statement::extract_merge(merge),
+        _ => Ok(Lineage::empty()),
+    }
+}

--- a/crates/sql-lineage/src/lib.rs
+++ b/crates/sql-lineage/src/lib.rs
@@ -1,0 +1,40 @@
+//! Column-level SQL lineage extraction for `dbmcp`.
+//!
+//! Given a single SQL statement and a `sqlparser`
+//! [`Dialect`](sqlparser::dialect::Dialect),
+//! [`extract`] returns a [`Lineage`] mapping each output column to the physical
+//! `table.column` sources that produced it. Read queries and write statements
+//! (`INSERT`, `UPDATE`, `DELETE`, `CREATE TABLE AS SELECT`, `MERGE`) are both
+//! handled; writes also record a [`Lineage::target`]. Resolution is fail-closed:
+//! any column that cannot be bound to a concrete source aborts the whole
+//! extraction. The crate never connects to or executes against a database — it
+//! analyzes SQL text only.
+//!
+//! Wildcards over base tables (`SELECT *`) and unqualified columns in
+//! multi-table joins cannot be resolved without a column catalog, so they fail
+//! closed; qualified references, single-table queries, and wildcards over
+//! CTEs/derived tables resolve normally.
+//!
+//! # Quickstart
+//!
+//! ```
+//! use dbmcp_sql_lineage::extract;
+//! use sqlparser::dialect::PostgreSqlDialect;
+//!
+//! let lineage = extract("SELECT u.id, u.email FROM users u", &PostgreSqlDialect {})?;
+//! assert_eq!(lineage.columns[1].name.as_deref(), Some("email"));
+//! # Ok::<(), dbmcp_sql_lineage::LineageError>(())
+//! ```
+
+#![deny(missing_docs)]
+
+mod error;
+mod extract;
+mod model;
+mod resolve;
+mod scope;
+mod statement;
+
+pub use crate::error::LineageError;
+pub use crate::extract::extract;
+pub use crate::model::{Lineage, OutputColumn, SourceRef, TableRef, TableRefBuilder};

--- a/crates/sql-lineage/src/lib.rs
+++ b/crates/sql-lineage/src/lib.rs
@@ -26,8 +26,6 @@
 //! # Ok::<(), dbmcp_sql_lineage::LineageError>(())
 //! ```
 
-#![deny(missing_docs)]
-
 mod error;
 mod extract;
 mod model;

--- a/crates/sql-lineage/src/model.rs
+++ b/crates/sql-lineage/src/model.rs
@@ -1,0 +1,245 @@
+//! Public lineage result types.
+//!
+//! [`TableRef`] and [`SourceRef`] compare and order case-insensitively (ASCII)
+//! so set membership matches the catalog's case-insensitive lookup semantics.
+
+use std::cmp::Ordering;
+use std::collections::BTreeSet;
+
+use serde::{Deserialize, Serialize};
+
+/// Lowercases an ASCII string for case-insensitive comparison.
+fn fold(s: &str) -> String {
+    s.to_ascii_lowercase()
+}
+
+/// A physical table, optionally schema- and database-qualified.
+///
+/// Equality, ordering, and hashing are case-insensitive (ASCII) on all parts.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct TableRef {
+    /// Optional database/catalog qualifier present in the query.
+    pub database: Option<String>,
+    /// Optional schema qualifier present in the query.
+    pub schema: Option<String>,
+    /// Physical table name, as written in the query (original case preserved).
+    pub name: String,
+}
+
+impl TableRef {
+    /// Creates a bare (unqualified) table reference.
+    pub fn new(name: impl Into<String>) -> Self {
+        Self {
+            database: None,
+            schema: None,
+            name: name.into(),
+        }
+    }
+
+    /// Creates a schema-qualified table reference (no database qualifier).
+    pub fn qualified(schema: impl Into<String>, name: impl Into<String>) -> Self {
+        Self {
+            database: None,
+            schema: Some(schema.into()),
+            name: name.into(),
+        }
+    }
+
+    /// Starts building a table reference with optional qualifiers.
+    pub fn builder(name: impl Into<String>) -> TableRefBuilder {
+        TableRefBuilder {
+            database: None,
+            schema: None,
+            name: name.into(),
+        }
+    }
+
+    /// Returns the case-insensitive comparison key `(database, schema, name)`.
+    fn key(&self) -> (Option<String>, Option<String>, String) {
+        (
+            self.database.as_deref().map(fold),
+            self.schema.as_deref().map(fold),
+            fold(&self.name),
+        )
+    }
+}
+
+/// Fluent builder for a schema/database-qualified [`TableRef`].
+#[derive(Debug, Clone)]
+pub struct TableRefBuilder {
+    database: Option<String>,
+    schema: Option<String>,
+    name: String,
+}
+
+impl TableRefBuilder {
+    /// Sets the schema qualifier.
+    #[must_use]
+    pub fn with_schema(mut self, schema: impl Into<String>) -> Self {
+        self.schema = Some(schema.into());
+        self
+    }
+
+    /// Sets the database/catalog qualifier.
+    #[must_use]
+    pub fn with_database(mut self, database: impl Into<String>) -> Self {
+        self.database = Some(database.into());
+        self
+    }
+
+    /// Builds the [`TableRef`].
+    #[must_use]
+    pub fn build(self) -> TableRef {
+        TableRef {
+            database: self.database,
+            schema: self.schema,
+            name: self.name,
+        }
+    }
+}
+
+impl PartialEq for TableRef {
+    fn eq(&self, other: &Self) -> bool {
+        self.key() == other.key()
+    }
+}
+
+impl Eq for TableRef {}
+
+impl PartialOrd for TableRef {
+    fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
+        Some(self.cmp(other))
+    }
+}
+
+impl Ord for TableRef {
+    fn cmp(&self, other: &Self) -> Ordering {
+        self.key().cmp(&other.key())
+    }
+}
+
+impl std::hash::Hash for TableRef {
+    fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
+        self.key().hash(state);
+    }
+}
+
+/// A concrete physical origin of (part of) an output column.
+///
+/// Equality, ordering, and hashing are case-insensitive (ASCII).
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct SourceRef {
+    /// The physical table (alias stripped, qualifier preserved).
+    pub table: TableRef,
+    /// The physical column name on that table.
+    pub column: String,
+}
+
+impl SourceRef {
+    /// Creates a source reference.
+    pub fn new(table: TableRef, column: impl Into<String>) -> Self {
+        Self {
+            table,
+            column: column.into(),
+        }
+    }
+
+    /// Returns the case-insensitive comparison key.
+    fn key(&self) -> (Option<String>, Option<String>, String, String) {
+        let (db, schema, table) = self.table.key();
+        (db, schema, table, fold(&self.column))
+    }
+}
+
+impl PartialEq for SourceRef {
+    fn eq(&self, other: &Self) -> bool {
+        self.key() == other.key()
+    }
+}
+
+impl Eq for SourceRef {}
+
+impl PartialOrd for SourceRef {
+    fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
+        Some(self.cmp(other))
+    }
+}
+
+impl Ord for SourceRef {
+    fn cmp(&self, other: &Self) -> Ordering {
+        self.key().cmp(&other.key())
+    }
+}
+
+impl std::hash::Hash for SourceRef {
+    fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
+        self.key().hash(state);
+    }
+}
+
+/// One column in a query's result set.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct OutputColumn {
+    /// Output name/alias as seen by the client; `None` for unnamed expressions.
+    pub name: Option<String>,
+    /// 0-based position in the result set.
+    pub position: usize,
+    /// Contributing source columns; empty for literals/constants.
+    pub sources: BTreeSet<SourceRef>,
+}
+
+/// The lineage extracted from a single statement.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct Lineage {
+    /// One entry per output column, in projection (or target) order.
+    pub columns: Vec<OutputColumn>,
+    /// All physical input/source tables referenced by the statement.
+    pub tables: BTreeSet<TableRef>,
+    /// Target table for a write statement; `None` for a read (`SELECT`).
+    pub target: Option<TableRef>,
+}
+
+impl Lineage {
+    /// Returns an empty lineage (no columns, no tables, no target).
+    #[must_use]
+    pub fn empty() -> Self {
+        Self {
+            columns: Vec::new(),
+            tables: BTreeSet::new(),
+            target: None,
+        }
+    }
+
+    /// Builds a read lineage from output columns, deriving the source tables.
+    #[must_use]
+    pub(crate) fn from_columns(columns: Vec<OutputColumn>) -> Self {
+        Self {
+            tables: tables_of(&columns),
+            columns,
+            target: None,
+        }
+    }
+
+    /// Builds a write lineage for `target` from its mapped output columns.
+    ///
+    /// `tables` accumulates `input_tables` plus every source table feeding a
+    /// column; the `target` sink is intentionally excluded.
+    #[must_use]
+    pub(crate) fn from_write(target: TableRef, columns: Vec<OutputColumn>, input_tables: BTreeSet<TableRef>) -> Self {
+        let mut tables = input_tables;
+        tables.extend(tables_of(&columns));
+        Self {
+            columns,
+            tables,
+            target: Some(target),
+        }
+    }
+}
+
+/// Collects the distinct source tables feeding a set of output columns.
+fn tables_of(columns: &[OutputColumn]) -> BTreeSet<TableRef> {
+    columns
+        .iter()
+        .flat_map(|c| c.sources.iter().map(|s| s.table.clone()))
+        .collect()
+}

--- a/crates/sql-lineage/src/resolve.rs
+++ b/crates/sql-lineage/src/resolve.rs
@@ -1,0 +1,385 @@
+//! Resolves a parsed query into per-output-column source lineage.
+//!
+//! Walks query scopes (final `SELECT`, CTEs, derived tables, subqueries),
+//! resolving each projected expression's column references to physical
+//! [`SourceRef`]s. Fails closed on any unresolvable projected column.
+
+use std::collections::{BTreeSet, HashMap};
+use std::ops::ControlFlow;
+
+use sqlparser::ast::{
+    Expr, ObjectName, Query, Select, SelectItem, SelectItemQualifiedWildcardKind, SetExpr, TableFactor, TableWithJoins,
+    Values, Visit, Visitor,
+};
+
+use crate::error::LineageError;
+use crate::model::{OutputColumn, SourceRef, TableRef};
+use crate::scope::{ExpandedColumns, RelExpose, Scope, VirtCol};
+
+/// Maximum query-nesting depth before failing with [`LineageError::DepthLimitExceeded`].
+const MAX_DEPTH: usize = 64;
+
+/// Map of (folded) CTE name → its defining query.
+pub(crate) type CteMap<'a> = HashMap<String, &'a Query>;
+
+/// Set of (folded) CTE names currently being resolved, for cycle detection.
+pub(crate) type ActiveCtes = BTreeSet<String>;
+
+/// Lowercases an ASCII string for case-insensitive matching.
+fn fold(s: &str) -> String {
+    s.to_ascii_lowercase()
+}
+
+/// Resolves a top-level query with no inherited CTEs.
+///
+/// # Errors
+/// Returns [`LineageError`] on unresolved columns or excessive nesting.
+pub(crate) fn resolve(query: &Query) -> Result<Vec<OutputColumn>, LineageError> {
+    resolve_query(query, &CteMap::new(), &ActiveCtes::new(), 0)
+}
+
+/// Resolves a query into its ordered output columns within a CTE context.
+///
+/// `active` carries the CTE names currently being resolved; a repeat triggers
+/// [`LineageError::CircularReference`] (this also rejects `WITH RECURSIVE`).
+///
+/// # Errors
+/// Returns [`LineageError`] on unresolved columns, cycles, or excessive nesting.
+fn resolve_query<'a>(
+    query: &'a Query,
+    parent: &CteMap<'a>,
+    active: &ActiveCtes,
+    depth: usize,
+) -> Result<Vec<OutputColumn>, LineageError> {
+    if depth > MAX_DEPTH {
+        return Err(LineageError::DepthLimitExceeded);
+    }
+    let mut ctes: CteMap<'a> = parent.clone();
+    if let Some(with) = &query.with {
+        for cte in &with.cte_tables {
+            ctes.insert(fold(&cte.alias.name.value), &cte.query);
+        }
+    }
+    resolve_setexpr(&query.body, &ctes, active, depth)
+}
+
+/// Resolves a `SetExpr` (SELECT, set operation, `VALUES`, or parenthesized query).
+fn resolve_setexpr<'a>(
+    body: &'a SetExpr,
+    ctes: &CteMap<'a>,
+    active: &ActiveCtes,
+    depth: usize,
+) -> Result<Vec<OutputColumn>, LineageError> {
+    match body {
+        SetExpr::Select(select) => resolve_select(select, ctes, active, depth),
+        SetExpr::Query(query) => resolve_query(query, ctes, active, depth + 1),
+        SetExpr::SetOperation { left, right, .. } => {
+            let left_cols = resolve_setexpr(left, ctes, active, depth)?;
+            let right_cols = resolve_setexpr(right, ctes, active, depth)?;
+            let mut out = Vec::with_capacity(left_cols.len());
+            for (i, lc) in left_cols.into_iter().enumerate() {
+                let mut sources = lc.sources;
+                if let Some(rc) = right_cols.get(i) {
+                    sources.extend(rc.sources.iter().cloned());
+                }
+                push_column(&mut out, lc.name, sources);
+            }
+            Ok(out)
+        }
+        SetExpr::Values(values) => resolve_values(values, ctes, active, depth),
+        _ => Ok(Vec::new()),
+    }
+}
+
+/// Resolves a `VALUES` clause into one unnamed output column per position.
+///
+/// Each row's expressions are resolved against an empty scope, so literals
+/// contribute no sources; a bare column reference fails closed.
+fn resolve_values<'a>(
+    values: &'a Values,
+    ctes: &CteMap<'a>,
+    active: &ActiveCtes,
+    depth: usize,
+) -> Result<Vec<OutputColumn>, LineageError> {
+    let scope = Scope::default();
+    let mut out: Vec<OutputColumn> = Vec::new();
+    for row in &values.rows {
+        for (i, expr) in row.content.iter().enumerate() {
+            let sources = collect_sources(expr, &scope, ctes, active, depth)?;
+            match out.get_mut(i) {
+                Some(col) => col.sources.extend(sources),
+                None => push_column(&mut out, None, sources),
+            }
+        }
+    }
+    Ok(out)
+}
+
+/// Resolves a single `SELECT` into its output columns.
+fn resolve_select<'a>(
+    select: &'a Select,
+    ctes: &CteMap<'a>,
+    active: &ActiveCtes,
+    depth: usize,
+) -> Result<Vec<OutputColumn>, LineageError> {
+    let scope = build_scope(&select.from, ctes, active, depth)?;
+    let mut out: Vec<OutputColumn> = Vec::new();
+
+    for item in &select.projection {
+        let (expr, name) = match item {
+            SelectItem::UnnamedExpr(expr) => (expr, output_name(expr)),
+            SelectItem::ExprWithAlias { expr, alias } => (expr, Some(alias.value.clone())),
+            SelectItem::ExprWithAliases { expr, aliases } => (expr, aliases.first().map(|a| a.value.clone())),
+            SelectItem::Wildcard(_) => {
+                push_expanded(&mut out, scope.expand_wildcard()?);
+                continue;
+            }
+            SelectItem::QualifiedWildcard(SelectItemQualifiedWildcardKind::ObjectName(obj), _) => {
+                push_expanded(&mut out, scope.expand_qualified_wildcard(last_ident(obj))?);
+                continue;
+            }
+            SelectItem::QualifiedWildcard(SelectItemQualifiedWildcardKind::Expr(_), _) => {
+                return Err(LineageError::UnresolvedColumn {
+                    column: "*".to_string(),
+                    reason: "wildcard on an arbitrary expression is unsupported".to_string(),
+                });
+            }
+        };
+        let sources = collect_sources(expr, &scope, ctes, active, depth)?;
+        push_column(&mut out, name, sources);
+    }
+
+    Ok(out)
+}
+
+/// Builds the visible-relation scope for a `FROM`/`JOIN` list.
+///
+/// # Errors
+/// Returns [`LineageError`] on unresolved nested queries, cycles, or nesting.
+pub(crate) fn build_scope<'a>(
+    from: &'a [TableWithJoins],
+    ctes: &CteMap<'a>,
+    active: &ActiveCtes,
+    depth: usize,
+) -> Result<Scope, LineageError> {
+    let mut scope = Scope::default();
+    for twj in from {
+        add_table_with_joins(twj, &mut scope, ctes, active, depth)?;
+    }
+    Ok(scope)
+}
+
+/// Adds a relation and each of its joined relations to a scope.
+///
+/// # Errors
+/// Returns [`LineageError`] on unresolved nested queries, cycles, or nesting.
+pub(crate) fn add_table_with_joins<'a>(
+    twj: &'a TableWithJoins,
+    scope: &mut Scope,
+    ctes: &CteMap<'a>,
+    active: &ActiveCtes,
+    depth: usize,
+) -> Result<(), LineageError> {
+    add_table_factor(&twj.relation, scope, ctes, active, depth)?;
+    for join in &twj.joins {
+        add_table_factor(&join.relation, scope, ctes, active, depth)?;
+    }
+    Ok(())
+}
+
+/// Adds one table factor (and any nested joins) to a scope.
+///
+/// # Errors
+/// Returns [`LineageError`] on unresolved nested queries, cycles, or nesting.
+pub(crate) fn add_table_factor<'a>(
+    factor: &'a TableFactor,
+    scope: &mut Scope,
+    ctes: &CteMap<'a>,
+    active: &ActiveCtes,
+    depth: usize,
+) -> Result<(), LineageError> {
+    match factor {
+        TableFactor::Table { name, alias, .. } => {
+            let last = last_ident(name);
+            let visible = alias
+                .as_ref()
+                .map_or_else(|| last.to_string(), |a| a.name.value.clone());
+
+            let folded = fold(last);
+            if let Some(&cte_query) = ctes.get(folded.as_str()) {
+                if active.contains(&folded) {
+                    return Err(LineageError::CircularReference { cte: last.to_string() });
+                }
+                let mut active = active.clone();
+                active.insert(folded);
+                let cols = resolve_query(cte_query, ctes, &active, depth + 1)?;
+                scope.push(visible, virtual_from(cols));
+            } else {
+                let table = table_ref_from_object_name(name);
+                scope.push(visible, RelExpose::Physical { table });
+            }
+            Ok(())
+        }
+        TableFactor::Derived { subquery, alias, .. } => {
+            let cols = resolve_query(subquery, ctes, active, depth + 1)?;
+            let visible = alias.as_ref().map_or_else(String::new, |a| a.name.value.clone());
+            scope.push(visible, virtual_from(cols));
+            Ok(())
+        }
+        TableFactor::NestedJoin { table_with_joins, .. } => {
+            add_table_with_joins(table_with_joins, scope, ctes, active, depth)
+        }
+        _ => Ok(()),
+    }
+}
+
+/// Appends one output column, assigning its position from the current length.
+fn push_column(out: &mut Vec<OutputColumn>, name: Option<String>, sources: BTreeSet<SourceRef>) {
+    let position = out.len();
+    out.push(OutputColumn {
+        name,
+        position,
+        sources,
+    });
+}
+
+/// Appends wildcard-expanded columns to the projection, assigning positions.
+fn push_expanded(out: &mut Vec<OutputColumn>, expanded: ExpandedColumns) {
+    for (name, sources) in expanded {
+        push_column(out, name, sources);
+    }
+}
+
+/// Wraps resolved output columns as a virtual relation.
+fn virtual_from(cols: Vec<OutputColumn>) -> RelExpose {
+    let columns = cols
+        .into_iter()
+        .map(|c| VirtCol {
+            name: c.name,
+            sources: c.sources,
+        })
+        .collect();
+    RelExpose::Virtual { columns }
+}
+
+/// Returns the last identifier of an object name (its bare name), or `""`.
+pub(crate) fn last_ident(name: &ObjectName) -> &str {
+    name.0
+        .last()
+        .and_then(|p| p.as_ident())
+        .map_or("", |i| i.value.as_str())
+}
+
+/// Builds a [`TableRef`] from an object name, keeping schema/database qualifiers.
+///
+/// Maps the last three identifier parts to `database.schema.name`; any deeper
+/// prefix (e.g. a linked-server qualifier) is deliberately dropped.
+pub(crate) fn table_ref_from_object_name(name: &ObjectName) -> TableRef {
+    let idents: Vec<&str> = name
+        .0
+        .iter()
+        .filter_map(|p| p.as_ident())
+        .map(|i| i.value.as_str())
+        .collect();
+    match idents.as_slice() {
+        [] => TableRef::new(name.to_string()),
+        [table] => TableRef::new(*table),
+        [schema, table] => TableRef::qualified(*schema, *table),
+        [.., database, schema, table] => TableRef::builder(*table)
+            .with_schema(*schema)
+            .with_database(*database)
+            .build(),
+    }
+}
+
+/// Derives the client-visible output name of an unaliased projection expression.
+fn output_name(expr: &Expr) -> Option<String> {
+    match expr {
+        Expr::Identifier(id) => Some(id.value.clone()),
+        Expr::CompoundIdentifier(parts) => parts.last().map(|i| i.value.clone()),
+        _ => None,
+    }
+}
+
+/// Collects the source columns contributing to one expression.
+///
+/// # Errors
+/// Returns [`LineageError`] when a referenced column cannot be resolved.
+pub(crate) fn collect_sources(
+    expr: &Expr,
+    scope: &Scope,
+    ctes: &CteMap<'_>,
+    active: &ActiveCtes,
+    depth: usize,
+) -> Result<BTreeSet<SourceRef>, LineageError> {
+    let mut collector = ExprCollector {
+        scope,
+        ctes,
+        active,
+        depth,
+        query_depth: 0,
+        sources: BTreeSet::new(),
+    };
+    match expr.visit(&mut collector) {
+        ControlFlow::Break(err) => Err(err),
+        ControlFlow::Continue(()) => Ok(collector.sources),
+    }
+}
+
+/// Visitor that collects column references from an expression subtree.
+///
+/// A scalar subquery is resolved as a whole (its output sources added); the
+/// subquery's inner column references are skipped via `query_depth`.
+struct ExprCollector<'a, 's> {
+    scope: &'s Scope,
+    ctes: &'s CteMap<'a>,
+    active: &'s ActiveCtes,
+    depth: usize,
+    query_depth: usize,
+    sources: BTreeSet<SourceRef>,
+}
+
+impl Visitor for ExprCollector<'_, '_> {
+    type Break = LineageError;
+
+    fn pre_visit_query(&mut self, query: &Query) -> ControlFlow<Self::Break> {
+        if self.query_depth == 0 {
+            match resolve_query(query, self.ctes, self.active, self.depth + 1) {
+                Ok(cols) => {
+                    for col in cols {
+                        self.sources.extend(col.sources);
+                    }
+                }
+                Err(err) => return ControlFlow::Break(err),
+            }
+        }
+        self.query_depth += 1;
+        ControlFlow::Continue(())
+    }
+
+    fn post_visit_query(&mut self, _query: &Query) -> ControlFlow<Self::Break> {
+        self.query_depth = self.query_depth.saturating_sub(1);
+        ControlFlow::Continue(())
+    }
+
+    fn pre_visit_expr(&mut self, expr: &Expr) -> ControlFlow<Self::Break> {
+        if self.query_depth > 0 {
+            return ControlFlow::Continue(());
+        }
+        let resolved = match expr {
+            Expr::Identifier(id) => Some(self.scope.resolve_column(None, &id.value)),
+            Expr::CompoundIdentifier(parts) => match parts.as_slice() {
+                [.., qualifier, col] => Some(self.scope.resolve_column(Some(&qualifier.value), &col.value)),
+                [col] => Some(self.scope.resolve_column(None, &col.value)),
+                [] => None,
+            },
+            _ => None,
+        };
+        match resolved {
+            Some(Ok(found)) => self.sources.extend(found),
+            Some(Err(err)) => return ControlFlow::Break(err),
+            None => {}
+        }
+        ControlFlow::Continue(())
+    }
+}

--- a/crates/sql-lineage/src/scope.rs
+++ b/crates/sql-lineage/src/scope.rs
@@ -1,0 +1,195 @@
+//! Name resolution over a query scope's visible relations.
+//!
+//! A [`Scope`] holds the relations visible in one `SELECT`'s `FROM`/`JOIN`
+//! list. Physical tables resolve explicitly-referenced columns directly;
+//! CTE/derived relations expose pre-resolved output columns
+//! ([`Virtual`](RelExpose::Virtual)) and can be wildcard-expanded.
+
+use std::collections::BTreeSet;
+
+use crate::error::LineageError;
+use crate::model::{SourceRef, TableRef};
+
+/// A resolved output column of a CTE or derived table.
+#[derive(Debug, Clone)]
+pub(crate) struct VirtCol {
+    /// Output name, if any.
+    pub name: Option<String>,
+    /// Physical sources backing this column.
+    pub sources: BTreeSet<SourceRef>,
+}
+
+/// What a visible relation exposes for column resolution.
+#[derive(Debug, Clone)]
+pub(crate) enum RelExpose {
+    /// A physical base table. Its column list is unknown, so wildcards cannot
+    /// be expanded and unqualified columns cannot be disambiguated against it.
+    Physical {
+        /// The physical table.
+        table: TableRef,
+    },
+    /// A CTE or derived table exposing pre-resolved output columns.
+    Virtual {
+        /// The relation's output columns.
+        columns: Vec<VirtCol>,
+    },
+}
+
+/// Expanded wildcard columns: each entry is an optional name and its sources.
+pub(crate) type ExpandedColumns = Vec<(Option<String>, BTreeSet<SourceRef>)>;
+
+/// A relation visible in a scope under a name (alias or table name).
+#[derive(Debug, Clone)]
+pub(crate) struct Relation {
+    /// The name this relation is referenced by within the scope.
+    pub visible: String,
+    /// What the relation exposes.
+    pub expose: RelExpose,
+}
+
+/// The relations visible within one `SELECT` scope.
+#[derive(Debug, Clone, Default)]
+pub(crate) struct Scope {
+    /// Visible relations, in `FROM`/`JOIN` order.
+    relations: Vec<Relation>,
+}
+
+impl Scope {
+    /// Adds a visible relation referenced by `visible` (alias or table name).
+    pub(crate) fn push(&mut self, visible: String, expose: RelExpose) {
+        self.relations.push(Relation { visible, expose });
+    }
+
+    /// Returns the physical (base-table) relations visible in this scope.
+    pub(crate) fn physical_tables(&self) -> BTreeSet<TableRef> {
+        self.relations
+            .iter()
+            .filter_map(|r| match &r.expose {
+                RelExpose::Physical { table } => Some(table.clone()),
+                RelExpose::Virtual { .. } => None,
+            })
+            .collect()
+    }
+
+    /// Resolves a (optionally qualified) column reference to its sources.
+    ///
+    /// # Errors
+    /// Returns [`LineageError::UnresolvedColumn`] / [`LineageError::UnknownTable`]
+    /// when the reference is unknown or ambiguous (fail closed).
+    pub(crate) fn resolve_column(
+        &self,
+        qualifier: Option<&str>,
+        column: &str,
+    ) -> Result<BTreeSet<SourceRef>, LineageError> {
+        if let Some(q) = qualifier {
+            return resolve_in_relation(self.relation_named(q)?, column);
+        }
+
+        if self.relations.len() == 1 {
+            return resolve_in_relation(&self.relations[0], column);
+        }
+
+        let mut candidates: Vec<BTreeSet<SourceRef>> = Vec::new();
+        let mut has_physical = false;
+        for rel in &self.relations {
+            match &rel.expose {
+                RelExpose::Physical { .. } => has_physical = true,
+                RelExpose::Virtual { columns } => {
+                    if let Some(vc) = find_virtual_column(columns, column) {
+                        candidates.push(vc.sources.clone());
+                    }
+                }
+            }
+        }
+
+        if has_physical {
+            return Err(LineageError::UnresolvedColumn {
+                column: column.to_string(),
+                reason: "ambiguous unqualified column across multiple tables".to_string(),
+            });
+        }
+        match candidates.len() {
+            1 => Ok(candidates.into_iter().next().unwrap_or_default()),
+            0 => Err(LineageError::UnresolvedColumn {
+                column: column.to_string(),
+                reason: "column not found in any source relation".to_string(),
+            }),
+            _ => Err(LineageError::UnresolvedColumn {
+                column: column.to_string(),
+                reason: "ambiguous: column present in multiple source relations".to_string(),
+            }),
+        }
+    }
+
+    /// Expands an unqualified `*` into one entry per visible column.
+    ///
+    /// # Errors
+    /// Fails closed for a physical base table, whose column list is unknown.
+    pub(crate) fn expand_wildcard(&self) -> Result<ExpandedColumns, LineageError> {
+        let mut out = Vec::new();
+        for rel in &self.relations {
+            expand_relation(rel, &mut out)?;
+        }
+        Ok(out)
+    }
+
+    /// Expands a qualified `name.*` into the named relation's columns.
+    ///
+    /// # Errors
+    /// Fails closed when the relation is unknown or is a physical base table.
+    pub(crate) fn expand_qualified_wildcard(&self, name: &str) -> Result<ExpandedColumns, LineageError> {
+        let mut out = Vec::new();
+        expand_relation(self.relation_named(name)?, &mut out)?;
+        Ok(out)
+    }
+
+    /// Finds a visible relation by case-insensitive (ASCII) name, or fails closed.
+    fn relation_named(&self, name: &str) -> Result<&Relation, LineageError> {
+        self.relations
+            .iter()
+            .find(|r| r.visible.eq_ignore_ascii_case(name))
+            .ok_or_else(|| LineageError::UnknownTable {
+                table: name.to_string(),
+            })
+    }
+}
+
+/// Finds a virtual column by case-insensitive (ASCII) output name.
+fn find_virtual_column<'a>(columns: &'a [VirtCol], name: &str) -> Option<&'a VirtCol> {
+    columns
+        .iter()
+        .find(|c| c.name.as_deref().is_some_and(|n| n.eq_ignore_ascii_case(name)))
+}
+
+/// Resolves a column within a single known relation.
+fn resolve_in_relation(rel: &Relation, column: &str) -> Result<BTreeSet<SourceRef>, LineageError> {
+    match &rel.expose {
+        RelExpose::Physical { table } => {
+            let mut s = BTreeSet::new();
+            s.insert(SourceRef::new(table.clone(), column));
+            Ok(s)
+        }
+        RelExpose::Virtual { columns } => find_virtual_column(columns, column)
+            .map(|c| c.sources.clone())
+            .ok_or_else(|| LineageError::UnresolvedColumn {
+                column: column.to_string(),
+                reason: format!("not produced by relation `{}`", rel.visible),
+            }),
+    }
+}
+
+/// Appends a relation's columns to a wildcard-expansion accumulator.
+fn expand_relation(rel: &Relation, out: &mut ExpandedColumns) -> Result<(), LineageError> {
+    match &rel.expose {
+        RelExpose::Physical { .. } => Err(LineageError::UnresolvedColumn {
+            column: "*".to_string(),
+            reason: "wildcard over a base table cannot be expanded (no column list)".to_string(),
+        }),
+        RelExpose::Virtual { columns } => {
+            for vc in columns {
+                out.push((vc.name.clone(), vc.sources.clone()));
+            }
+            Ok(())
+        }
+    }
+}

--- a/crates/sql-lineage/src/statement.rs
+++ b/crates/sql-lineage/src/statement.rs
@@ -1,0 +1,268 @@
+//! Column lineage for write statements (INSERT/UPDATE/DELETE/CTAS/MERGE).
+//!
+//! Each extractor records the write `target` and maps its target columns back
+//! to source columns, reusing the scope and expression engine from [`resolve`].
+//! Resolution stays fail-closed: any unresolvable column aborts the statement.
+
+use std::collections::BTreeSet;
+
+use sqlparser::ast::{
+    Assignment, AssignmentTarget, CreateTable, Delete, FromTable, Insert, Merge, MergeAction, MergeInsertKind,
+    ObjectName, TableFactor, TableObject, Update, UpdateTableFromKind,
+};
+
+use crate::error::LineageError;
+use crate::model::{Lineage, OutputColumn, SourceRef, TableRef};
+use crate::resolve::{
+    self, ActiveCtes, CteMap, add_table_factor, add_table_with_joins, collect_sources, last_ident,
+    table_ref_from_object_name,
+};
+use crate::scope::Scope;
+
+/// Extracts lineage from an `INSERT`, including `INSERT … SELECT/VALUES/SET`.
+///
+/// # Errors
+/// Returns [`LineageError`] on a non-table target, count mismatch, or unresolved column.
+pub(crate) fn extract_insert(insert: &Insert) -> Result<Lineage, LineageError> {
+    let target = target_table(&insert.table)?;
+
+    let columns = if let Some(query) = &insert.source {
+        let source = resolve::resolve(query)?;
+        if insert.columns.is_empty() {
+            source
+        } else {
+            map_columns(&target, &target_column_names(&insert.columns), source)?
+        }
+    } else if !insert.assignments.is_empty() {
+        resolve_assignments(&insert.assignments, &Scope::default())?
+    } else {
+        Vec::new()
+    };
+
+    Ok(Lineage::from_write(target, columns, BTreeSet::new()))
+}
+
+/// Extracts lineage from `CREATE TABLE … AS SELECT`.
+///
+/// Returns an empty lineage for a plain `CREATE TABLE` without a query.
+///
+/// # Errors
+/// Returns [`LineageError`] on count mismatch or an unresolved source column.
+pub(crate) fn extract_create_table(ct: &CreateTable) -> Result<Lineage, LineageError> {
+    let Some(query) = &ct.query else {
+        return Ok(Lineage::empty());
+    };
+    let target = table_ref_from_object_name(&ct.name);
+    let source = resolve::resolve(query)?;
+    let columns = if ct.columns.is_empty() {
+        source
+    } else {
+        let names: Vec<String> = ct.columns.iter().map(|c| c.name.value.clone()).collect();
+        map_columns(&target, &names, source)?
+    };
+    Ok(Lineage::from_write(target, columns, BTreeSet::new()))
+}
+
+/// Extracts lineage from `UPDATE t SET col = expr [FROM src]`.
+///
+/// # Errors
+/// Returns [`LineageError`] on a non-table target or unresolved assignment.
+pub(crate) fn extract_update(update: &Update) -> Result<Lineage, LineageError> {
+    let target = table_ref_from_table_factor(&update.table.relation)?;
+
+    let ctes = CteMap::new();
+    let active = ActiveCtes::new();
+    let mut scope = Scope::default();
+    add_table_with_joins(&update.table, &mut scope, &ctes, &active, 0)?;
+    if let Some(from) = &update.from {
+        for twj in update_from_tables(from) {
+            add_table_with_joins(twj, &mut scope, &ctes, &active, 0)?;
+        }
+    }
+
+    let columns = resolve_assignments(&update.assignments, &scope)?;
+    Ok(Lineage::from_write(target, columns, BTreeSet::new()))
+}
+
+/// Extracts lineage from `DELETE FROM t [USING src]` (table-level only).
+///
+/// # Errors
+/// Returns [`LineageError`] on a non-table target or unresolved `USING` relation.
+pub(crate) fn extract_delete(delete: &Delete) -> Result<Lineage, LineageError> {
+    let target = if let Some(name) = delete.tables.first() {
+        table_ref_from_object_name(name)
+    } else {
+        let twjs = from_table_tables(&delete.from);
+        let first = twjs.first().ok_or_else(|| LineageError::UnknownTable {
+            table: "<delete target>".to_string(),
+        })?;
+        table_ref_from_table_factor(&first.relation)?
+    };
+
+    let ctes = CteMap::new();
+    let active = ActiveCtes::new();
+    let mut scope = Scope::default();
+    if let Some(using) = &delete.using {
+        for twj in using {
+            add_table_with_joins(twj, &mut scope, &ctes, &active, 0)?;
+        }
+    }
+    Ok(Lineage::from_write(target, Vec::new(), scope.physical_tables()))
+}
+
+/// Extracts lineage from `MERGE INTO t USING src … WHEN … THEN INSERT/UPDATE`.
+///
+/// # Errors
+/// Returns [`LineageError`] on a non-table target/source or unresolved column.
+pub(crate) fn extract_merge(merge: &Merge) -> Result<Lineage, LineageError> {
+    let target = table_ref_from_table_factor(&merge.table)?;
+
+    let ctes = CteMap::new();
+    let active = ActiveCtes::new();
+    let mut scope = Scope::default();
+    add_table_factor(&merge.table, &mut scope, &ctes, &active, 0)?;
+    add_table_factor(&merge.source, &mut scope, &ctes, &active, 0)?;
+
+    let mut columns: Vec<OutputColumn> = Vec::new();
+    for clause in &merge.clauses {
+        match &clause.action {
+            MergeAction::Update(update) => {
+                for assignment in &update.assignments {
+                    let (name, sources) = resolve_assignment(assignment, &scope)?;
+                    union_column(&mut columns, Some(name), sources);
+                }
+            }
+            MergeAction::Insert(insert) => {
+                if let MergeInsertKind::Values(values) = &insert.kind {
+                    let names = target_column_names(&insert.columns);
+                    if let Some(row) = values.rows.first() {
+                        for (name, expr) in names.iter().zip(&row.content) {
+                            let sources = collect_sources(expr, &scope, &ctes, &active, 0)?;
+                            union_column(&mut columns, Some(name.clone()), sources);
+                        }
+                    }
+                }
+            }
+            MergeAction::Delete { .. } => {}
+        }
+    }
+
+    Ok(Lineage::from_write(target, columns, BTreeSet::new()))
+}
+
+/// Resolves a list of assignments into one output column each.
+fn resolve_assignments(assignments: &[Assignment], scope: &Scope) -> Result<Vec<OutputColumn>, LineageError> {
+    let mut out: Vec<OutputColumn> = Vec::new();
+    for assignment in assignments {
+        let (name, sources) = resolve_assignment(assignment, scope)?;
+        let position = out.len();
+        out.push(OutputColumn {
+            name: Some(name),
+            position,
+            sources,
+        });
+    }
+    Ok(out)
+}
+
+/// Resolves one `col = expr` assignment to its target name and source columns.
+fn resolve_assignment(assignment: &Assignment, scope: &Scope) -> Result<(String, BTreeSet<SourceRef>), LineageError> {
+    let name = assignment_target_name(&assignment.target)?;
+    let sources = collect_sources(&assignment.value, scope, &CteMap::new(), &ActiveCtes::new(), 0)?;
+    Ok((name, sources))
+}
+
+/// Returns the assigned column name; tuple targets are unsupported (fail closed).
+fn assignment_target_name(target: &AssignmentTarget) -> Result<String, LineageError> {
+    match target {
+        AssignmentTarget::ColumnName(name) => Ok(last_ident(name).to_string()),
+        AssignmentTarget::Tuple(_) => Err(LineageError::UnresolvedColumn {
+            column: "(tuple)".to_string(),
+            reason: "tuple assignment unsupported".to_string(),
+        }),
+    }
+}
+
+/// Maps an explicit target column list onto a source projection, positionally.
+///
+/// Fails closed with [`LineageError::ColumnCountMismatch`] on length mismatch.
+fn map_columns(
+    target: &TableRef,
+    names: &[String],
+    source: Vec<OutputColumn>,
+) -> Result<Vec<OutputColumn>, LineageError> {
+    if names.len() != source.len() {
+        return Err(LineageError::ColumnCountMismatch {
+            target: target.name.clone(),
+            expected: names.len(),
+            found: source.len(),
+        });
+    }
+    Ok(source
+        .into_iter()
+        .zip(names)
+        .enumerate()
+        .map(|(position, (col, name))| OutputColumn {
+            name: Some(name.clone()),
+            position,
+            sources: col.sources,
+        })
+        .collect())
+}
+
+/// Adds sources under a target column, merging into an existing same-named one.
+fn union_column(columns: &mut Vec<OutputColumn>, name: Option<String>, sources: BTreeSet<SourceRef>) {
+    if let Some(n) = &name
+        && let Some(existing) = columns
+            .iter_mut()
+            .find(|c| c.name.as_deref().is_some_and(|e| e.eq_ignore_ascii_case(n)))
+    {
+        existing.sources.extend(sources);
+        return;
+    }
+    let position = columns.len();
+    columns.push(OutputColumn {
+        name,
+        position,
+        sources,
+    });
+}
+
+/// Extracts the bare column names from an explicit target column list.
+fn target_column_names(columns: &[ObjectName]) -> Vec<String> {
+    columns.iter().map(|c| last_ident(c).to_string()).collect()
+}
+
+/// Resolves an `INSERT`/`MERGE` target object into a [`TableRef`].
+fn target_table(obj: &TableObject) -> Result<TableRef, LineageError> {
+    match obj {
+        TableObject::TableName(name) => Ok(table_ref_from_object_name(name)),
+        _ => Err(LineageError::UnknownTable {
+            table: "<non-table insert target>".to_string(),
+        }),
+    }
+}
+
+/// Resolves a `TableFactor` write target into a [`TableRef`] (plain tables only).
+fn table_ref_from_table_factor(factor: &TableFactor) -> Result<TableRef, LineageError> {
+    match factor {
+        TableFactor::Table { name, .. } => Ok(table_ref_from_object_name(name)),
+        _ => Err(LineageError::UnknownTable {
+            table: "<non-table target>".to_string(),
+        }),
+    }
+}
+
+/// Returns the relations in an `UPDATE … FROM` clause.
+fn update_from_tables(kind: &UpdateTableFromKind) -> &[sqlparser::ast::TableWithJoins] {
+    match kind {
+        UpdateTableFromKind::BeforeSet(tables) | UpdateTableFromKind::AfterSet(tables) => tables,
+    }
+}
+
+/// Returns the relations in a `DELETE`'s `FROM` clause.
+fn from_table_tables(from: &FromTable) -> &[sqlparser::ast::TableWithJoins] {
+    match from {
+        FromTable::WithFromKeyword(tables) | FromTable::WithoutKeyword(tables) => tables,
+    }
+}

--- a/crates/sql-lineage/tests/extract.rs
+++ b/crates/sql-lineage/tests/extract.rs
@@ -1,0 +1,680 @@
+//! Acceptance corpus for lineage extraction, expressed as data-driven cases.
+
+use std::collections::BTreeSet;
+
+use dbmcp_sql_lineage::{Lineage, LineageError, SourceRef, TableRef, extract};
+use sqlparser::dialect::{Dialect, MySqlDialect, PostgreSqlDialect, SQLiteDialect};
+
+/// One expected output column: its name and exact dotted source columns.
+#[derive(Debug, Clone, Copy)]
+struct Col {
+    /// Expected output name (`None` for an unnamed expression).
+    name: Option<&'static str>,
+    /// Expected dotted `[db.][schema.]table.column` sources.
+    sources: &'static [&'static str],
+}
+
+/// One successful-extraction expectation.
+#[derive(Clone, Copy)]
+struct Case {
+    /// Human label, used in assertion messages.
+    name: &'static str,
+    /// SQL to extract.
+    sql: &'static str,
+    /// Dialect to parse with.
+    dialect: &'static dyn Dialect,
+    /// Expected write target (`None` for a read query).
+    target: Option<&'static str>,
+    /// Expected output columns, in order.
+    cols: &'static [Col],
+    /// Dotted table paths that must appear in the source `tables` set.
+    tables: &'static [&'static str],
+}
+
+/// One fail-closed expectation.
+struct ErrCase {
+    /// Human label, used in assertion messages.
+    name: &'static str,
+    /// SQL to extract.
+    sql: &'static str,
+    /// Dialect to parse with.
+    dialect: &'static dyn Dialect,
+    /// The error variant the input must produce (payload ignored).
+    expected: LineageError,
+}
+
+/// Asserts the lineage's write target matches the expectation.
+fn assert_target(case: &str, lineage: &Lineage, expected: Option<&str>) {
+    let got = lineage.target.as_ref().map(table_str);
+    assert_eq!(got.as_deref(), expected, "{case}: target mismatch");
+}
+
+/// Asserts the output column at `pos` has the expected name and sources.
+fn assert_col(case: &str, lineage: &Lineage, pos: usize, expected: &Col) {
+    let col = &lineage.columns[pos];
+    assert_eq!(col.name.as_deref(), expected.name, "{case}: name mismatch at {pos}");
+    let want: BTreeSet<String> = expected.sources.iter().map(|s| (*s).to_string()).collect();
+    assert_eq!(srcs(&col.sources), want, "{case}: sources mismatch at {pos}");
+}
+
+/// Asserts each expected dotted table path is present in the source set.
+///
+/// Membership uses [`TableRef`]'s case-insensitive equality.
+fn assert_tables(case: &str, lineage: &Lineage, expected: &[&str]) {
+    for t in expected {
+        let want = parse_table(t);
+        assert!(
+            lineage.tables.contains(&want),
+            "{case}: missing source table `{t}` in {:?}",
+            lineage.tables
+        );
+    }
+}
+
+/// Parses a dotted `[db.][schema.]name` path into a [`TableRef`].
+fn parse_table(dotted: &str) -> TableRef {
+    let parts: Vec<&str> = dotted.split('.').collect();
+    match parts.as_slice() {
+        [name] => TableRef::new(*name),
+        [schema, name] => TableRef::qualified(*schema, *name),
+        [.., database, schema, name] => TableRef::builder(*name)
+            .with_schema(*schema)
+            .with_database(*database)
+            .build(),
+        [] => TableRef::new(""),
+    }
+}
+
+/// Builds the set of dotted `[db.][schema.]table.column` strings for sources.
+fn srcs(sources: &BTreeSet<SourceRef>) -> BTreeSet<String> {
+    sources
+        .iter()
+        .map(|s| format!("{}.{}", table_str(&s.table), s.column))
+        .collect()
+}
+
+/// Renders a table reference as its dotted `[db.][schema.]name` path.
+fn table_str(t: &TableRef) -> String {
+    let mut parts: Vec<&str> = Vec::new();
+    if let Some(d) = &t.database {
+        parts.push(d);
+    }
+    if let Some(s) = &t.schema {
+        parts.push(s);
+    }
+    parts.push(&t.name);
+    parts.join(".")
+}
+
+#[test]
+#[allow(clippy::too_many_lines)]
+fn extract_succeeds() {
+    let cases: &'static [Case] = &[
+        Case {
+            name: "single_table_qualified",
+            sql: "SELECT u.id, u.email FROM users u",
+            dialect: &PostgreSqlDialect {},
+            target: None,
+            cols: &[
+                Col {
+                    name: Some("id"),
+                    sources: &["users.id"],
+                },
+                Col {
+                    name: Some("email"),
+                    sources: &["users.email"],
+                },
+            ],
+            tables: &["users"],
+        },
+        Case {
+            name: "alias_output_name",
+            sql: "SELECT email AS contact FROM users",
+            dialect: &PostgreSqlDialect {},
+            target: None,
+            cols: &[Col {
+                name: Some("contact"),
+                sources: &["users.email"],
+            }],
+            tables: &["users"],
+        },
+        Case {
+            name: "literal_has_no_sources",
+            sql: "SELECT 1 AS n",
+            dialect: &PostgreSqlDialect {},
+            target: None,
+            cols: &[Col {
+                name: Some("n"),
+                sources: &[],
+            }],
+            tables: &[],
+        },
+        Case {
+            name: "join_with_aliases",
+            sql: "SELECT u.id, o.total FROM users u JOIN orders o ON o.user_id = u.id",
+            dialect: &PostgreSqlDialect {},
+            target: None,
+            cols: &[
+                Col {
+                    name: Some("id"),
+                    sources: &["users.id"],
+                },
+                Col {
+                    name: Some("total"),
+                    sources: &["orders.total"],
+                },
+            ],
+            tables: &["users", "orders"],
+        },
+        Case {
+            name: "unqualified_single_table",
+            sql: "SELECT email FROM users",
+            dialect: &PostgreSqlDialect {},
+            target: None,
+            cols: &[Col {
+                name: Some("email"),
+                sources: &["users.email"],
+            }],
+            tables: &["users"],
+        },
+        Case {
+            name: "schema_qualified_table",
+            sql: "SELECT analytics.events.id FROM analytics.events",
+            dialect: &PostgreSqlDialect {},
+            target: None,
+            cols: &[Col {
+                name: Some("id"),
+                sources: &["analytics.events.id"],
+            }],
+            tables: &["analytics.events"],
+        },
+        Case {
+            name: "multipart_three_level_table",
+            sql: "SELECT db.sch.t.id FROM db.sch.t",
+            dialect: &PostgreSqlDialect {},
+            target: None,
+            cols: &[Col {
+                name: Some("id"),
+                sources: &["db.sch.t.id"],
+            }],
+            tables: &["db.sch.t"],
+        },
+        Case {
+            name: "case_insensitive_table",
+            sql: "SELECT U.Email FROM Users U",
+            dialect: &PostgreSqlDialect {},
+            target: None,
+            cols: &[Col {
+                name: Some("Email"),
+                sources: &["Users.Email"],
+            }],
+            tables: &["users"],
+        },
+        Case {
+            name: "dialect_matrix_pg",
+            sql: "SELECT u.email FROM users u",
+            dialect: &PostgreSqlDialect {},
+            target: None,
+            cols: &[Col {
+                name: Some("email"),
+                sources: &["users.email"],
+            }],
+            tables: &["users"],
+        },
+        Case {
+            name: "dialect_matrix_mysql",
+            sql: "SELECT u.email FROM users u",
+            dialect: &MySqlDialect {},
+            target: None,
+            cols: &[Col {
+                name: Some("email"),
+                sources: &["users.email"],
+            }],
+            tables: &["users"],
+        },
+        Case {
+            name: "dialect_matrix_sqlite",
+            sql: "SELECT u.email FROM users u",
+            dialect: &SQLiteDialect {},
+            target: None,
+            cols: &[Col {
+                name: Some("email"),
+                sources: &["users.email"],
+            }],
+            tables: &["users"],
+        },
+        Case {
+            name: "aggregate",
+            sql: "SELECT department, MAX(salary) AS top FROM employees GROUP BY department",
+            dialect: &PostgreSqlDialect {},
+            target: None,
+            cols: &[
+                Col {
+                    name: Some("department"),
+                    sources: &["employees.department"],
+                },
+                Col {
+                    name: Some("top"),
+                    sources: &["employees.salary"],
+                },
+            ],
+            tables: &["employees"],
+        },
+        Case {
+            name: "concat_expression",
+            sql: "SELECT first_name || ' ' || last_name AS full FROM users",
+            dialect: &PostgreSqlDialect {},
+            target: None,
+            cols: &[Col {
+                name: Some("full"),
+                sources: &["users.first_name", "users.last_name"],
+            }],
+            tables: &["users"],
+        },
+        Case {
+            name: "case_expression",
+            sql: "SELECT CASE WHEN active THEN email ELSE name END AS c FROM users",
+            dialect: &PostgreSqlDialect {},
+            target: None,
+            cols: &[Col {
+                name: Some("c"),
+                sources: &["users.active", "users.email", "users.name"],
+            }],
+            tables: &["users"],
+        },
+        Case {
+            name: "window_function",
+            sql: "SELECT ROW_NUMBER() OVER (PARTITION BY dept ORDER BY hired) AS rn FROM staff",
+            dialect: &PostgreSqlDialect {},
+            target: None,
+            cols: &[Col {
+                name: Some("rn"),
+                sources: &["staff.dept", "staff.hired"],
+            }],
+            tables: &["staff"],
+        },
+        Case {
+            name: "json_arrow_operator",
+            sql: "SELECT data->>'ssn' AS ssn FROM accounts",
+            dialect: &PostgreSqlDialect {},
+            target: None,
+            cols: &[Col {
+                name: Some("ssn"),
+                sources: &["accounts.data"],
+            }],
+            tables: &["accounts"],
+        },
+        Case {
+            name: "json_extract_function",
+            sql: "SELECT JSON_EXTRACT(data, '$.ssn') AS ssn FROM accounts",
+            dialect: &MySqlDialect {},
+            target: None,
+            cols: &[Col {
+                name: Some("ssn"),
+                sources: &["accounts.data"],
+            }],
+            tables: &["accounts"],
+        },
+        Case {
+            name: "json_hash_arrow",
+            sql: "SELECT data#>>'{a,b}' AS v FROM accounts",
+            dialect: &PostgreSqlDialect {},
+            target: None,
+            cols: &[Col {
+                name: Some("v"),
+                sources: &["accounts.data"],
+            }],
+            tables: &["accounts"],
+        },
+        Case {
+            name: "union_per_position",
+            sql: "SELECT a.x FROM t a UNION SELECT b.x FROM s b",
+            dialect: &PostgreSqlDialect {},
+            target: None,
+            cols: &[Col {
+                name: Some("x"),
+                sources: &["t.x", "s.x"],
+            }],
+            tables: &["t", "s"],
+        },
+        Case {
+            name: "derived_table",
+            sql: "SELECT t.email FROM (SELECT email FROM users) t",
+            dialect: &PostgreSqlDialect {},
+            target: None,
+            cols: &[Col {
+                name: Some("email"),
+                sources: &["users.email"],
+            }],
+            tables: &["users"],
+        },
+        Case {
+            name: "scalar_subquery_in_projection",
+            sql: "SELECT (SELECT MAX(amount) FROM orders) AS top FROM users",
+            dialect: &PostgreSqlDialect {},
+            target: None,
+            cols: &[Col {
+                name: Some("top"),
+                sources: &["orders.amount"],
+            }],
+            tables: &["orders"],
+        },
+        Case {
+            name: "cte_traces_to_base_table",
+            sql: "WITH a AS (SELECT email FROM users) SELECT email FROM a",
+            dialect: &PostgreSqlDialect {},
+            target: None,
+            cols: &[Col {
+                name: Some("email"),
+                sources: &["users.email"],
+            }],
+            tables: &["users"],
+        },
+        Case {
+            name: "nested_cte",
+            sql: "WITH a AS (SELECT email FROM users), b AS (SELECT email FROM a) SELECT email FROM b",
+            dialect: &PostgreSqlDialect {},
+            target: None,
+            cols: &[Col {
+                name: Some("email"),
+                sources: &["users.email"],
+            }],
+            tables: &["users"],
+        },
+        Case {
+            name: "wildcard_over_derived_table",
+            sql: "SELECT * FROM (SELECT id, email FROM users) t",
+            dialect: &PostgreSqlDialect {},
+            target: None,
+            cols: &[
+                Col {
+                    name: Some("id"),
+                    sources: &["users.id"],
+                },
+                Col {
+                    name: Some("email"),
+                    sources: &["users.email"],
+                },
+            ],
+            tables: &["users"],
+        },
+        Case {
+            name: "qualified_wildcard_over_cte",
+            sql: "WITH a AS (SELECT id, email FROM users) SELECT a.* FROM a",
+            dialect: &PostgreSqlDialect {},
+            target: None,
+            cols: &[
+                Col {
+                    name: Some("id"),
+                    sources: &["users.id"],
+                },
+                Col {
+                    name: Some("email"),
+                    sources: &["users.email"],
+                },
+            ],
+            tables: &["users"],
+        },
+        Case {
+            name: "insert_select_explicit_columns",
+            sql: "INSERT INTO tgt (a, b) SELECT x, y FROM s",
+            dialect: &PostgreSqlDialect {},
+            target: Some("tgt"),
+            cols: &[
+                Col {
+                    name: Some("a"),
+                    sources: &["s.x"],
+                },
+                Col {
+                    name: Some("b"),
+                    sources: &["s.y"],
+                },
+            ],
+            tables: &["s"],
+        },
+        Case {
+            name: "insert_select_no_columns_keeps_names",
+            sql: "INSERT INTO tgt SELECT id, email FROM users",
+            dialect: &PostgreSqlDialect {},
+            target: Some("tgt"),
+            cols: &[
+                Col {
+                    name: Some("id"),
+                    sources: &["users.id"],
+                },
+                Col {
+                    name: Some("email"),
+                    sources: &["users.email"],
+                },
+            ],
+            tables: &["users"],
+        },
+        Case {
+            name: "insert_values_literals_empty_sources",
+            sql: "INSERT INTO tgt (a, b) VALUES (1, 'x')",
+            dialect: &PostgreSqlDialect {},
+            target: Some("tgt"),
+            cols: &[
+                Col {
+                    name: Some("a"),
+                    sources: &[],
+                },
+                Col {
+                    name: Some("b"),
+                    sources: &[],
+                },
+            ],
+            tables: &[],
+        },
+        Case {
+            name: "insert_set_mysql",
+            sql: "INSERT INTO tgt SET a = 1, b = 2",
+            dialect: &MySqlDialect {},
+            target: Some("tgt"),
+            cols: &[
+                Col {
+                    name: Some("a"),
+                    sources: &[],
+                },
+                Col {
+                    name: Some("b"),
+                    sources: &[],
+                },
+            ],
+            tables: &[],
+        },
+        Case {
+            name: "ctas_basic",
+            sql: "CREATE TABLE rollup AS SELECT u.id, u.email FROM users u",
+            dialect: &PostgreSqlDialect {},
+            target: Some("rollup"),
+            cols: &[
+                Col {
+                    name: Some("id"),
+                    sources: &["users.id"],
+                },
+                Col {
+                    name: Some("email"),
+                    sources: &["users.email"],
+                },
+            ],
+            tables: &["users"],
+        },
+        Case {
+            name: "ctas_explicit_columns_override",
+            sql: "CREATE TABLE rollup (uid INT, mail TEXT) AS SELECT id, email FROM users",
+            dialect: &PostgreSqlDialect {},
+            target: Some("rollup"),
+            cols: &[
+                Col {
+                    name: Some("uid"),
+                    sources: &["users.id"],
+                },
+                Col {
+                    name: Some("mail"),
+                    sources: &["users.email"],
+                },
+            ],
+            tables: &["users"],
+        },
+        Case {
+            name: "create_table_no_query_is_empty",
+            sql: "CREATE TABLE t (a int)",
+            dialect: &PostgreSqlDialect {},
+            target: None,
+            cols: &[],
+            tables: &[],
+        },
+        Case {
+            name: "update_from_source",
+            sql: "UPDATE accounts a SET balance = t.delta FROM txns t WHERE t.acct = a.id",
+            dialect: &PostgreSqlDialect {},
+            target: Some("accounts"),
+            cols: &[Col {
+                name: Some("balance"),
+                sources: &["txns.delta"],
+            }],
+            tables: &["txns"],
+        },
+        Case {
+            name: "update_self_column",
+            sql: "UPDATE users SET active = active",
+            dialect: &PostgreSqlDialect {},
+            target: Some("users"),
+            cols: &[Col {
+                name: Some("active"),
+                sources: &["users.active"],
+            }],
+            tables: &["users"],
+        },
+        Case {
+            name: "delete_using",
+            sql: "DELETE FROM stale s USING archive a WHERE s.id = a.id",
+            dialect: &PostgreSqlDialect {},
+            target: Some("stale"),
+            cols: &[],
+            tables: &["archive"],
+        },
+        Case {
+            name: "merge_update_and_insert",
+            sql: "MERGE INTO tgt t USING src s ON t.id = s.id \
+                  WHEN MATCHED THEN UPDATE SET val = s.val \
+                  WHEN NOT MATCHED THEN INSERT (id, val) VALUES (s.id, s.val)",
+            dialect: &PostgreSqlDialect {},
+            target: Some("tgt"),
+            cols: &[
+                Col {
+                    name: Some("val"),
+                    sources: &["src.val"],
+                },
+                Col {
+                    name: Some("id"),
+                    sources: &["src.id"],
+                },
+            ],
+            tables: &["src"],
+        },
+        Case {
+            name: "explain_is_empty",
+            sql: "EXPLAIN SELECT 1",
+            dialect: &PostgreSqlDialect {},
+            target: None,
+            cols: &[],
+            tables: &[],
+        },
+        Case {
+            name: "show_is_empty",
+            sql: "SHOW TABLES",
+            dialect: &MySqlDialect {},
+            target: None,
+            cols: &[],
+            tables: &[],
+        },
+    ];
+    for case in cases {
+        let l = extract(case.sql, case.dialect).unwrap_or_else(|e| panic!("{}: unexpected error {e:?}", case.name));
+        assert_target(case.name, &l, case.target);
+        assert_eq!(l.columns.len(), case.cols.len(), "{}: column count", case.name);
+        for (i, expected) in case.cols.iter().enumerate() {
+            assert_col(case.name, &l, i, expected);
+        }
+        assert_tables(case.name, &l, case.tables);
+    }
+}
+
+#[test]
+fn extract_fails() {
+    let cases = [
+        ErrCase {
+            name: "circular_cte",
+            sql: "WITH a AS (SELECT x FROM b), b AS (SELECT x FROM a) SELECT x FROM a",
+            dialect: &PostgreSqlDialect {},
+            expected: LineageError::CircularReference { cte: String::new() },
+        },
+        ErrCase {
+            name: "recursive_cte",
+            sql: "WITH RECURSIVE r AS (SELECT id FROM seed UNION ALL SELECT id FROM r) SELECT id FROM r",
+            dialect: &PostgreSqlDialect {},
+            expected: LineageError::CircularReference { cte: String::new() },
+        },
+        ErrCase {
+            name: "wildcard_over_base_table",
+            sql: "SELECT * FROM users",
+            dialect: &SQLiteDialect {},
+            expected: LineageError::UnresolvedColumn {
+                column: String::new(),
+                reason: String::new(),
+            },
+        },
+        ErrCase {
+            name: "ambiguous_unqualified",
+            sql: "SELECT x FROM t1 JOIN t2 ON t1.id = t2.id",
+            dialect: &PostgreSqlDialect {},
+            expected: LineageError::UnresolvedColumn {
+                column: String::new(),
+                reason: String::new(),
+            },
+        },
+        ErrCase {
+            name: "insert_count_mismatch",
+            sql: "INSERT INTO tgt (a) SELECT x, y FROM s",
+            dialect: &PostgreSqlDialect {},
+            expected: LineageError::ColumnCountMismatch {
+                target: String::new(),
+                expected: 0,
+                found: 0,
+            },
+        },
+        ErrCase {
+            name: "parse_error",
+            sql: "garbage sql ;;",
+            dialect: &PostgreSqlDialect {},
+            expected: LineageError::Parse(String::new()),
+        },
+        ErrCase {
+            name: "multi_statement",
+            sql: "SELECT 1; SELECT 2",
+            dialect: &PostgreSqlDialect {},
+            expected: LineageError::MultiStatement,
+        },
+    ];
+    for case in &cases {
+        let err = extract(case.sql, case.dialect).expect_err(case.name);
+        assert_eq!(
+            std::mem::discriminant(&err),
+            std::mem::discriminant(&case.expected),
+            "{}: expected {:?}, got {err:?}",
+            case.name,
+            case.expected
+        );
+    }
+}
+
+#[test]
+fn deep_nesting_does_not_panic() {
+    let mut sql = String::from("SELECT x FROM t");
+    for _ in 0..200 {
+        sql = format!("SELECT x FROM ({sql}) s");
+    }
+    let _ = extract(&sql, &PostgreSqlDialect {});
+}


### PR DESCRIPTION
## Summary

Adds a new `sql-lineage` workspace crate for column-level SQL lineage extraction.

- Parses SQL and resolves output columns back to their source table columns
- Scope tracking, statement modeling, and resolution across CTEs/subqueries
- Crate README and module-level docs

## Crate layout

- `model.rs` — lineage data model
- `scope.rs` — name/scope resolution context
- `statement.rs` — statement parsing/modeling
- `resolve.rs` — column resolution logic
- `extract.rs` — top-level extraction entry point
- `error.rs` — `thiserror`-based error type

## Test plan

- [x] `cargo fmt --check`
- [x] `cargo clippy --workspace --tests -- -D warnings`
- [x] `cargo test --workspace --lib --bins`
- 680-line integration suite in `tests/extract.rs`
